### PR TITLE
Parent #125: Close test coverage gaps (76.9% to 95%+)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,34 +67,51 @@ jobs:
           --results-directory coverage-results \
           --logger "trx;LogFileName=test-results.trx"
 
-    - name: Enforce coverage threshold (≥ 70 %, excluding Azure-SDK-dependent code)
+    - name: Enforce coverage threshold (line >= 78%, branch >= 55%)
       run: |
         python3 - <<'EOF'
         import xml.etree.ElementTree as ET
         import sys, glob, os
 
-        # Find the generated Cobertura XML (Azure-dependent classes are already excluded
-        # via coverage.runsettings, so the total line-rate reflects testable code only).
+        # Find the most-recently-modified Cobertura XML so a stale file from a
+        # previous partial run cannot silently override the freshly generated one.
         xml_files = glob.glob("coverage-results/**/coverage.cobertura.xml", recursive=True)
         if not xml_files:
             print("::error::No coverage XML found. Did the test step run?")
             sys.exit(1)
+        xml_file = max(xml_files, key=os.path.getmtime)
+        print(f"Parsing {xml_file}")
 
-        tree = ET.parse(xml_files[0])
+        tree = ET.parse(xml_file)
         root = tree.getroot()
 
         line_rate = float(root.attrib.get("line-rate", "0"))
-        coverage_pct = line_rate * 100
-        threshold_pct = 70.0   # Current milestone; increase as coverage grows toward the 90% goal.
+        branch_rate = float(root.attrib.get("branch-rate", "0"))
+        line_pct = line_rate * 100
+        branch_pct = branch_rate * 100
 
-        print(f"Coverage (excluding Azure-SDK-dependent files): {coverage_pct:.1f}%")
-        print(f"Required threshold: {threshold_pct:.0f}%")
+        # Regression-enforcement ratchet -- not the final target.
+        # Parent issue #125 targets >= 95% line. This gate locks in the
+        # baseline after sub-issues #180-#185 landed; future PRs should
+        # raise these numbers as new tests are added. See PR #230 for
+        # the gap analysis and the follow-up Wave-2 work needed to hit 95%.
+        line_threshold_pct = 78.0
+        branch_threshold_pct = 55.0
 
-        if coverage_pct < threshold_pct:
-            print(f"::error::Coverage {coverage_pct:.1f}% is below the required {threshold_pct:.0f}% threshold.")
+        print(f"Coverage: line {line_pct:.2f}% (gate {line_threshold_pct:.0f}%), branch {branch_pct:.2f}% (gate {branch_threshold_pct:.0f}%)")
+
+        failed = False
+        if line_pct < line_threshold_pct:
+            print(f"::error::Line coverage {line_pct:.2f}% is below the required {line_threshold_pct:.0f}% threshold.")
+            failed = True
+        if branch_pct < branch_threshold_pct:
+            print(f"::error::Branch coverage {branch_pct:.2f}% is below the required {branch_threshold_pct:.0f}% threshold.")
+            failed = True
+
+        if failed:
             sys.exit(1)
 
-        print(f"✅ Coverage check passed ({coverage_pct:.1f}% ≥ {threshold_pct:.0f}%)")
+        print(f"Coverage check passed (line {line_pct:.2f}% >= {line_threshold_pct:.0f}%, branch {branch_pct:.2f}% >= {branch_threshold_pct:.0f}%)")
         EOF
 
     - name: Publish test results

--- a/CosmosToSqlAssessment.csproj
+++ b/CosmosToSqlAssessment.csproj
@@ -27,4 +27,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="CosmosToSqlAssessment.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/Services/CosmosDbAnalysisService.cs
+++ b/Services/CosmosDbAnalysisService.cs
@@ -66,6 +66,23 @@ namespace CosmosToSqlAssessment.Services
         }
 
         /// <summary>
+        /// Test-friendly constructor that accepts pre-built SDK clients. Use this from
+        /// unit tests via the mock harness in <c>tests/CosmosToSqlAssessment.Tests/Mocks</c>.
+        /// The production DI container always resolves the public constructor above.
+        /// </summary>
+        internal CosmosDbAnalysisService(
+            IConfiguration configuration,
+            ILogger<CosmosDbAnalysisService> logger,
+            CosmosClient cosmosClient,
+            LogsQueryClient? logsQueryClient = null)
+        {
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _cosmosClient = cosmosClient ?? throw new ArgumentNullException(nameof(cosmosClient));
+            _logsQueryClient = logsQueryClient;
+        }
+
+        /// <summary>
         /// Performs comprehensive analysis of the Cosmos DB database
         /// </summary>
         public async Task<CosmosDbAnalysis> AnalyzeDatabaseAsync(CancellationToken cancellationToken = default)

--- a/Services/DataQualityAnalysisService.cs
+++ b/Services/DataQualityAnalysisService.cs
@@ -49,6 +49,24 @@ namespace CosmosToSqlAssessment.Services
         }
 
         /// <summary>
+        /// Test-friendly constructor that accepts a pre-built <see cref="CosmosClient"/> and
+        /// optional analysis options override. Use this from unit tests via the mock harness
+        /// in <c>tests/CosmosToSqlAssessment.Tests/Mocks</c>. The production DI container
+        /// always resolves the public constructor above.
+        /// </summary>
+        internal DataQualityAnalysisService(
+            IConfiguration configuration,
+            ILogger<DataQualityAnalysisService> logger,
+            CosmosClient cosmosClient,
+            DataQualityAnalysisOptions? options = null)
+        {
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _cosmosClient = cosmosClient ?? throw new ArgumentNullException(nameof(cosmosClient));
+            _options = options ?? new DataQualityAnalysisOptions();
+        }
+
+        /// <summary>
         /// Performs comprehensive data quality analysis on Cosmos DB database
         /// </summary>
         public async Task<DataQualityAnalysis> AnalyzeDataQualityAsync(

--- a/tests/CosmosToSqlAssessment.Tests/EndToEnd/E2EFixture.cs
+++ b/tests/CosmosToSqlAssessment.Tests/EndToEnd/E2EFixture.cs
@@ -1,0 +1,255 @@
+using Azure.Monitor.Query;
+using CosmosToSqlAssessment.Models;
+using CosmosToSqlAssessment.Services;
+using CosmosToSqlAssessment.SqlProject;
+using CosmosToSqlAssessment.Tests.Mocks;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CosmosToSqlAssessment.Tests.EndToEnd;
+
+/// <summary>
+/// Self-contained fluent fixture that wires every real production service in
+/// the assessment → SQL project generation pipeline against the mock Azure
+/// SDKs from <c>tests/CosmosToSqlAssessment.Tests/Mocks/</c>.
+///
+/// <para>
+/// The fixture is the canonical smoke-test entry point for sub-issue #181 and
+/// for every Wave-2+ parent that needs to verify "the whole pipeline still
+/// works end-to-end" before declaring a refactor safe. See
+/// <c>EndToEnd/README.md</c> for usage guidance and assertion patterns.
+/// </para>
+///
+/// <para>
+/// Each fixture instance owns a temp directory (see <see cref="TempRoot"/>)
+/// that is created on construction and removed on <see cref="Dispose"/> with a
+/// small retry loop to tolerate Windows file-lock races. Use one fixture per
+/// test (<c>using var fixture = new E2EFixture()...</c>).
+/// </para>
+/// </summary>
+public sealed class E2EFixture : IDisposable
+{
+    private const string DefaultEndpoint = "https://test.documents.azure.com:443/";
+
+    private readonly CosmosClientMockBuilder _cosmosBuilder = new();
+    private readonly Dictionary<string, string?> _config = new(StringComparer.Ordinal)
+    {
+        ["CosmosDb:AccountEndpoint"] = DefaultEndpoint,
+    };
+    private LogsQueryClient? _logsQueryClient;
+    private bool _built;
+    private bool _disposed;
+
+    private CosmosClient? _cosmosClient;
+
+    /// <summary>
+    /// Temporary root directory owned by this fixture. SQL project generation
+    /// targets this folder so tests never leak files into the repo.
+    /// </summary>
+    public string TempRoot { get; } = Directory.CreateTempSubdirectory("e2e-").FullName;
+
+    /// <summary>Underlying configuration; populated by <see cref="Build"/>.</summary>
+    public IConfiguration Configuration { get; private set; } = null!;
+
+    // ----- Real services exposed for granular Wave-2 reuse (R11) -----
+    public CosmosDbAnalysisService CosmosService { get; private set; } = null!;
+    public SqlMigrationAssessmentService SqlAssessmentService { get; private set; } = null!;
+    public DataQualityAnalysisService DataQualityService { get; private set; } = null!;
+    public DataFactoryEstimateService DataFactoryService { get; private set; } = null!;
+    public SqlProjectGenerationService SqlProjectService { get; private set; } = null!;
+    public SqlDatabaseProjectService SqlDatabaseProjectService { get; private set; } = null!;
+    public SqlProjectIntegrationService SqlProjectIntegrationService { get; private set; } = null!;
+
+    /// <summary>Adds a database with optional container configuration.</summary>
+    public E2EFixture WithDatabase(string databaseId, Action<DatabaseMockBuilder>? configure = null)
+    {
+        EnsureNotBuilt();
+        _cosmosBuilder.WithDatabase(databaseId, configure);
+        return this;
+    }
+
+    /// <summary>
+    /// Sets a configuration key. Use this to override Cosmos endpoint, DataFactory
+    /// defaults, or any other key the real services read from <see cref="IConfiguration"/>.
+    /// </summary>
+    public E2EFixture WithConfig(string key, string? value)
+    {
+        EnsureNotBuilt();
+        _config[key] = value;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures Azure Monitor metrics for the pipeline. Sets both
+    /// <c>AzureMonitor:WorkspaceId</c> and <c>AzureMonitor:CosmosAccountName</c>
+    /// (production short-circuits to default zero metrics if either is missing -
+    /// R2 from rubber-duck).
+    /// </summary>
+    public E2EFixture WithAzureMonitorMetrics(
+        IEnumerable<(DateTimeOffset Timestamp, double Avg, double Max, double Total)> rows,
+        string workspaceId = "test-workspace",
+        string cosmosAccountName = "test-account")
+    {
+        EnsureNotBuilt();
+        _config["AzureMonitor:WorkspaceId"] = workspaceId;
+        _config["AzureMonitor:CosmosAccountName"] = cosmosAccountName;
+        _logsQueryClient = new LogsQueryClientMockBuilder().WithMetricsRows(rows).Build();
+        return this;
+    }
+
+    /// <summary>
+    /// Wires the configuration, mocked clients, and all real services. Must be
+    /// called before <see cref="RunAssessmentAsync"/> or any project generator.
+    /// Idempotent: subsequent calls are no-ops.
+    /// </summary>
+    public E2EFixture Build()
+    {
+        if (_built) return this;
+
+        Configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(_config!)
+            .Build();
+
+        _cosmosClient = _cosmosBuilder.Build();
+
+        CosmosService = new CosmosDbAnalysisService(
+            Configuration,
+            NullLogger<CosmosDbAnalysisService>.Instance,
+            _cosmosClient,
+            _logsQueryClient);
+
+        SqlAssessmentService = new SqlMigrationAssessmentService(
+            Configuration,
+            NullLogger<SqlMigrationAssessmentService>.Instance);
+
+        DataQualityService = new DataQualityAnalysisService(
+            Configuration,
+            NullLogger<DataQualityAnalysisService>.Instance,
+            _cosmosClient);
+
+        DataFactoryService = new DataFactoryEstimateService(
+            Configuration,
+            NullLogger<DataFactoryEstimateService>.Instance);
+
+        SqlProjectService = new SqlProjectGenerationService(
+            Configuration,
+            NullLogger<SqlProjectGenerationService>.Instance);
+
+        SqlDatabaseProjectService = new SqlDatabaseProjectService(
+            Configuration,
+            NullLogger<SqlDatabaseProjectService>.Instance);
+
+        SqlProjectIntegrationService = new SqlProjectIntegrationService(
+            SqlDatabaseProjectService,
+            Configuration,
+            NullLogger<SqlProjectIntegrationService>.Instance);
+
+        _built = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Runs the four-phase assessment pipeline (Cosmos analysis → SQL assessment
+    /// → data quality → Data Factory estimate) and returns the populated
+    /// <see cref="AssessmentResult"/>.
+    ///
+    /// <para>
+    /// Unlike <c>Program.RunAssessmentAsync</c>, this method does **not** swallow
+    /// data-quality exceptions (R6) - tests want clear failures when mocks are
+    /// wired wrong.
+    /// </para>
+    /// </summary>
+    public async Task<AssessmentResult> RunAssessmentAsync(
+        string databaseName,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureBuilt();
+
+        var result = new AssessmentResult
+        {
+            CosmosAccountName = "test-account",
+            DatabaseName = databaseName
+        };
+
+        result.CosmosAnalysis = await CosmosService.AnalyzeDatabaseAsync(databaseName, cancellationToken);
+        result.SqlAssessment = await SqlAssessmentService.AssessMigrationAsync(result.CosmosAnalysis, databaseName, cancellationToken);
+        result.DataQualityAnalysis = await DataQualityService.AnalyzeDataQualityAsync(result.CosmosAnalysis, databaseName, cancellationToken);
+        result.DataFactoryEstimate = await DataFactoryService.EstimateMigrationAsync(result.CosmosAnalysis, result.SqlAssessment, cancellationToken);
+
+        return result;
+    }
+
+    /// <summary>
+    /// Runs the production path used by <c>Program.GenerateOutputsAsync</c>:
+    /// <see cref="SqlProjectGenerationService.GenerateSqlProjectsAsync"/> over the
+    /// fixture's temp directory. Returns the resolved <c>sql-projects/</c> folder.
+    /// </summary>
+    public async Task<string> GenerateSqlProjectsViaGenerationServiceAsync(
+        AssessmentResult assessment,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureBuilt();
+        var baseDir = Path.Combine(TempRoot, "generation-service");
+        Directory.CreateDirectory(baseDir);
+        await SqlProjectService.GenerateSqlProjectsAsync(assessment, baseDir, cancellationToken);
+        return Path.Combine(baseDir, "sql-projects");
+    }
+
+    /// <summary>
+    /// Runs the production path used by <c>Program.GenerateSqlProjectAsync</c>:
+    /// <see cref="SqlProjectIntegrationService.GenerateSqlProjectAsync"/> with a
+    /// per-fixture <see cref="SqlProjectOptions"/> rooted in the temp directory.
+    /// </summary>
+    public async Task<SqlProjectGenerationResult> GenerateSqlProjectsViaIntegrationAsync(
+        AssessmentResult assessment,
+        SqlProjectOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureBuilt();
+        options ??= SqlProjectOptions.CreateDefault();
+        options.OutputPath = Path.Combine(TempRoot, "integration-service");
+        if (string.IsNullOrEmpty(options.ProjectName))
+        {
+            options.ProjectName = $"{assessment.DatabaseName}_Migration";
+        }
+        return await SqlProjectIntegrationService.GenerateSqlProjectAsync(assessment.SqlAssessment, options, cancellationToken);
+    }
+
+    private void EnsureNotBuilt()
+    {
+        if (_built) throw new InvalidOperationException("Fixture already built; configure before calling Build().");
+    }
+
+    private void EnsureBuilt()
+    {
+        if (!_built) throw new InvalidOperationException("Call Build() before invoking pipeline methods.");
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        // Retry directory deletion to tolerate transient Windows file locks (R7).
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                if (Directory.Exists(TempRoot))
+                {
+                    Directory.Delete(TempRoot, recursive: true);
+                }
+                return;
+            }
+            catch (IOException) when (attempt < 2)
+            {
+                Thread.Sleep(50 * (attempt + 1));
+            }
+            catch (UnauthorizedAccessException) when (attempt < 2)
+            {
+                Thread.Sleep(50 * (attempt + 1));
+            }
+        }
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/EndToEnd/E2EPipelineTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/EndToEnd/E2EPipelineTests.cs
@@ -1,0 +1,189 @@
+using System.Xml.Linq;
+using CosmosToSqlAssessment.Models;
+
+namespace CosmosToSqlAssessment.Tests.EndToEnd;
+
+/// <summary>
+/// End-to-end smoke tests for the full assessment → SQL project generation
+/// pipeline. These tests drive the real production services against the mocked
+/// Azure SDKs from <c>../Mocks/</c> and assert on the on-disk artifacts the
+/// two project-generation paths produce.
+///
+/// <para>
+/// Wave-2+ parents are expected to run this suite (or extend it) before
+/// declaring a refactor safe. See <c>EndToEnd/README.md</c> for the recommended
+/// assertion patterns.
+/// </para>
+/// </summary>
+public class E2EPipelineTests
+{
+    [Fact]
+    public async Task FullPipeline_with_two_containers_generates_sql_project_via_integration()
+    {
+        using var fixture = new E2EFixture()
+            .WithDatabase("AppDb", db => db
+                .WithContainer("users", c => c
+                    .WithPartitionKey("/userId").WithThroughput(400)
+                    .WithDocuments(E2ESampleData.TwoUsers.ToArray()))
+                .WithContainer("orders", c => c
+                    .WithPartitionKey("/orderId").WithThroughput(800)
+                    .WithDocuments(E2ESampleData.ThreeOrders.ToArray())))
+            .Build();
+
+        var assessment = await fixture.RunAssessmentAsync("AppDb");
+
+        assessment.CosmosAnalysis.Containers.Should().HaveCount(2);
+        assessment.SqlAssessment.DatabaseMappings.Should().NotBeEmpty();
+        assessment.SqlAssessment.DatabaseMappings
+            .SelectMany(m => m.ContainerMappings)
+            .Select(cm => cm.SourceContainer)
+            .Should().BeEquivalentTo(new[] { "users", "orders" });
+
+        var result = await fixture.GenerateSqlProjectsViaIntegrationAsync(assessment);
+
+        result.Success.Should().BeTrue();
+        result.Project.Should().NotBeNull();
+        File.Exists(result.Project!.ProjectFilePath).Should().BeTrue();
+
+        // .sqlproj must parse as XML (R8 - structural, not text-comparison).
+        var sqlproj = XDocument.Load(result.Project!.ProjectFilePath);
+        sqlproj.Root.Should().NotBeNull();
+
+        // Per-container table SQL files exist on disk and contain CREATE TABLE.
+        var mappings = assessment.SqlAssessment.DatabaseMappings.SelectMany(m => m.ContainerMappings).ToList();
+        var tablesRoot = Path.Combine(result.Project!.OutputPath, "Tables");
+        Directory.Exists(tablesRoot).Should().BeTrue("a Tables/ folder should be generated under the SQL project");
+        foreach (var cm in mappings)
+        {
+            var tableFile = Directory.EnumerateFiles(tablesRoot, $"*{cm.TargetTable}*.sql", SearchOption.AllDirectories)
+                .FirstOrDefault();
+            tableFile.Should().NotBeNull($"a table file for {cm.TargetTable} should be generated under Tables/");
+            var contents = await File.ReadAllTextAsync(tableFile!);
+            contents.Should().Contain("CREATE TABLE", $"table file {tableFile} should declare a table");
+        }
+    }
+
+    [Fact]
+    public async Task FullPipeline_with_two_containers_generates_sql_project_via_generation_service()
+    {
+        using var fixture = new E2EFixture()
+            .WithDatabase("AppDb", db => db
+                .WithContainer("users", c => c
+                    .WithPartitionKey("/userId").WithThroughput(400)
+                    .WithDocuments(E2ESampleData.TwoUsers.ToArray()))
+                .WithContainer("orders", c => c
+                    .WithPartitionKey("/orderId").WithThroughput(800)
+                    .WithDocuments(E2ESampleData.ThreeOrders.ToArray())))
+            .Build();
+
+        var assessment = await fixture.RunAssessmentAsync("AppDb");
+        var sqlProjectsDir = await fixture.GenerateSqlProjectsViaGenerationServiceAsync(assessment);
+
+        Directory.Exists(sqlProjectsDir).Should().BeTrue();
+
+        // One <db>.Database folder per database mapping with the canonical layout.
+        var dbProjectDir = Directory.EnumerateDirectories(sqlProjectsDir).Single();
+        Directory.Exists(Path.Combine(dbProjectDir, "Tables")).Should().BeTrue();
+        Directory.Exists(Path.Combine(dbProjectDir, "Indexes")).Should().BeTrue();
+        Directory.Exists(Path.Combine(dbProjectDir, "ForeignKeys")).Should().BeTrue();
+        Directory.Exists(Path.Combine(dbProjectDir, "Scripts")).Should().BeTrue();
+
+        var sqlprojFile = Directory.EnumerateFiles(dbProjectDir, "*.sqlproj").Single();
+        var sqlproj = XDocument.Load(sqlprojFile);
+        sqlproj.Root.Should().NotBeNull();
+
+        // A table file exists per container mapping and references CREATE TABLE.
+        var mappings = assessment.SqlAssessment.DatabaseMappings.SelectMany(m => m.ContainerMappings).ToList();
+        var tablesDir = Path.Combine(dbProjectDir, "Tables");
+        Directory.EnumerateFiles(tablesDir, "*.sql").Should().HaveCountGreaterThanOrEqualTo(mappings.Count);
+
+        foreach (var tableFile in Directory.EnumerateFiles(tablesDir, "*.sql"))
+        {
+            (await File.ReadAllTextAsync(tableFile)).Should().Contain("CREATE TABLE");
+        }
+    }
+
+    [Fact]
+    public async Task FullPipeline_data_quality_runs_and_produces_score()
+    {
+        using var fixture = new E2EFixture()
+            .WithDatabase("AppDb", db => db
+                .WithContainer("users", c => c
+                    .WithPartitionKey("/userId").WithThroughput(400)
+                    .WithDocuments(E2ESampleData.TwoUsers.ToArray())))
+            .Build();
+
+        var assessment = await fixture.RunAssessmentAsync("AppDb");
+
+        assessment.DataQualityAnalysis.Should().NotBeNull();
+        assessment.DataQualityAnalysis!.ContainerAnalyses.Should().ContainSingle();
+        assessment.DataQualityAnalysis.TotalDocumentsAnalyzed.Should().Be(2);
+        assessment.DataQualityAnalysis.Summary.Should().NotBeNull();
+        assessment.DataQualityAnalysis.Summary.OverallQualityScore.Should().BeGreaterThan(0);
+        assessment.DataQualityAnalysis.Summary.QualityRating.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task FullPipeline_uses_azure_monitor_when_configured()
+    {
+        using var fixture = new E2EFixture()
+            .WithDatabase("AppDb", db => db
+                .WithContainer("orders", c => c
+                    .WithPartitionKey("/orderId").WithThroughput(400)
+                    .WithDocuments(E2ESampleData.ThreeOrders.ToArray())))
+            .WithAzureMonitorMetrics(E2ESampleData.SixHoursOfMetrics)
+            .Build();
+
+        var assessment = await fixture.RunAssessmentAsync("AppDb");
+
+        assessment.CosmosAnalysis.PerformanceMetrics.Should().NotBeNull();
+        assessment.CosmosAnalysis.PerformanceMetrics.AverageRUsPerSecond.Should().BeGreaterThan(0);
+        assessment.CosmosAnalysis.PerformanceMetrics.PeakRUsPerSecond.Should().BeGreaterThan(0);
+        assessment.CosmosAnalysis.PerformanceMetrics.TotalRUConsumption.Should().BeGreaterThan(0);
+        assessment.CosmosAnalysis.MonitoringLimitations
+            .Should().NotContain(l => l.Contains("Azure Monitor", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task FullPipeline_without_azure_monitor_records_limitation()
+    {
+        using var fixture = new E2EFixture()
+            .WithDatabase("AppDb", db => db
+                .WithContainer("orders", c => c
+                    .WithPartitionKey("/orderId").WithThroughput(400)
+                    .WithDocuments(E2ESampleData.ThreeOrders.ToArray())))
+            .Build();
+
+        var assessment = await fixture.RunAssessmentAsync("AppDb");
+
+        assessment.CosmosAnalysis.MonitoringLimitations
+            .Should().Contain(l => l.Contains("Azure Monitor", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task FullPipeline_single_empty_container_completes_without_error()
+    {
+        // Single empty container is the supported "no data" scenario.
+        // Zero-container databases are explicitly out of scope (would crash
+        // DataFactoryEstimateService - see README.md known limitations).
+        using var fixture = new E2EFixture()
+            .WithDatabase("AppDb", db => db
+                .WithContainer("empty", c => c
+                    .WithPartitionKey("/id").WithThroughput(400)))
+            .Build();
+
+        var assessment = await fixture.RunAssessmentAsync("AppDb");
+
+        assessment.CosmosAnalysis.Containers.Should().ContainSingle();
+        assessment.CosmosAnalysis.Containers[0].DocumentCount.Should().Be(0);
+
+        // Both project-generation paths complete without throwing; we do not
+        // assert that the generated table SQL is semantically meaningful (R4).
+        var integrationResult = await fixture.GenerateSqlProjectsViaIntegrationAsync(assessment);
+        integrationResult.Success.Should().BeTrue();
+        File.Exists(integrationResult.Project!.ProjectFilePath).Should().BeTrue();
+
+        var generationDir = await fixture.GenerateSqlProjectsViaGenerationServiceAsync(assessment);
+        Directory.Exists(generationDir).Should().BeTrue();
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/EndToEnd/E2ESampleData.cs
+++ b/tests/CosmosToSqlAssessment.Tests/EndToEnd/E2ESampleData.cs
@@ -1,0 +1,59 @@
+using Newtonsoft.Json.Linq;
+
+namespace CosmosToSqlAssessment.Tests.EndToEnd;
+
+/// <summary>
+/// Tiny, deterministic in-memory document samples for the E2E pipeline harness.
+///
+/// Samples are intentionally small (2-3 documents per container) so the full
+/// pipeline runs in well under 60 seconds even with verbose console logging
+/// from the production services. Each document is a <see cref="JObject"/>,
+/// which is the only document shape supported by the mock harness (see
+/// <c>Mocks/README.md</c>).
+/// </summary>
+public static class E2ESampleData
+{
+    /// <summary>Two simple user documents.</summary>
+    public static IReadOnlyList<JObject> TwoUsers => new[]
+    {
+        JObject.Parse("{\"id\":\"u1\",\"userId\":\"u1\",\"email\":\"a@example.com\",\"age\":30}"),
+        JObject.Parse("{\"id\":\"u2\",\"userId\":\"u2\",\"email\":\"b@example.com\",\"age\":42}")
+    };
+
+    /// <summary>Three simple order documents.</summary>
+    public static IReadOnlyList<JObject> ThreeOrders => new[]
+    {
+        JObject.Parse("{\"id\":\"o1\",\"orderId\":\"o1\",\"total\":99.99,\"userId\":\"u1\"}"),
+        JObject.Parse("{\"id\":\"o2\",\"orderId\":\"o2\",\"total\":12.50,\"userId\":\"u2\"}"),
+        JObject.Parse("{\"id\":\"o3\",\"orderId\":\"o3\",\"total\":250.00,\"userId\":\"u1\"}")
+    };
+
+    /// <summary>Two product documents.</summary>
+    public static IReadOnlyList<JObject> TwoProducts => new[]
+    {
+        JObject.Parse("{\"id\":\"p1\",\"productId\":\"p1\",\"name\":\"Widget\",\"price\":9.99}"),
+        JObject.Parse("{\"id\":\"p2\",\"productId\":\"p2\",\"name\":\"Gizmo\",\"price\":19.99}")
+    };
+
+    /// <summary>
+    /// Six hours of synthetic RU metrics (avg, max, total per hour). The
+    /// production code averages the avg column, takes max of the max column,
+    /// and sums the total column - so these numbers are easy to reason about.
+    /// </summary>
+    public static IReadOnlyList<(DateTimeOffset Timestamp, double Avg, double Max, double Total)> SixHoursOfMetrics
+    {
+        get
+        {
+            var now = DateTimeOffset.UtcNow;
+            return new[]
+            {
+                (now.AddHours(-6), 10.0, 25.0, 100.0),
+                (now.AddHours(-5), 12.0, 30.0, 110.0),
+                (now.AddHours(-4), 15.0, 40.0, 150.0),
+                (now.AddHours(-3), 18.0, 45.0, 180.0),
+                (now.AddHours(-2), 20.0, 50.0, 200.0),
+                (now.AddHours(-1), 22.0, 55.0, 220.0)
+            };
+        }
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/EndToEnd/README.md
+++ b/tests/CosmosToSqlAssessment.Tests/EndToEnd/README.md
@@ -1,23 +1,148 @@
 # End-to-End Test Harness
 
-_Placeholder — populated by sub-issue **#181** under parent **#125**._
+Reusable smoke-test harness for the full **assessment → SQL project generation**
+pipeline. Built on top of the mock Azure SDK harness in [`../Mocks/`](../Mocks/README.md).
 
-This folder will host the **full-pipeline E2E test harness** that wires real
-services (with the mock Azure SDK layer from `../Mocks/`) end-to-end:
+This is the canonical entry point Wave-2+ parents should use **before
+declaring a refactor safe**: stand up an `E2EFixture`, run the assessment,
+generate a SQL project, and assert on the on-disk artifacts.
+
+## Pipeline under test
 
 ```
-CosmosDbAnalysisService
-    -> DataQualityAnalysisService
-    -> SqlMigrationAssessmentService
-    -> DataFactoryEstimateService
-    -> SqlProjectGenerationService
-    -> ReportGenerationService
+CosmosDbAnalysisService            (uses mocked CosmosClient + LogsQueryClient)
+  -> SqlMigrationAssessmentService (pure compute)
+  -> DataQualityAnalysisService    (uses mocked CosmosClient)
+  -> DataFactoryEstimateService    (pure compute)
+  -> EITHER SqlProjectGenerationService.GenerateSqlProjectsAsync
+            (the path Program.GenerateOutputsAsync uses, produces
+             sql-projects/<db>.Database/Tables|Indexes|ForeignKeys|Scripts/)
+     OR     SqlProjectIntegrationService.GenerateSqlProjectAsync
+            (the path Program.GenerateSqlProjectAsync uses, wraps
+             SqlDatabaseProjectService)
 ```
 
-E2E tests must:
+Both project-generation paths are real production code paths. The
+[`E2EPipelineTests`](./E2EPipelineTests.cs) suite exercises each one.
 
-- Run with **no Azure resources** (use the `Mocks/` harness).
-- Complete in **< 60 seconds** total.
-- Be the smoke-test entry point every Wave-2+ parent runs before declaring done.
+## Quick start
 
-See parent issue #125 and the `../Mocks/README.md` for context.
+```csharp
+using CosmosToSqlAssessment.Tests.EndToEnd;
+
+[Fact]
+public async Task My_pipeline_smoke_test()
+{
+    using var fixture = new E2EFixture()
+        .WithDatabase("AppDb", db => db
+            .WithContainer("users", c => c
+                .WithPartitionKey("/userId").WithThroughput(400)
+                .WithDocuments(E2ESampleData.TwoUsers.ToArray()))
+            .WithContainer("orders", c => c
+                .WithPartitionKey("/orderId").WithThroughput(800)
+                .WithDocuments(E2ESampleData.ThreeOrders.ToArray())))
+        .WithAzureMonitorMetrics(E2ESampleData.SixHoursOfMetrics)   // optional
+        .Build();
+
+    var assessment = await fixture.RunAssessmentAsync("AppDb");
+
+    // Path 1: SqlProjectIntegrationService -> SqlDatabaseProjectService
+    var integrationResult = await fixture.GenerateSqlProjectsViaIntegrationAsync(assessment);
+    integrationResult.Success.Should().BeTrue();
+    File.Exists(integrationResult.Project!.ProjectFilePath).Should().BeTrue();
+
+    // Path 2: SqlProjectGenerationService.GenerateSqlProjectsAsync
+    var sqlProjectsDir = await fixture.GenerateSqlProjectsViaGenerationServiceAsync(assessment);
+    Directory.Exists(sqlProjectsDir).Should().BeTrue();
+}
+```
+
+## Required document shape
+
+Documents **must** be `Newtonsoft.Json.Linq.JObject` instances. This is the only
+type that satisfies both the dynamic-member access (`obj.id`) **and** the
+`ToString()` → valid-JSON requirement that production code relies on. See the
+mock harness README for the rationale.
+
+```csharp
+var doc = JObject.Parse("{\"id\":\"u1\",\"email\":\"a@example.com\",\"age\":30}");
+```
+
+## Azure Monitor metrics
+
+Calling `.WithAzureMonitorMetrics(rows)` does **two** things:
+
+1. Sets the `AzureMonitor:WorkspaceId` and `AzureMonitor:CosmosAccountName`
+   configuration keys (the production code short-circuits to default zero
+   metrics if either is missing).
+2. Injects a `LogsQueryClient` built by
+   [`LogsQueryClientMockBuilder`](../Mocks/LogsQueryClientMockBuilder.cs)
+   that returns a `LogsQueryResult` containing your synthetic rows.
+
+Each row is a `(DateTimeOffset, double Avg, double Max, double Total)` tuple.
+Production averages `Avg`, takes max of `Max`, sums `Total`. Without this call,
+`CosmosAnalysis.PerformanceMetrics` will all be zero and a single entry will
+appear in `CosmosAnalysis.MonitoringLimitations`.
+
+## Temp directory & cleanup
+
+Each fixture owns a temp subdirectory at `Directory.CreateTempSubdirectory("e2e-")`.
+- `GenerateSqlProjectsViaGenerationServiceAsync` writes under
+  `<TempRoot>/generation-service/sql-projects/...`.
+- `GenerateSqlProjectsViaIntegrationAsync` writes under
+  `<TempRoot>/integration-service/...`.
+
+`Dispose` removes the temp root with a short retry loop to tolerate transient
+Windows file-lock races. **Always use `using var fixture = ...` so cleanup runs
+even on test failure.**
+
+## Granular reuse
+
+The fixture exposes every real service as a public read-only property:
+
+```csharp
+fixture.Configuration              // IConfiguration
+fixture.CosmosService              // CosmosDbAnalysisService
+fixture.SqlAssessmentService       // SqlMigrationAssessmentService
+fixture.DataQualityService         // DataQualityAnalysisService
+fixture.DataFactoryService         // DataFactoryEstimateService
+fixture.SqlProjectService          // SqlProjectGenerationService
+fixture.SqlDatabaseProjectService  // SqlDatabaseProjectService
+fixture.SqlProjectIntegrationService
+fixture.TempRoot                   // path to per-fixture temp dir
+```
+
+Use these directly when you want to drive an individual service through a
+specific scenario without going through `RunAssessmentAsync`.
+
+## Recommended assertion patterns
+
+- **Validate structure, not text.** Parse the `.sqlproj` with `XDocument.Load`,
+  enumerate generated table files with `Directory.EnumerateFiles(... "*.sql"
+  ...)`, and check each contains `CREATE TABLE`.
+- **Derive expected names from `assessment.SqlAssessment.DatabaseMappings`** —
+  do not hard-code `Users.sql`/`Orders.sql` because the sanitisation rules
+  may evolve.
+- **Avoid** asserting against timestamps, GUIDs, full file text, comment lines,
+  or generation order — those are brittle.
+- For metrics: assert "> 0" rather than exact values where averages over six
+  synthetic rows are involved (rounding is not the point of an E2E test).
+
+## Known limitations
+
+- **Empty containers** are supported but the generated `CREATE TABLE` will be
+  near-empty because there are no detected fields. Use at least one container
+  with real documents if you need a meaningful schema.
+- **Zero-container databases** would crash `DataFactoryEstimateService`
+  (`analysis.Containers.Max(...)`). Not a supported scenario — add at least
+  one container.
+- Behaviour-changing or expensive options like `IncludeOutlierDetection` are
+  driven by `DataQualityAnalysisOptions`, which the fixture does not currently
+  expose; sub-issue #183 will broaden coverage here on top of this harness.
+
+## Performance budget
+
+Six tests, each touching disk, complete in well under 60 seconds on a typical
+developer machine. If a new E2E test pushes this budget, prefer **smaller
+samples** (2-3 documents per container) over reducing the assertion surface.
+

--- a/tests/CosmosToSqlAssessment.Tests/EndToEnd/README.md
+++ b/tests/CosmosToSqlAssessment.Tests/EndToEnd/README.md
@@ -1,0 +1,23 @@
+# End-to-End Test Harness
+
+_Placeholder — populated by sub-issue **#181** under parent **#125**._
+
+This folder will host the **full-pipeline E2E test harness** that wires real
+services (with the mock Azure SDK layer from `../Mocks/`) end-to-end:
+
+```
+CosmosDbAnalysisService
+    -> DataQualityAnalysisService
+    -> SqlMigrationAssessmentService
+    -> DataFactoryEstimateService
+    -> SqlProjectGenerationService
+    -> ReportGenerationService
+```
+
+E2E tests must:
+
+- Run with **no Azure resources** (use the `Mocks/` harness).
+- Complete in **< 60 seconds** total.
+- Be the smoke-test entry point every Wave-2+ parent runs before declaring done.
+
+See parent issue #125 and the `../Mocks/README.md` for context.

--- a/tests/CosmosToSqlAssessment.Tests/Mocks/CosmosClientMockBuilder.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Mocks/CosmosClientMockBuilder.cs
@@ -1,0 +1,331 @@
+using Microsoft.Azure.Cosmos;
+using Newtonsoft.Json.Linq;
+
+namespace CosmosToSqlAssessment.Tests.Mocks;
+
+/// <summary>
+/// Fluent builder that stands up a complete mock <see cref="CosmosClient"/>
+/// hierarchy (client → databases → containers → documents + throughput +
+/// indexing policy + query results) in a handful of lines.
+///
+/// <para>
+/// Designed for reuse across the test suite and by every Wave-2+ parent that
+/// needs to drive production code through Cosmos SDK calls without hitting a
+/// real Azure resource. See <c>tests/CosmosToSqlAssessment.Tests/Mocks/README.md</c>
+/// for a quick start.
+/// </para>
+///
+/// <example>
+/// <code>
+/// var cosmosClient = new CosmosClientMockBuilder()
+///     .WithDatabase("MyDb", db => db
+///         .WithContainer("orders", c => c
+///             .WithPartitionKey("/orderId")
+///             .WithThroughput(400)
+///             .WithDocuments(
+///                 JObject.Parse("{ \"id\": \"1\", \"total\": 42.0 }"),
+///                 JObject.Parse("{ \"id\": \"2\", \"total\": 9.99 }"))))
+///     .Build();
+/// </code>
+/// </example>
+/// </summary>
+public sealed class CosmosClientMockBuilder
+{
+    private readonly Dictionary<string, DatabaseMockBuilder> _databases = new(StringComparer.Ordinal);
+
+    /// <summary>Adds a database; <paramref name="configure"/> sets up its containers.</summary>
+    public CosmosClientMockBuilder WithDatabase(string databaseId, Action<DatabaseMockBuilder>? configure = null)
+    {
+        var builder = new DatabaseMockBuilder(databaseId);
+        configure?.Invoke(builder);
+        _databases[databaseId] = builder;
+        return this;
+    }
+
+    /// <summary>Materialises the fully-wired mock <see cref="CosmosClient"/>.</summary>
+    public CosmosClient Build()
+    {
+        var clientMock = new Mock<CosmosClient>();
+        clientMock
+            .Setup(c => c.GetDatabase(It.IsAny<string>()))
+            .Returns<string>(id =>
+            {
+                if (_databases.TryGetValue(id, out var b))
+                {
+                    return b.Build();
+                }
+                // Unknown database -- still return a usable Database whose
+                // ReadAsync / queries simulate a 404 so production code's
+                // catch handlers can be exercised.
+                return new DatabaseMockBuilder(id).BuildAsMissing();
+            });
+        return clientMock.Object;
+    }
+}
+
+/// <summary>
+/// Inner builder for a single mock <see cref="Database"/>. Use
+/// <see cref="WithContainer"/> to add containers; the database's container-listing
+/// query iterator is materialised from those entries.
+/// </summary>
+public sealed class DatabaseMockBuilder
+{
+    private readonly string _databaseId;
+    private readonly Dictionary<string, ContainerMockBuilder> _containers = new(StringComparer.Ordinal);
+
+    internal DatabaseMockBuilder(string databaseId)
+    {
+        _databaseId = databaseId;
+    }
+
+    public DatabaseMockBuilder WithContainer(string containerId, Action<ContainerMockBuilder>? configure = null)
+    {
+        var builder = new ContainerMockBuilder(containerId);
+        configure?.Invoke(builder);
+        _containers[containerId] = builder;
+        return this;
+    }
+
+    internal Database Build()
+    {
+        var dbMock = new Mock<Database>();
+
+        dbMock.SetupGet(d => d.Id).Returns(_databaseId);
+
+        dbMock
+            .Setup(d => d.ReadAsync(It.IsAny<RequestOptions?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MockDatabaseResponse.Build(_databaseId));
+
+        // Container listing iterator -- production calls
+        // database.GetContainerQueryIterator<dynamic>() with no args. The compiled
+        // call site supplies (null, null, null).
+        // Container list pages: each element exposes an `id` member via dynamic.
+        // JObject implements IDynamicMetaObjectProvider so `container.id` works.
+        var containerListItems = _containers.Keys
+            .Select(id => (dynamic)JObject.FromObject(new { id }))
+            .ToList();
+
+        dbMock
+            .Setup(d => d.GetContainerQueryIterator<dynamic>(
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<QueryRequestOptions?>()))
+            .Returns(() => MockFeedIterator.OfDocuments(containerListItems));
+
+        // GetContainer(name) -- return wired container or a "missing" stub.
+        dbMock
+            .Setup(d => d.GetContainer(It.IsAny<string>()))
+            .Returns<string>(name =>
+            {
+                if (_containers.TryGetValue(name, out var cb))
+                {
+                    return cb.Build();
+                }
+                return new ContainerMockBuilder(name).BuildAsMissing();
+            });
+
+        return dbMock.Object;
+    }
+
+    /// <summary>
+    /// Builds a Database that simulates a 404 (NotFound) on any operation.
+    /// Used when production calls <c>GetDatabase</c> for an id that wasn't
+    /// configured on the builder, so tests can exercise error-handling paths.
+    /// </summary>
+    internal Database BuildAsMissing()
+    {
+        var dbMock = new Mock<Database>();
+        dbMock.SetupGet(d => d.Id).Returns(_databaseId);
+        dbMock
+            .Setup(d => d.ReadAsync(It.IsAny<RequestOptions?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(CosmosExceptionFactory.NotFound());
+        dbMock
+            .Setup(d => d.GetContainerQueryIterator<dynamic>(
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<QueryRequestOptions?>()))
+            .Returns(MockFeedIterator.Empty<dynamic>());
+        dbMock
+            .Setup(d => d.GetContainer(It.IsAny<string>()))
+            .Returns<string>(name => new ContainerMockBuilder(name).BuildAsMissing());
+        return dbMock.Object;
+    }
+}
+
+/// <summary>
+/// Inner builder for a single mock <see cref="Container"/>. Captures partition
+/// key, throughput, indexing policy and the documents that should be returned
+/// from <c>GetItemQueryIterator</c> calls.
+/// </summary>
+public sealed class ContainerMockBuilder
+{
+    private readonly string _containerId;
+    private string _partitionKeyPath = "/id";
+    private int? _throughput;
+    private IndexingPolicy? _indexingPolicy;
+    private readonly List<JObject> _documents = new();
+    private Exception? _throughputException;
+    private Exception? _readContainerException;
+    private Exception? _queryException;
+
+    internal ContainerMockBuilder(string containerId)
+    {
+        _containerId = containerId;
+    }
+
+    public ContainerMockBuilder WithPartitionKey(string path)
+    {
+        _partitionKeyPath = path;
+        return this;
+    }
+
+    /// <summary>Sets the value returned from <c>ReadThroughputAsync()</c> (the <c>int?</c> overload).</summary>
+    public ContainerMockBuilder WithThroughput(int? throughput)
+    {
+        _throughput = throughput;
+        _throughputException = null;
+        return this;
+    }
+
+    /// <summary>Causes <c>ReadThroughputAsync()</c> to throw the provided exception.</summary>
+    public ContainerMockBuilder WithThroughputError(Exception exception)
+    {
+        _throughputException = exception;
+        return this;
+    }
+
+    public ContainerMockBuilder WithIndexingPolicy(IndexingPolicy policy)
+    {
+        _indexingPolicy = policy;
+        return this;
+    }
+
+    /// <summary>
+    /// Adds documents that will be returned by <c>GetItemQueryIterator&lt;T&gt;</c> calls.
+    /// Documents must be <see cref="JObject"/> so they satisfy both:
+    /// dynamic member access (<c>doc.id</c>) and JSON round-trip via <c>ToString()</c>.
+    /// </summary>
+    public ContainerMockBuilder WithDocuments(params JObject[] documents)
+    {
+        _documents.AddRange(documents);
+        return this;
+    }
+
+    public ContainerMockBuilder WithDocuments(IEnumerable<JObject> documents)
+    {
+        _documents.AddRange(documents);
+        return this;
+    }
+
+    /// <summary>Causes <c>ReadContainerAsync</c> to throw the provided exception.</summary>
+    public ContainerMockBuilder WithReadContainerError(Exception exception)
+    {
+        _readContainerException = exception;
+        return this;
+    }
+
+    /// <summary>
+    /// Causes <c>GetItemQueryIterator&lt;T&gt;.ReadNextAsync</c> to throw the
+    /// provided exception on first read. Useful for transient-failure / retry
+    /// tests (#184).
+    /// </summary>
+    public ContainerMockBuilder WithQueryError(Exception exception)
+    {
+        _queryException = exception;
+        return this;
+    }
+
+    internal Container Build()
+    {
+        var containerMock = new Mock<Container>();
+
+        containerMock.SetupGet(c => c.Id).Returns(_containerId);
+
+        // ReadContainerAsync
+        if (_readContainerException != null)
+        {
+            containerMock
+                .Setup(c => c.ReadContainerAsync(It.IsAny<ContainerRequestOptions?>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(_readContainerException);
+        }
+        else
+        {
+            var containerResponse = MockContainerResponse.Build(
+                _containerId,
+                _partitionKeyPath,
+                _indexingPolicy ?? new IndexingPolicy());
+            containerMock
+                .Setup(c => c.ReadContainerAsync(It.IsAny<ContainerRequestOptions?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(containerResponse);
+        }
+
+        // ReadThroughputAsync (int? overload). Production binds to:
+        //   container.ReadThroughputAsync(cancellationToken: ct)
+        // which resolves to the (CancellationToken) overload returning Task<int?>.
+        if (_throughputException != null)
+        {
+            containerMock
+                .Setup(c => c.ReadThroughputAsync(It.IsAny<CancellationToken>()))
+                .ThrowsAsync(_throughputException);
+        }
+        else
+        {
+            containerMock
+                .Setup(c => c.ReadThroughputAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_throughput);
+        }
+
+        // GetItemQueryIterator<dynamic>(QueryDefinition, ...) -- schema sampling
+        SetupItemQueryIterator<dynamic>(containerMock, _documents.Cast<dynamic>().ToList());
+
+        // GetItemQueryIterator<JsonDocument>(QueryDefinition, ...) -- DataQualityAnalysisService
+        var jsonDocs = _documents
+            .Select(j => System.Text.Json.JsonDocument.Parse(j.ToString()))
+            .ToList();
+        SetupItemQueryIterator<System.Text.Json.JsonDocument>(containerMock, jsonDocs);
+
+        // GetItemQueryIterator<int>(QueryDefinition, ...) -- count queries
+        SetupItemQueryIterator<int>(containerMock, new List<int> { _documents.Count });
+
+        return containerMock.Object;
+    }
+
+    private void SetupItemQueryIterator<T>(Mock<Container> containerMock, List<T> items)
+    {
+        if (_queryException != null)
+        {
+            containerMock
+                .Setup(c => c.GetItemQueryIterator<T>(
+                    It.IsAny<QueryDefinition>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<QueryRequestOptions?>()))
+                .Returns(MockFeedIterator.ThrowsOnRead<T>(_queryException));
+        }
+        else
+        {
+            containerMock
+                .Setup(c => c.GetItemQueryIterator<T>(
+                    It.IsAny<QueryDefinition>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<QueryRequestOptions?>()))
+                .Returns(() => MockFeedIterator.OfDocuments(items));
+        }
+    }
+
+    /// <summary>
+    /// Builds a Container whose every operation throws <see cref="CosmosExceptionFactory.NotFound"/>.
+    /// Used when production calls <c>GetContainer</c> for an id that wasn't configured.
+    /// </summary>
+    internal Container BuildAsMissing()
+    {
+        var containerMock = new Mock<Container>();
+        containerMock.SetupGet(c => c.Id).Returns(_containerId);
+        containerMock
+            .Setup(c => c.ReadContainerAsync(It.IsAny<ContainerRequestOptions?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(CosmosExceptionFactory.NotFound());
+        containerMock
+            .Setup(c => c.ReadThroughputAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(CosmosExceptionFactory.NotFound());
+        return containerMock.Object;
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Mocks/CosmosClientMockBuilder.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Mocks/CosmosClientMockBuilder.cs
@@ -72,10 +72,23 @@ public sealed class DatabaseMockBuilder
 {
     private readonly string _databaseId;
     private readonly Dictionary<string, ContainerMockBuilder> _containers = new(StringComparer.Ordinal);
+    private Exception? _containerListException;
 
     internal DatabaseMockBuilder(string databaseId)
     {
         _databaseId = databaseId;
+    }
+
+    /// <summary>
+    /// Causes <c>Database.GetContainerQueryIterator&lt;dynamic&gt;().ReadNextAsync</c>
+    /// to throw the provided exception on first read. Useful for #184-style
+    /// transient-failure tests against the container-discovery path
+    /// (production has no try/catch around that call).
+    /// </summary>
+    public DatabaseMockBuilder WithContainerListError(Exception exception)
+    {
+        _containerListException = exception;
+        return this;
     }
 
     public DatabaseMockBuilder WithContainer(string containerId, Action<ContainerMockBuilder>? configure = null)
@@ -105,12 +118,24 @@ public sealed class DatabaseMockBuilder
             .Select(id => (dynamic)JObject.FromObject(new { id }))
             .ToList();
 
-        dbMock
-            .Setup(d => d.GetContainerQueryIterator<dynamic>(
-                It.IsAny<string?>(),
-                It.IsAny<string?>(),
-                It.IsAny<QueryRequestOptions?>()))
-            .Returns(() => MockFeedIterator.OfDocuments(containerListItems));
+        if (_containerListException != null)
+        {
+            dbMock
+                .Setup(d => d.GetContainerQueryIterator<dynamic>(
+                    It.IsAny<string?>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<QueryRequestOptions?>()))
+                .Returns(() => MockFeedIterator.ThrowsOnRead<dynamic>(_containerListException));
+        }
+        else
+        {
+            dbMock
+                .Setup(d => d.GetContainerQueryIterator<dynamic>(
+                    It.IsAny<string?>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<QueryRequestOptions?>()))
+                .Returns(() => MockFeedIterator.OfDocuments(containerListItems));
+        }
 
         // GetContainer(name) -- return wired container or a "missing" stub.
         dbMock
@@ -167,6 +192,7 @@ public sealed class ContainerMockBuilder
     private Exception? _throughputException;
     private Exception? _readContainerException;
     private Exception? _queryException;
+    private readonly Dictionary<Type, Exception> _typedQueryExceptions = new();
 
     internal ContainerMockBuilder(string containerId)
     {
@@ -226,12 +252,32 @@ public sealed class ContainerMockBuilder
 
     /// <summary>
     /// Causes <c>GetItemQueryIterator&lt;T&gt;.ReadNextAsync</c> to throw the
-    /// provided exception on first read. Useful for transient-failure / retry
-    /// tests (#184).
+    /// provided exception on first read, for **every** generic parameter
+    /// (<c>dynamic</c>, <c>JsonDocument</c>, <c>int</c>). Use the typed overload
+    /// <see cref="WithQueryError{T}(Exception)"/> when you need to fail only
+    /// one specific call site (e.g. schema-sample but not the count query).
+    /// Useful for transient-failure / retry tests (#184).
     /// </summary>
     public ContainerMockBuilder WithQueryError(Exception exception)
     {
         _queryException = exception;
+        return this;
+    }
+
+    /// <summary>
+    /// Causes <c>GetItemQueryIterator&lt;T&gt;.ReadNextAsync</c> to throw the
+    /// provided exception on first read **only for the requested generic
+    /// parameter <typeparamref name="T"/></b>. The other overloads keep
+    /// returning their configured documents. Required to isolate
+    /// production branches that swallow a query failure on one type but
+    /// propagate on another (e.g. <c>AnalyzeDocumentSchemasAsync</c>
+    /// swallows <c>&lt;dynamic&gt;</c> failures but
+    /// <c>AnalyzeContainerAsync</c>'s count query
+    /// <c>&lt;int&gt;</c> propagates them).
+    /// </summary>
+    public ContainerMockBuilder WithQueryError<T>(Exception exception)
+    {
+        _typedQueryExceptions[typeof(T)] = exception;
         return this;
     }
 
@@ -292,7 +338,16 @@ public sealed class ContainerMockBuilder
 
     private void SetupItemQueryIterator<T>(Mock<Container> containerMock, List<T> items)
     {
-        if (_queryException != null)
+        if (_typedQueryExceptions.TryGetValue(typeof(T), out var typedEx))
+        {
+            containerMock
+                .Setup(c => c.GetItemQueryIterator<T>(
+                    It.IsAny<QueryDefinition>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<QueryRequestOptions?>()))
+                .Returns(MockFeedIterator.ThrowsOnRead<T>(typedEx));
+        }
+        else if (_queryException != null)
         {
             containerMock
                 .Setup(c => c.GetItemQueryIterator<T>(

--- a/tests/CosmosToSqlAssessment.Tests/Mocks/CosmosExceptionFactory.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Mocks/CosmosExceptionFactory.cs
@@ -1,0 +1,66 @@
+using System.Net;
+using Microsoft.Azure.Cosmos;
+
+namespace CosmosToSqlAssessment.Tests.Mocks;
+
+/// <summary>
+/// Factory for crafting <see cref="CosmosException"/>s that mirror real Azure
+/// error shapes. Used by the harness, #183 (edge cases), and especially #184
+/// (transient failure / retry tests).
+/// </summary>
+public static class CosmosExceptionFactory
+{
+    /// <summary>HTTP 429 - request rate too large (throttling).</summary>
+    public static CosmosException Throttled(string? activityId = null)
+        => new(
+            message: "Request rate is large",
+            statusCode: (HttpStatusCode)429,
+            subStatusCode: 3200,
+            activityId: activityId ?? Guid.NewGuid().ToString(),
+            requestCharge: 0);
+
+    /// <summary>HTTP 503 - service unavailable.</summary>
+    public static CosmosException ServiceUnavailable(string? activityId = null)
+        => new(
+            message: "Service unavailable",
+            statusCode: HttpStatusCode.ServiceUnavailable,
+            subStatusCode: 0,
+            activityId: activityId ?? Guid.NewGuid().ToString(),
+            requestCharge: 0);
+
+    /// <summary>HTTP 408 - request timeout.</summary>
+    public static CosmosException Timeout(string? activityId = null)
+        => new(
+            message: "Request timed out",
+            statusCode: HttpStatusCode.RequestTimeout,
+            subStatusCode: 0,
+            activityId: activityId ?? Guid.NewGuid().ToString(),
+            requestCharge: 0);
+
+    /// <summary>HTTP 403 - insufficient permissions (Forbidden).</summary>
+    public static CosmosException Forbidden(string? activityId = null)
+        => new(
+            message: "Forbidden",
+            statusCode: HttpStatusCode.Forbidden,
+            subStatusCode: 0,
+            activityId: activityId ?? Guid.NewGuid().ToString(),
+            requestCharge: 0);
+
+    /// <summary>HTTP 404 - resource not found.</summary>
+    public static CosmosException NotFound(string? activityId = null)
+        => new(
+            message: "Not Found",
+            statusCode: HttpStatusCode.NotFound,
+            subStatusCode: 0,
+            activityId: activityId ?? Guid.NewGuid().ToString(),
+            requestCharge: 0);
+
+    /// <summary>HTTP 400 - bad request (also raised when a container is using shared db throughput).</summary>
+    public static CosmosException BadRequest(string? message = null, string? activityId = null)
+        => new(
+            message: message ?? "Bad request",
+            statusCode: HttpStatusCode.BadRequest,
+            subStatusCode: 0,
+            activityId: activityId ?? Guid.NewGuid().ToString(),
+            requestCharge: 0);
+}

--- a/tests/CosmosToSqlAssessment.Tests/Mocks/LogsQueryClientMockBuilder.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Mocks/LogsQueryClientMockBuilder.cs
@@ -1,0 +1,111 @@
+using Azure;
+using Azure.Monitor.Query;
+using Azure.Monitor.Query.Models;
+
+namespace CosmosToSqlAssessment.Tests.Mocks;
+
+/// <summary>
+/// Builder for a mock <see cref="LogsQueryClient"/> that returns canned
+/// <see cref="LogsQueryResult"/>s from <c>QueryWorkspaceAsync</c>.
+///
+/// <para>
+/// Production code (see <c>CosmosDbAnalysisService.CollectPerformanceMetricsAsync</c>)
+/// reads <c>response.Value.Table.Rows</c> and indexes <c>row[1]</c>, <c>row[2]</c>,
+/// <c>row[3]</c>, so the builder always emits at least one table with four columns
+/// (TimeGenerated + three numeric metrics). Override via
+/// <see cref="WithTable"/> if you need a different shape.
+/// </para>
+/// </summary>
+public sealed class LogsQueryClientMockBuilder
+{
+    private readonly List<LogsTable> _tables = new();
+    private Exception? _exception;
+
+    /// <summary>
+    /// Adds a metrics table with one row per <paramref name="rows"/> entry.
+    /// Each row is a tuple of (TimeGenerated, AverageRUs, MaxRUs, TotalRUs).
+    /// </summary>
+    public LogsQueryClientMockBuilder WithMetricsRows(IEnumerable<(DateTimeOffset Time, double Avg, double Max, double Total)> rows)
+    {
+        var columns = new[]
+        {
+            MonitorQueryModelFactory.LogsTableColumn("TimeGenerated", LogsColumnType.Datetime),
+            MonitorQueryModelFactory.LogsTableColumn("AvgRUs", LogsColumnType.Real),
+            MonitorQueryModelFactory.LogsTableColumn("MaxRUs", LogsColumnType.Real),
+            MonitorQueryModelFactory.LogsTableColumn("TotalRUs", LogsColumnType.Real)
+        };
+
+        var tableRows = rows
+            .Select(r => MonitorQueryModelFactory.LogsTableRow(
+                columns,
+                new object[] { r.Time, r.Avg, r.Max, r.Total }))
+            .ToList();
+
+        var table = MonitorQueryModelFactory.LogsTable("PrimaryResult", columns, tableRows);
+        _tables.Add(table);
+        return this;
+    }
+
+    /// <summary>Adds a fully-customised table to the result set.</summary>
+    public LogsQueryClientMockBuilder WithTable(LogsTable table)
+    {
+        _tables.Add(table);
+        return this;
+    }
+
+    /// <summary>Causes <c>QueryWorkspaceAsync</c> to throw the provided exception.</summary>
+    public LogsQueryClientMockBuilder WithError(Exception exception)
+    {
+        _exception = exception;
+        return this;
+    }
+
+    /// <summary>Materialises the mock client.</summary>
+    public LogsQueryClient Build()
+    {
+        var mock = new Mock<LogsQueryClient>();
+
+        if (_exception != null)
+        {
+            mock.Setup(c => c.QueryWorkspaceAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<QueryTimeRange>(),
+                    It.IsAny<LogsQueryOptions?>(),
+                    It.IsAny<CancellationToken>()))
+                .ThrowsAsync(_exception);
+            return mock.Object;
+        }
+
+        if (_tables.Count == 0)
+        {
+            // Default: a single empty table so production code's null checks succeed.
+            var emptyColumns = new[]
+            {
+                MonitorQueryModelFactory.LogsTableColumn("TimeGenerated", LogsColumnType.Datetime),
+                MonitorQueryModelFactory.LogsTableColumn("AvgRUs", LogsColumnType.Real),
+                MonitorQueryModelFactory.LogsTableColumn("MaxRUs", LogsColumnType.Real),
+                MonitorQueryModelFactory.LogsTableColumn("TotalRUs", LogsColumnType.Real)
+            };
+            _tables.Add(MonitorQueryModelFactory.LogsTable("PrimaryResult", emptyColumns, Array.Empty<LogsTableRow>()));
+        }
+
+        var result = MonitorQueryModelFactory.LogsQueryResult(
+            allTables: _tables,
+            statistics: BinaryData.FromString("{}"),
+            visualization: BinaryData.FromString("{}"),
+            error: BinaryData.FromString("{}"));
+
+        var response = Response.FromValue(result, Mock.Of<Response>());
+
+        mock.Setup(c => c.QueryWorkspaceAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<QueryTimeRange>(),
+                It.IsAny<LogsQueryOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        return mock.Object;
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Mocks/LogsQueryClientMockBuilderTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Mocks/LogsQueryClientMockBuilderTests.cs
@@ -1,0 +1,71 @@
+using Azure.Monitor.Query;
+using CosmosToSqlAssessment.Tests.Mocks;
+
+namespace CosmosToSqlAssessment.Tests.Mocks;
+
+/// <summary>
+/// Meta-tests for the <see cref="LogsQueryClientMockBuilder"/>. Production code in
+/// <c>CosmosDbAnalysisService.CollectPerformanceMetricsAsync</c> reads
+/// <c>response.Value.Table.Rows</c> and indexes columns 1, 2, 3, so the builder
+/// must produce that exact shape.
+/// </summary>
+public class LogsQueryClientMockBuilderTests
+{
+    [Fact]
+    public async Task Build_default_returns_response_with_single_empty_table()
+    {
+        var client = new LogsQueryClientMockBuilder().Build();
+
+        var response = await client.QueryWorkspaceAsync(
+            "workspace-id",
+            "AzureDiagnostics | take 1",
+            new QueryTimeRange(TimeSpan.FromHours(1)));
+
+        response.Value.Should().NotBeNull();
+        response.Value.Table.Should().NotBeNull();
+        response.Value.Table.Rows.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Build_with_metrics_rows_returns_correctly_shaped_table()
+    {
+        var rows = new[]
+        {
+            (DateTimeOffset.UtcNow.AddHours(-2), 10.0, 25.0, 100.0),
+            (DateTimeOffset.UtcNow.AddHours(-1), 12.0, 30.0, 120.0)
+        };
+
+        var client = new LogsQueryClientMockBuilder()
+            .WithMetricsRows(rows)
+            .Build();
+
+        var response = await client.QueryWorkspaceAsync(
+            "workspace-id",
+            "AzureDiagnostics | take 2",
+            new QueryTimeRange(TimeSpan.FromDays(1)));
+
+        var table = response.Value.Table;
+        table.Rows.Should().HaveCount(2);
+
+        // Production indexes row[1], row[2], row[3] -- verify those positions hold numbers.
+        Convert.ToDouble(table.Rows[0][1]).Should().Be(10.0);
+        Convert.ToDouble(table.Rows[0][2]).Should().Be(25.0);
+        Convert.ToDouble(table.Rows[0][3]).Should().Be(100.0);
+    }
+
+    [Fact]
+    public async Task Build_with_error_propagates_exception()
+    {
+        var client = new LogsQueryClientMockBuilder()
+            .WithError(new InvalidOperationException("Workspace unavailable"))
+            .Build();
+
+        var act = async () => await client.QueryWorkspaceAsync(
+            "workspace-id",
+            "AzureDiagnostics",
+            new QueryTimeRange(TimeSpan.FromHours(1)));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Workspace unavailable");
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Mocks/MockContainerResponse.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Mocks/MockContainerResponse.cs
@@ -1,0 +1,32 @@
+using System.Net;
+using Microsoft.Azure.Cosmos;
+
+namespace CosmosToSqlAssessment.Tests.Mocks;
+
+/// <summary>
+/// Factory for mock <see cref="ContainerResponse"/> instances.
+/// Production code reads <c>response.Resource</c> (a <see cref="ContainerProperties"/>)
+/// to inspect the container's partition key path and indexing policy.
+/// </summary>
+public static class MockContainerResponse
+{
+    public static ContainerResponse Build(
+        string containerId,
+        string partitionKeyPath,
+        IndexingPolicy? indexingPolicy = null)
+    {
+        var properties = new ContainerProperties(containerId, partitionKeyPath);
+        if (indexingPolicy != null)
+        {
+            properties.IndexingPolicy = indexingPolicy;
+        }
+
+        var mock = new Mock<ContainerResponse>();
+        mock.SetupGet(r => r.Resource).Returns(properties);
+        mock.SetupGet(r => r.StatusCode).Returns(HttpStatusCode.OK);
+        mock.SetupGet(r => r.RequestCharge).Returns(1.0);
+        mock.SetupGet(r => r.ActivityId).Returns(Guid.NewGuid().ToString());
+        mock.SetupGet(r => r.ETag).Returns(Guid.NewGuid().ToString());
+        return mock.Object;
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Mocks/MockDatabaseResponse.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Mocks/MockDatabaseResponse.cs
@@ -1,0 +1,24 @@
+using System.Net;
+using Microsoft.Azure.Cosmos;
+
+namespace CosmosToSqlAssessment.Tests.Mocks;
+
+/// <summary>
+/// Factory for mock <see cref="DatabaseResponse"/> instances.
+/// Production reads <c>response.Resource.Id</c> when logging discovered databases.
+/// </summary>
+public static class MockDatabaseResponse
+{
+    public static DatabaseResponse Build(string databaseId)
+    {
+        var properties = new DatabaseProperties(databaseId);
+
+        var mock = new Mock<DatabaseResponse>();
+        mock.SetupGet(r => r.Resource).Returns(properties);
+        mock.SetupGet(r => r.StatusCode).Returns(HttpStatusCode.OK);
+        mock.SetupGet(r => r.RequestCharge).Returns(1.0);
+        mock.SetupGet(r => r.ActivityId).Returns(Guid.NewGuid().ToString());
+        mock.SetupGet(r => r.ETag).Returns(Guid.NewGuid().ToString());
+        return mock.Object;
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Mocks/MockFeedIterator.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Mocks/MockFeedIterator.cs
@@ -1,0 +1,67 @@
+using Microsoft.Azure.Cosmos;
+
+namespace CosmosToSqlAssessment.Tests.Mocks;
+
+/// <summary>
+/// Factory helpers for building mock <see cref="FeedIterator{T}"/> instances.
+/// Supports single-page, multi-page (paginated), empty, and faulted iterators.
+/// </summary>
+public static class MockFeedIterator
+{
+    /// <summary>
+    /// Builds a <see cref="FeedIterator{T}"/> that returns all <paramref name="items"/>
+    /// in a single page.
+    /// </summary>
+    public static FeedIterator<T> OfDocuments<T>(IEnumerable<T> items)
+        => OfPages(new[] { items.ToList() });
+
+    /// <summary>
+    /// Builds a <see cref="FeedIterator{T}"/> that returns each element of
+    /// <paramref name="pages"/> as a separate page (in order).
+    /// </summary>
+    public static FeedIterator<T> OfPages<T>(IEnumerable<IReadOnlyCollection<T>> pages)
+    {
+        var pageList = pages.Select(p => (IEnumerable<T>)p).ToList();
+        var mock = new Mock<FeedIterator<T>>();
+        var index = 0;
+
+        mock.SetupGet(i => i.HasMoreResults).Returns(() => index < pageList.Count);
+        mock.Setup(i => i.ReadNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                if (index >= pageList.Count)
+                {
+                    return new MockFeedResponse<T>(Array.Empty<T>());
+                }
+                var page = pageList[index];
+                index++;
+                return new MockFeedResponse<T>(page);
+            });
+        return mock.Object;
+    }
+
+    /// <summary>
+    /// Builds an empty <see cref="FeedIterator{T}"/> (no pages, <c>HasMoreResults</c> false).
+    /// </summary>
+    public static FeedIterator<T> Empty<T>()
+    {
+        var mock = new Mock<FeedIterator<T>>();
+        mock.SetupGet(i => i.HasMoreResults).Returns(false);
+        mock.Setup(i => i.ReadNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MockFeedResponse<T>(Array.Empty<T>()));
+        return mock.Object;
+    }
+
+    /// <summary>
+    /// Builds a <see cref="FeedIterator{T}"/> whose first <c>ReadNextAsync</c> throws
+    /// the provided exception. Useful for retry / transient-failure tests (#184).
+    /// </summary>
+    public static FeedIterator<T> ThrowsOnRead<T>(Exception exception)
+    {
+        var mock = new Mock<FeedIterator<T>>();
+        mock.SetupGet(i => i.HasMoreResults).Returns(true);
+        mock.Setup(i => i.ReadNextAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(exception);
+        return mock.Object;
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Mocks/MockFeedResponse.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Mocks/MockFeedResponse.cs
@@ -1,0 +1,34 @@
+using System.Collections;
+using System.Net;
+using Microsoft.Azure.Cosmos;
+
+namespace CosmosToSqlAssessment.Tests.Mocks;
+
+/// <summary>
+/// Concrete <see cref="FeedResponse{T}"/> implementation backed by an in-memory list.
+/// Returns a <b>fresh</b> enumerator on every call to <see cref="GetEnumerator"/> so
+/// callers can safely enumerate the same instance multiple times (production code
+/// frequently does <c>response.Count()</c> followed by <c>foreach (var x in response)</c>).
+/// </summary>
+public sealed class MockFeedResponse<T> : FeedResponse<T>
+{
+    private readonly IReadOnlyList<T> _items;
+
+    public MockFeedResponse(IEnumerable<T> items, string? continuationToken = null)
+    {
+        _items = items?.ToList() ?? new List<T>();
+        ContinuationToken = continuationToken;
+    }
+
+    public override string? ContinuationToken { get; }
+    public override int Count => _items.Count;
+    public override string IndexMetrics => string.Empty;
+    public override Headers Headers { get; } = new();
+    public override IEnumerable<T> Resource => _items;
+    public override HttpStatusCode StatusCode => HttpStatusCode.OK;
+    public override double RequestCharge => 1.0;
+    public override string ActivityId => Guid.NewGuid().ToString();
+    public override CosmosDiagnostics? Diagnostics => null;
+
+    public override IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+}

--- a/tests/CosmosToSqlAssessment.Tests/Mocks/MockHarnessTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Mocks/MockHarnessTests.cs
@@ -1,0 +1,243 @@
+using CosmosToSqlAssessment.Tests.Mocks;
+using Microsoft.Azure.Cosmos;
+using Newtonsoft.Json.Linq;
+
+namespace CosmosToSqlAssessment.Tests.Mocks;
+
+/// <summary>
+/// Meta-tests for the mock harness. These verify the primitives in <c>Mocks/</c>
+/// behave as documented so later sub-issues (and Wave-2+ parents) can rely on them.
+/// </summary>
+public class MockHarnessTests
+{
+    [Fact]
+    public async Task MockFeedIterator_OfDocuments_returns_items_in_single_page()
+    {
+        var docs = new[] { JObject.Parse("{\"id\":\"1\"}"), JObject.Parse("{\"id\":\"2\"}") };
+        var iterator = MockFeedIterator.OfDocuments(docs);
+
+        iterator.HasMoreResults.Should().BeTrue();
+        var response = await iterator.ReadNextAsync(CancellationToken.None);
+        response.Count().Should().Be(2);
+        response.Select(j => (string?)j["id"]).Should().Equal("1", "2");
+
+        iterator.HasMoreResults.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task MockFeedIterator_OfPages_returns_each_page_in_order()
+    {
+        var page1 = new List<JObject> { JObject.Parse("{\"id\":\"a\"}") };
+        var page2 = new List<JObject> { JObject.Parse("{\"id\":\"b\"}"), JObject.Parse("{\"id\":\"c\"}") };
+
+        var iterator = MockFeedIterator.OfPages(new[] { page1, page2 });
+
+        var allIds = new List<string?>();
+        while (iterator.HasMoreResults)
+        {
+            var resp = await iterator.ReadNextAsync(CancellationToken.None);
+            allIds.AddRange(resp.Select(j => (string?)j["id"]));
+        }
+
+        allIds.Should().Equal("a", "b", "c");
+    }
+
+    [Fact]
+    public async Task MockFeedIterator_Empty_HasMoreResults_is_false()
+    {
+        var iterator = MockFeedIterator.Empty<JObject>();
+        iterator.HasMoreResults.Should().BeFalse();
+        var resp = await iterator.ReadNextAsync(CancellationToken.None);
+        resp.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task MockFeedIterator_ThrowsOnRead_propagates_exception()
+    {
+        var ex = CosmosExceptionFactory.Throttled();
+        var iterator = MockFeedIterator.ThrowsOnRead<JObject>(ex);
+
+        iterator.HasMoreResults.Should().BeTrue();
+        var act = async () => await iterator.ReadNextAsync(CancellationToken.None);
+        var thrown = await act.Should().ThrowAsync<CosmosException>();
+        thrown.Which.StatusCode.Should().Be((System.Net.HttpStatusCode)429);
+    }
+
+    [Fact]
+    public void MockFeedResponse_can_be_enumerated_multiple_times()
+    {
+        // Critical: production code does response.Count() then foreach (...). Both must work.
+        var docs = new[] { JObject.Parse("{\"id\":\"1\"}"), JObject.Parse("{\"id\":\"2\"}") };
+        var response = new MockFeedResponse<JObject>(docs);
+
+        response.Count().Should().Be(2);
+        var collected = new List<string?>();
+        foreach (var d in response)
+        {
+            collected.Add((string?)d["id"]);
+        }
+        collected.Should().Equal("1", "2");
+
+        // Triple-enumerate to be sure.
+        response.Sum(d => 1).Should().Be(2);
+    }
+
+    [Fact]
+    public async Task CosmosClientMockBuilder_returns_configured_database()
+    {
+        var client = new CosmosClientMockBuilder()
+            .WithDatabase("TestDb")
+            .Build();
+
+        var db = client.GetDatabase("TestDb");
+        db.Should().NotBeNull();
+        var resp = await db.ReadAsync();
+        resp.Resource.Id.Should().Be("TestDb");
+    }
+
+    [Fact]
+    public async Task CosmosClientMockBuilder_unknown_database_simulates_NotFound_on_read()
+    {
+        var client = new CosmosClientMockBuilder()
+            .WithDatabase("KnownDb")
+            .Build();
+
+        var unknown = client.GetDatabase("Missing");
+        var act = async () => await unknown.ReadAsync();
+        var thrown = await act.Should().ThrowAsync<CosmosException>();
+        thrown.Which.StatusCode.Should().Be(System.Net.HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task DatabaseMockBuilder_container_listing_returns_dynamic_with_id()
+    {
+        var client = new CosmosClientMockBuilder()
+            .WithDatabase("Db", db => db
+                .WithContainer("c1")
+                .WithContainer("c2"))
+            .Build();
+
+        var db = client.GetDatabase("Db");
+        var iterator = db.GetContainerQueryIterator<dynamic>();
+
+        var names = new List<string>();
+        while (iterator.HasMoreResults)
+        {
+            var resp = await iterator.ReadNextAsync(CancellationToken.None);
+            foreach (var item in resp)
+            {
+                // Production code does: container.id.ToString()
+                names.Add(((string)item.id.ToString()));
+            }
+        }
+
+        names.Should().BeEquivalentTo(new[] { "c1", "c2" });
+    }
+
+    [Fact]
+    public async Task ContainerMockBuilder_throughput_and_partition_key_round_trip()
+    {
+        var client = new CosmosClientMockBuilder()
+            .WithDatabase("Db", db => db
+                .WithContainer("orders", c => c
+                    .WithPartitionKey("/customerId")
+                    .WithThroughput(800)))
+            .Build();
+
+        var container = client.GetDatabase("Db").GetContainer("orders");
+        container.Id.Should().Be("orders");
+
+        var props = await container.ReadContainerAsync();
+        props.Resource.PartitionKeyPath.Should().Be("/customerId");
+
+        var throughput = await container.ReadThroughputAsync(cancellationToken: CancellationToken.None);
+        throughput.Should().Be(800);
+    }
+
+    [Fact]
+    public async Task ContainerMockBuilder_documents_can_be_round_tripped_as_dynamic_and_json()
+    {
+        // The two ways production accesses dynamic documents:
+        //  1. doc.ToString() must return valid JSON parseable by JsonDocument.Parse.
+        //  2. doc.id (dynamic member access) must yield the id field.
+        var doc = JObject.Parse("{\"id\":\"abc\",\"value\":42}");
+        var client = new CosmosClientMockBuilder()
+            .WithDatabase("Db", db => db.WithContainer("c", c => c.WithDocuments(doc)))
+            .Build();
+
+        var container = client.GetDatabase("Db").GetContainer("c");
+        var iterator = container.GetItemQueryIterator<dynamic>(new QueryDefinition("SELECT * FROM c"));
+        var resp = await iterator.ReadNextAsync(CancellationToken.None);
+
+        foreach (var d in resp)
+        {
+            string json = d.ToString();
+            json.Should().Contain("\"id\"").And.Contain("\"abc\"");
+            using var parsed = System.Text.Json.JsonDocument.Parse(json);
+            parsed.RootElement.GetProperty("id").GetString().Should().Be("abc");
+
+            // Dynamic member access via Newtonsoft.Json's IDynamicMetaObjectProvider.
+            ((string)d.id).Should().Be("abc");
+        }
+    }
+
+    [Fact]
+    public async Task ContainerMockBuilder_count_query_returns_document_count()
+    {
+        var docs = new[]
+        {
+            JObject.Parse("{\"id\":\"1\"}"),
+            JObject.Parse("{\"id\":\"2\"}"),
+            JObject.Parse("{\"id\":\"3\"}")
+        };
+        var client = new CosmosClientMockBuilder()
+            .WithDatabase("Db", db => db.WithContainer("c", c => c.WithDocuments(docs)))
+            .Build();
+
+        var container = client.GetDatabase("Db").GetContainer("c");
+        var iterator = container.GetItemQueryIterator<int>(new QueryDefinition("SELECT VALUE COUNT(1) FROM c"));
+
+        iterator.HasMoreResults.Should().BeTrue();
+        var resp = await iterator.ReadNextAsync(CancellationToken.None);
+        resp.FirstOrDefault().Should().Be(3);
+    }
+
+    [Fact]
+    public async Task ContainerMockBuilder_query_error_is_thrown_on_ReadNext()
+    {
+        var client = new CosmosClientMockBuilder()
+            .WithDatabase("Db", db => db.WithContainer("c", c => c.WithQueryError(CosmosExceptionFactory.ServiceUnavailable())))
+            .Build();
+
+        var container = client.GetDatabase("Db").GetContainer("c");
+        var iterator = container.GetItemQueryIterator<dynamic>(new QueryDefinition("SELECT * FROM c"));
+
+        var act = async () => await iterator.ReadNextAsync(CancellationToken.None);
+        var thrown = await act.Should().ThrowAsync<CosmosException>();
+        thrown.Which.StatusCode.Should().Be(System.Net.HttpStatusCode.ServiceUnavailable);
+    }
+
+    [Fact]
+    public async Task ContainerMockBuilder_throughput_error_is_thrown()
+    {
+        var client = new CosmosClientMockBuilder()
+            .WithDatabase("Db", db => db.WithContainer("c", c => c.WithThroughputError(CosmosExceptionFactory.Forbidden())))
+            .Build();
+
+        var container = client.GetDatabase("Db").GetContainer("c");
+        var act = async () => await container.ReadThroughputAsync(cancellationToken: CancellationToken.None);
+        var thrown = await act.Should().ThrowAsync<CosmosException>();
+        thrown.Which.StatusCode.Should().Be(System.Net.HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public void CosmosExceptionFactory_produces_expected_status_codes()
+    {
+        CosmosExceptionFactory.Throttled().StatusCode.Should().Be((System.Net.HttpStatusCode)429);
+        CosmosExceptionFactory.ServiceUnavailable().StatusCode.Should().Be(System.Net.HttpStatusCode.ServiceUnavailable);
+        CosmosExceptionFactory.Timeout().StatusCode.Should().Be(System.Net.HttpStatusCode.RequestTimeout);
+        CosmosExceptionFactory.Forbidden().StatusCode.Should().Be(System.Net.HttpStatusCode.Forbidden);
+        CosmosExceptionFactory.NotFound().StatusCode.Should().Be(System.Net.HttpStatusCode.NotFound);
+        CosmosExceptionFactory.BadRequest().StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Mocks/README.md
+++ b/tests/CosmosToSqlAssessment.Tests/Mocks/README.md
@@ -1,0 +1,154 @@
+# Azure SDK Mock Harness
+
+This folder contains a **reusable, hermetic mock harness** for the Azure SDKs
+this project depends on. It lets every unit and integration test run with **no
+real Azure resources** — no network, no auth, no Cosmos account, no Log
+Analytics workspace.
+
+The harness was introduced by sub-issue **#180** under parent **#125** and is
+the foundation every Wave-2+ parent should build on **before** refactoring
+production code or adding new service paths.
+
+---
+
+## Quick start
+
+```csharp
+using CosmosToSqlAssessment.Tests.Mocks;
+using Newtonsoft.Json.Linq;
+
+var cosmosClient = new CosmosClientMockBuilder()
+    .WithDatabase("AppDb", db => db
+        .WithContainer("orders", c => c
+            .WithPartitionKey("/orderId")
+            .WithThroughput(400)
+            .WithDocuments(
+                JObject.Parse("{ \"id\": \"o1\", \"total\": 42.0 }"),
+                JObject.Parse("{ \"id\": \"o2\", \"total\": 9.99 }"))))
+    .Build();
+
+var logsClient = new LogsQueryClientMockBuilder()
+    .WithMetricsRows(new[]
+    {
+        (DateTimeOffset.UtcNow.AddHours(-1), avg: 12.0, max: 30.0, total: 120.0)
+    })
+    .Build();
+
+var service = new CosmosDbAnalysisService(
+    MockConfiguration.Object,
+    CreateMockLogger<CosmosDbAnalysisService>().Object,
+    cosmosClient,
+    logsClient);
+
+var result = await service.AnalyzeDatabaseAsync("AppDb", CancellationToken.None);
+```
+
+`new CosmosDbAnalysisService(IConfiguration, ILogger, CosmosClient, LogsQueryClient?)`
+is an **`internal` test-friendly constructor** exposed to the test assembly via
+`[InternalsVisibleTo("CosmosToSqlAssessment.Tests")]`. Production DI always uses
+the public constructor that builds Azure clients from `IConfiguration`.
+
+`DataQualityAnalysisService` has the same shape:
+
+```csharp
+new DataQualityAnalysisService(IConfiguration, ILogger, CosmosClient, DataQualityAnalysisOptions?)
+```
+
+---
+
+## What's in the box
+
+| File | What it gives you |
+| --- | --- |
+| `CosmosClientMockBuilder.cs` | Top-level fluent builder. Composes `Database` / `Container` / documents / throughput / indexing policy. |
+| `MockFeedIterator.cs` | `OfDocuments<T>(items)`, `OfPages<T>(pages)`, `Empty<T>()`, `ThrowsOnRead<T>(ex)`. |
+| `MockFeedResponse.cs` | Concrete `FeedResponse<T>` that is **safely re-enumerable** (production code does `Count()` then `foreach` on the same instance). |
+| `MockContainerResponse.cs` / `MockDatabaseResponse.cs` | Factories used internally by the builder; you usually don't touch them. |
+| `CosmosExceptionFactory.cs` | `Throttled()`, `ServiceUnavailable()`, `Timeout()`, `Forbidden()`, `NotFound()`, `BadRequest()`. Used by #184 retry tests. |
+| `LogsQueryClientMockBuilder.cs` | Canned `LogsQueryResult` from `MonitorQueryModelFactory`. Wraps in `Response.FromValue(...)`. |
+| `MockHarnessTests.cs` / `LogsQueryClientMockBuilderTests.cs` | Meta-tests that pin the harness contract. |
+
+---
+
+## Conventions
+
+### Document shape: always use `JObject`
+Production code uses `dynamic` in two incompatible ways:
+
+1. **Member access** — `container.id`, `doc.id` (compiled against `dynamic`).
+2. **JSON round-trip** — `dynamic.ToString()` is parsed back via
+   `JsonDocument.Parse(...)`.
+
+`Newtonsoft.Json.Linq.JObject` is the **only** type that satisfies both: it
+implements `IDynamicMetaObjectProvider` for member access **and** `ToString()`
+returns valid JSON. The builder enforces this signature on `WithDocuments`.
+
+### Throughput
+`Container.ReadThroughputAsync(cancellationToken: ct)` binds to the
+`Task<int?>` overload. The builder targets that overload directly:
+
+```csharp
+.WithContainer("c", c => c.WithThroughput(400))
+```
+
+Pass `null` to simulate "throughput unknown" / shared-database mode.
+
+### Transient errors
+Use `CosmosExceptionFactory` plus a `With…Error` setter on the container builder:
+
+```csharp
+.WithContainer("c", c => c
+    .WithThroughputError(CosmosExceptionFactory.Forbidden())
+    .WithQueryError(CosmosExceptionFactory.Throttled()))
+```
+
+For pure feed-level errors:
+
+```csharp
+var iterator = MockFeedIterator.ThrowsOnRead<JObject>(CosmosExceptionFactory.Throttled());
+```
+
+### Multi-page queries
+```csharp
+var iterator = MockFeedIterator.OfPages(new[]
+{
+    new List<JObject> { doc1, doc2 },
+    new List<JObject> { doc3 }
+});
+```
+
+### Missing databases / containers
+Calling `GetDatabase("Unknown")` on a builder that did not configure `"Unknown"`
+returns a Database whose `ReadAsync` throws `CosmosException(NotFound)`. Same for
+`GetContainer("missing")`. This lets you exercise error-handling paths without
+extra setup.
+
+---
+
+## Adding new mocks (Wave-2+ workflow)
+
+When your parent introduces a new Azure SDK usage:
+
+1. **Don't** instantiate the SDK client inside a service constructor — that's
+   what made `CosmosDbAnalysisService` and `DataQualityAnalysisService`
+   un-mockable historically. Add an `internal` test-friendly ctor that accepts
+   the client, and rely on `[InternalsVisibleTo]` for the test assembly.
+2. Add a builder file here (e.g. `BlobContainerClientMockBuilder.cs`) using the
+   same fluent pattern.
+3. Add a `…BuilderTests.cs` next to it pinning the contract.
+4. Update this README with the new builder and a quick-start snippet.
+
+The full overload signature must be reproduced in Moq setups — `It.IsAny<T>()`
+for each slot, including optional parameters that compile to `null` at the
+call site. See `CosmosClientMockBuilder.SetupItemQueryIterator` for examples.
+
+---
+
+## Why this harness is required for Wave-2+ work
+
+Without it, the coverage runsettings has to **exclude** every service that
+touches an Azure client (currently `CosmosDbAnalysisService` and
+`DataQualityAnalysisService`). That hides bugs and makes any refactor a coin
+flip. Future parents — multi-agent orchestration, incremental migration,
+adaptive loops — will land **more** Azure-touching code; the harness is what
+keeps the coverage gate honest as that code arrives.

--- a/tests/CosmosToSqlAssessment.Tests/Mocks/README.md
+++ b/tests/CosmosToSqlAssessment.Tests/Mocks/README.md
@@ -102,11 +102,38 @@ Use `CosmosExceptionFactory` plus a `With…Error` setter on the container build
     .WithQueryError(CosmosExceptionFactory.Throttled()))
 ```
 
+`WithQueryError(Exception)` makes **every** `GetItemQueryIterator<T>` throw.
+To fail only one specific T (e.g. exercise a production branch that
+swallows `<dynamic>` errors but propagates `<int>`):
+
+```csharp
+.WithContainer("c", c => c
+    .WithQueryError<dynamic>(CosmosExceptionFactory.Throttled()))
+```
+
+The container-discovery iterator on the database has its own hook:
+
+```csharp
+.WithDatabase("Db", db => db
+    .WithContainerListError(CosmosExceptionFactory.Throttled()))
+```
+
 For pure feed-level errors:
 
 ```csharp
 var iterator = MockFeedIterator.ThrowsOnRead<JObject>(CosmosExceptionFactory.Throttled());
 ```
+
+For Azure Monitor failures:
+
+```csharp
+var logsClient = new LogsQueryClientMockBuilder()
+    .WithError(new Azure.RequestFailedException(429, "Too Many Requests"))
+    .Build();
+```
+
+See `tests/CosmosToSqlAssessment.Tests/Services/TransientFailureRetryTests.cs`
+for the canonical reference (added by #184).
 
 ### Multi-page queries
 ```csharp

--- a/tests/CosmosToSqlAssessment.Tests/Models/ModelPocoCoverageTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Models/ModelPocoCoverageTests.cs
@@ -1,0 +1,120 @@
+using CosmosToSqlAssessment.Models;
+
+namespace CosmosToSqlAssessment.Tests.Models;
+
+// Tests for thin model POCOs that are otherwise instantiated only by production code paths
+// that the rest of the test suite doesn't reach. Round-tripping properties keeps these
+// classes counted against the coverage gate so accidental dead code is easier to spot.
+public class ModelPocoCoverageTests
+{
+    [Fact]
+    public void QueryMetrics_RoundTrips_All_Properties()
+    {
+        var metrics = new QueryMetrics
+        {
+            QueryPattern = "SELECT * FROM c WHERE c.id = @id",
+            ExecutionCount = 1234,
+            AverageRUs = 3.5,
+            AverageLatencyMs = 12.75
+        };
+
+        metrics.QueryPattern.Should().Be("SELECT * FROM c WHERE c.id = @id");
+        metrics.ExecutionCount.Should().Be(1234);
+        metrics.AverageRUs.Should().Be(3.5);
+        metrics.AverageLatencyMs.Should().Be(12.75);
+    }
+
+    [Fact]
+    public void QueryMetrics_Defaults_Are_Safe()
+    {
+        var metrics = new QueryMetrics();
+
+        metrics.QueryPattern.Should().BeEmpty();
+        metrics.ExecutionCount.Should().Be(0);
+        metrics.AverageRUs.Should().Be(0);
+        metrics.AverageLatencyMs.Should().Be(0);
+    }
+
+    [Fact]
+    public void HotPartition_RoundTrips_All_Properties()
+    {
+        var hot = new HotPartition
+        {
+            PartitionKeyValue = "tenant-42",
+            RUConsumptionPercentage = 87.5,
+            RequestCount = 9876
+        };
+
+        hot.PartitionKeyValue.Should().Be("tenant-42");
+        hot.RUConsumptionPercentage.Should().Be(87.5);
+        hot.RequestCount.Should().Be(9876);
+    }
+
+    [Fact]
+    public void HotPartition_Defaults_Are_Safe()
+    {
+        var hot = new HotPartition();
+
+        hot.PartitionKeyValue.Should().BeEmpty();
+        hot.RUConsumptionPercentage.Should().Be(0);
+        hot.RequestCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void PerformanceTrend_RoundTrips_All_Properties()
+    {
+        var trend = new PerformanceTrend
+        {
+            MetricName = "AverageRUs",
+            Trend = "Increasing",
+            ChangePercentage = 22.5
+        };
+
+        trend.MetricName.Should().Be("AverageRUs");
+        trend.Trend.Should().Be("Increasing");
+        trend.ChangePercentage.Should().Be(22.5);
+    }
+
+    [Fact]
+    public void PerformanceTrend_Defaults_Are_Safe()
+    {
+        var trend = new PerformanceTrend();
+
+        trend.MetricName.Should().BeEmpty();
+        trend.Trend.Should().BeEmpty();
+        trend.ChangePercentage.Should().Be(0);
+    }
+
+    [Fact]
+    public void PerformanceMetrics_Aggregates_HotPartitions_And_Trends()
+    {
+        var metrics = new PerformanceMetrics
+        {
+            TotalRUConsumption = 1_000_000,
+            AverageRUsPerSecond = 100,
+            PeakRUsPerSecond = 250,
+            AverageRequestLatencyMs = 8.4,
+            TotalRequests = 999_999,
+            ErrorRate = 0.001,
+            ThrottlingRate = 0.02,
+            AnalysisPeriod = new TimeRange
+            {
+                StartTime = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                EndTime = new DateTime(2025, 6, 30, 23, 59, 59, DateTimeKind.Utc)
+            },
+            Trends = new List<PerformanceTrend>
+            {
+                new() { MetricName = "AverageRUs", Trend = "Stable", ChangePercentage = 0.5 },
+                new() { MetricName = "Latency", Trend = "Decreasing", ChangePercentage = -10.0 }
+            }
+        };
+
+        metrics.TotalRUConsumption.Should().Be(1_000_000);
+        metrics.PeakRUsPerSecond.Should().Be(250);
+        metrics.AnalysisPeriod.StartTime.Year.Should().Be(2025);
+        metrics.AnalysisPeriod.EndTime.Month.Should().Be(6);
+        metrics.Trends.Should().HaveCount(2);
+        metrics.Trends[0].Trend.Should().Be("Stable");
+        metrics.Trends[1].ChangePercentage.Should().Be(-10.0);
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/CosmosDbAnalysisServiceMockedTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/CosmosDbAnalysisServiceMockedTests.cs
@@ -1,0 +1,141 @@
+using CosmosToSqlAssessment.Services;
+using CosmosToSqlAssessment.Tests.Infrastructure;
+using CosmosToSqlAssessment.Tests.Mocks;
+using Newtonsoft.Json.Linq;
+
+namespace CosmosToSqlAssessment.Tests.Services;
+
+/// <summary>
+/// Smoke tests that drive the real <see cref="CosmosDbAnalysisService"/> through
+/// the mock Cosmos SDK harness. The point of these tests is to prove the harness
+/// can exercise production code end-to-end without an Azure resource - deeper
+/// edge-case coverage lands in sub-issues #183 and #184.
+/// </summary>
+public class CosmosDbAnalysisServiceMockedTests : TestBase
+{
+    [Fact]
+    public async Task AnalyzeDatabaseAsync_with_two_containers_returns_both()
+    {
+        var cosmosClient = new CosmosClientMockBuilder()
+            .WithDatabase("AppDb", db => db
+                .WithContainer("users", c => c
+                    .WithPartitionKey("/userId")
+                    .WithThroughput(400)
+                    .WithDocuments(
+                        JObject.Parse("{\"id\":\"u1\",\"email\":\"a@b.com\",\"age\":30}"),
+                        JObject.Parse("{\"id\":\"u2\",\"email\":\"c@d.com\",\"age\":42}")))
+                .WithContainer("orders", c => c
+                    .WithPartitionKey("/orderId")
+                    .WithThroughput(800)
+                    .WithDocuments(
+                        JObject.Parse("{\"id\":\"o1\",\"total\":99.99}"))))
+            .Build();
+
+        var service = new CosmosDbAnalysisService(
+            MockConfiguration.Object,
+            CreateMockLogger<CosmosDbAnalysisService>().Object,
+            cosmosClient);
+
+        var result = await service.AnalyzeDatabaseAsync("AppDb", CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.Containers.Should().HaveCount(2);
+
+        var users = result.Containers.Single(c => c.ContainerName == "users");
+        users.PartitionKey.Should().Be("/userId");
+        users.ProvisionedRUs.Should().Be(400);
+        users.DocumentCount.Should().Be(2);
+        users.DetectedSchemas.Should().NotBeEmpty();
+
+        var orders = result.Containers.Single(c => c.ContainerName == "orders");
+        orders.PartitionKey.Should().Be("/orderId");
+        orders.ProvisionedRUs.Should().Be(800);
+        orders.DocumentCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task AnalyzeDatabaseAsync_with_no_documents_yields_zero_count()
+    {
+        var cosmosClient = new CosmosClientMockBuilder()
+            .WithDatabase("EmptyDb", db => db
+                .WithContainer("empty", c => c
+                    .WithPartitionKey("/id")
+                    .WithThroughput(400)))
+            .Build();
+
+        var service = new CosmosDbAnalysisService(
+            MockConfiguration.Object,
+            CreateMockLogger<CosmosDbAnalysisService>().Object,
+            cosmosClient);
+
+        var result = await service.AnalyzeDatabaseAsync("EmptyDb", CancellationToken.None);
+
+        result.Containers.Should().ContainSingle();
+        result.Containers[0].DocumentCount.Should().Be(0);
+        result.Containers[0].DetectedSchemas.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task AnalyzeDatabaseAsync_without_logs_client_records_monitoring_limitation()
+    {
+        var cosmosClient = new CosmosClientMockBuilder()
+            .WithDatabase("AppDb", db => db.WithContainer("c", c => c.WithThroughput(400)))
+            .Build();
+
+        var service = new CosmosDbAnalysisService(
+            MockConfiguration.Object,
+            CreateMockLogger<CosmosDbAnalysisService>().Object,
+            cosmosClient,
+            logsQueryClient: null);
+
+        var result = await service.AnalyzeDatabaseAsync("AppDb", CancellationToken.None);
+
+        result.MonitoringLimitations.Should().ContainSingle(l => l.Contains("Azure Monitor"));
+    }
+
+    [Fact]
+    public async Task AnalyzeDatabaseAsync_with_logs_client_populates_performance_metrics()
+    {
+        var cosmosClient = new CosmosClientMockBuilder()
+            .WithDatabase("AppDb", db => db.WithContainer("c", c => c.WithThroughput(400)))
+            .Build();
+
+        // Configure the workspace so the production code attempts the query.
+        MockConfiguration.Setup(c => c["AzureMonitor:WorkspaceId"]).Returns("workspace-1");
+        MockConfiguration.Setup(c => c["AzureMonitor:CosmosAccountName"]).Returns("test-account");
+
+        var logsClient = new LogsQueryClientMockBuilder()
+            .WithMetricsRows(new[]
+            {
+                (DateTimeOffset.UtcNow.AddHours(-2), 10.0, 25.0, 100.0),
+                (DateTimeOffset.UtcNow.AddHours(-1), 20.0, 50.0, 200.0)
+            })
+            .Build();
+
+        var service = new CosmosDbAnalysisService(
+            MockConfiguration.Object,
+            CreateMockLogger<CosmosDbAnalysisService>().Object,
+            cosmosClient,
+            logsClient);
+
+        var result = await service.AnalyzeDatabaseAsync("AppDb", CancellationToken.None);
+
+        result.PerformanceMetrics.Should().NotBeNull();
+        result.PerformanceMetrics.AverageRUsPerSecond.Should().Be(15.0);    // mean of 10 and 20
+        result.PerformanceMetrics.PeakRUsPerSecond.Should().Be(50.0);       // max of 25 and 50
+        result.PerformanceMetrics.TotalRUConsumption.Should().Be(300.0);    // sum of 100 and 200
+    }
+
+    [Fact]
+    public async Task AnalyzeDatabaseAsync_with_empty_database_name_throws()
+    {
+        var cosmosClient = new CosmosClientMockBuilder().Build();
+        var service = new CosmosDbAnalysisService(
+            MockConfiguration.Object,
+            CreateMockLogger<CosmosDbAnalysisService>().Object,
+            cosmosClient);
+
+        var act = async () => await service.AnalyzeDatabaseAsync(string.Empty, CancellationToken.None);
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/DataQualityAnalysisServiceEdgeCaseTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/DataQualityAnalysisServiceEdgeCaseTests.cs
@@ -1,0 +1,541 @@
+using CosmosToSqlAssessment.Models;
+using CosmosToSqlAssessment.Services;
+using CosmosToSqlAssessment.Tests.Infrastructure;
+using CosmosToSqlAssessment.Tests.Mocks;
+using Newtonsoft.Json.Linq;
+
+namespace CosmosToSqlAssessment.Tests.Services;
+
+/// <summary>
+/// Edge-case coverage for <see cref="DataQualityAnalysisService"/>'s analyzer
+/// branches: null thresholds, duplicate detection (id / partition key /
+/// business key), type-consistency mismatches, string-length recommendation
+/// boundaries, encoding (non-ASCII / control / emoji), date validation, and
+/// per-analyzer enable/disable toggles. Sits on top of the mock harness from
+/// sub-issue #180 and is the data-quality companion to the
+/// <see cref="SqlProjectGenerationServiceEdgeCaseTests"/> file added under
+/// sub-issue #182.
+/// </summary>
+public class DataQualityAnalysisServiceEdgeCaseTests : TestBase
+{
+    private DataQualityAnalysisService BuildService(
+        Microsoft.Azure.Cosmos.CosmosClient cosmosClient,
+        DataQualityAnalysisOptions? options = null)
+        => new(
+            MockConfiguration.Object,
+            CreateMockLogger<DataQualityAnalysisService>().Object,
+            cosmosClient,
+            options);
+
+    private static CosmosDbAnalysis BuildCosmosAnalysis(
+        string containerName,
+        int documentCount,
+        string partitionKey = "/id",
+        params string[] extraFields)
+    {
+        var fields = new Dictionary<string, CosmosToSqlAssessment.Models.FieldInfo>
+        {
+            ["id"] = new() { FieldName = "id", DetectedTypes = new List<string> { "string" } }
+        };
+        foreach (var f in extraFields)
+        {
+            fields[f] = new CosmosToSqlAssessment.Models.FieldInfo
+            {
+                FieldName = f,
+                DetectedTypes = new List<string> { "string" }
+            };
+        }
+
+        return new CosmosDbAnalysis
+        {
+            Containers = new List<ContainerAnalysis>
+            {
+                new()
+                {
+                    ContainerName = containerName,
+                    DocumentCount = documentCount,
+                    PartitionKey = partitionKey,
+                    DetectedSchemas = new List<DocumentSchema>
+                    {
+                        new()
+                        {
+                            SchemaName = "Default",
+                            Fields = fields,
+                            SampleCount = documentCount,
+                            Prevalence = 1.0
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    private static Microsoft.Azure.Cosmos.CosmosClient BuildClient(
+        string database,
+        string container,
+        string partitionKey,
+        params JObject[] docs)
+        => new CosmosClientMockBuilder()
+            .WithDatabase(database, db => db
+                .WithContainer(container, c => c
+                    .WithPartitionKey(partitionKey)
+                    .WithDocuments(docs)))
+            .Build();
+
+    // -------------------------------------------------------------------
+    // Null analyzer
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public async Task Null_threshold_below_info_emits_no_null_issue()
+    {
+        var docs = Enumerable.Range(1, 100)
+            .Select(i => JObject.Parse($"{{\"id\":\"d{i}\",\"value\":{i}}}"))
+            .ToArray();
+
+        var service = BuildService(BuildClient("Db", "c", "/id", docs));
+        var input = BuildCosmosAnalysis("c", 100, "/id", "value");
+
+        var result = await service.AnalyzeDataQualityAsync(input, "Db", CancellationToken.None);
+
+        var container = result.ContainerAnalyses.Single();
+        container.NullAnalysis.Should().NotContain(n => n.FieldName == "value");
+    }
+
+    [Fact]
+    public async Task Null_threshold_between_info_and_warning_emits_info_severity()
+    {
+        var docs = new List<JObject>();
+        for (var i = 1; i <= 97; i++)
+            docs.Add(JObject.Parse($"{{\"id\":\"d{i}\",\"value\":{i}}}"));
+        for (var i = 98; i <= 100; i++)
+            docs.Add(JObject.Parse($"{{\"id\":\"d{i}\",\"value\":null}}"));
+
+        var service = BuildService(BuildClient("Db", "c", "/id", docs.ToArray()));
+        var input = BuildCosmosAnalysis("c", 100, "/id", "value");
+
+        var result = await service.AnalyzeDataQualityAsync(input, "Db", CancellationToken.None);
+
+        var container = result.ContainerAnalyses.Single();
+        container.NullAnalysis.Should().Contain(n => n.FieldName == "value");
+
+        var issue = container.AllIssues.Should()
+            .ContainSingle(i => i.Category == "Null" && i.FieldName == "value").Subject;
+        issue.Severity.Should().Be(DataQualitySeverity.Info);
+    }
+
+    [Fact]
+    public async Task Null_threshold_above_critical_emits_critical_and_blocks_migration()
+    {
+        var docs = new List<JObject>();
+        for (var i = 1; i <= 80; i++)
+            docs.Add(JObject.Parse($"{{\"id\":\"d{i}\",\"value\":{i}}}"));
+        for (var i = 81; i <= 100; i++)
+            docs.Add(JObject.Parse($"{{\"id\":\"d{i}\",\"value\":null}}"));
+
+        var service = BuildService(BuildClient("Db", "c", "/id", docs.ToArray()));
+        var input = BuildCosmosAnalysis("c", 100, "/id", "value");
+
+        var result = await service.AnalyzeDataQualityAsync(input, "Db", CancellationToken.None);
+
+        result.CriticalIssuesCount.Should().BeGreaterThan(0);
+        result.Summary.ReadyForMigration.Should().BeFalse();
+        result.Summary.BlockingIssues.Should().NotBeEmpty();
+        result.ContainerAnalyses.Single()
+            .AllIssues.Should().Contain(i => i.Category == "Null" && i.Severity == DataQualitySeverity.Critical);
+    }
+
+    [Fact]
+    public async Task Null_value_detection_treats_string_null_literal_and_whitespace_as_null()
+    {
+        var docs = new List<JObject>
+        {
+            JObject.Parse("{\"id\":\"d1\",\"value\":\"actual\"}"),
+            JObject.Parse("{\"id\":\"d2\",\"value\":\"null\"}"),
+            JObject.Parse("{\"id\":\"d3\",\"value\":\"   \"}"),
+            JObject.Parse("{\"id\":\"d4\",\"value\":\"\"}"),
+        };
+        for (var i = 5; i <= 50; i++)
+            docs.Add(JObject.Parse($"{{\"id\":\"d{i}\",\"value\":\"v{i}\"}}"));
+
+        var service = BuildService(BuildClient("Db", "c", "/id", docs.ToArray()));
+        var input = BuildCosmosAnalysis("c", 50, "/id", "value");
+
+        var result = await service.AnalyzeDataQualityAsync(input, "Db", CancellationToken.None);
+
+        var nullEntry = result.ContainerAnalyses.Single()
+            .NullAnalysis.Should().Contain(n => n.FieldName == "value").Subject;
+        nullEntry.NullCount.Should().Be(3);
+        nullEntry.MissingCount.Should().Be(0);
+    }
+
+    // -------------------------------------------------------------------
+    // Duplicate analyzer
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public async Task Duplicate_ids_emit_id_duplicate_with_critical_recommendation()
+    {
+        var docs = Enumerable.Range(1, 10)
+            .Select(i => JObject.Parse($"{{\"id\":\"shared\",\"pk\":\"p{i}\"}}"))
+            .ToArray();
+
+        var service = BuildService(BuildClient("Db", "c", "/pk", docs));
+        var input = BuildCosmosAnalysis("c", 10, "/pk", "pk");
+
+        var result = await service.AnalyzeDataQualityAsync(input, "Db", CancellationToken.None);
+
+        var container = result.ContainerAnalyses.Single();
+        var idDup = container.DuplicateAnalysis.Should()
+            .ContainSingle(d => d.KeyType == "ID").Subject;
+        idDup.DuplicateGroupCount.Should().Be(1);
+        idDup.TotalDuplicateRecords.Should().Be(10);
+        idDup.RecommendedResolution.Should().StartWith("Critical");
+        container.AllIssues.Should().Contain(i => i.Category == "Duplicate" && i.Severity == DataQualitySeverity.Critical);
+    }
+
+    [Fact]
+    public async Task Duplicate_business_keys_detect_email_username_code()
+    {
+        var docs = new List<JObject>();
+        for (var i = 1; i <= 3; i++)
+            docs.Add(JObject.Parse($"{{\"id\":\"e{i}\",\"userId\":\"u{i}\",\"email\":\"shared@example.com\",\"username\":\"alice{i}\",\"code\":\"c{i}\"}}"));
+        for (var i = 1; i <= 3; i++)
+            docs.Add(JObject.Parse($"{{\"id\":\"u{i}\",\"userId\":\"v{i}\",\"email\":\"a{i}@example.com\",\"username\":\"sharedUser\",\"code\":\"d{i}\"}}"));
+        for (var i = 1; i <= 3; i++)
+            docs.Add(JObject.Parse($"{{\"id\":\"c{i}\",\"userId\":\"w{i}\",\"email\":\"b{i}@example.com\",\"username\":\"bob{i}\",\"code\":\"SHARED\"}}"));
+
+        var service = BuildService(BuildClient("Db", "c", "/userId", docs.ToArray()));
+        var input = BuildCosmosAnalysis("c", 9, "/userId", "email", "username", "code", "userId");
+
+        var result = await service.AnalyzeDataQualityAsync(input, "Db", CancellationToken.None);
+
+        var businessKeyEntries = result.ContainerAnalyses.Single()
+            .DuplicateAnalysis.Where(d => d.KeyType == "BusinessKey").ToList();
+        var fields = businessKeyEntries.SelectMany(d => d.KeyFields).Distinct().ToList();
+        fields.Should().Contain(new[] { "email", "username", "code" });
+    }
+
+    [Fact]
+    public async Task Duplicate_detection_disabled_skips_analyzer()
+    {
+        var docs = Enumerable.Range(1, 10)
+            .Select(i => JObject.Parse($"{{\"id\":\"shared\",\"pk\":\"p{i}\"}}"))
+            .ToArray();
+
+        var options = new DataQualityAnalysisOptions { IncludeDuplicateDetection = false };
+        var service = BuildService(BuildClient("Db", "c", "/pk", docs), options);
+        var input = BuildCosmosAnalysis("c", 10, "/pk", "pk");
+
+        var result = await service.AnalyzeDataQualityAsync(input, "Db", CancellationToken.None);
+
+        result.ContainerAnalyses.Single().DuplicateAnalysis.Should().BeEmpty();
+    }
+
+    // -------------------------------------------------------------------
+    // Type consistency analyzer
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public async Task Type_consistency_with_mixed_types_below_threshold_records_mismatches()
+    {
+        var docs = new List<JObject>();
+        for (var i = 1; i <= 7; i++)
+            docs.Add(JObject.Parse($"{{\"id\":\"d{i}\",\"value\":\"text{i}\"}}"));
+        for (var i = 8; i <= 10; i++)
+            docs.Add(JObject.Parse($"{{\"id\":\"d{i}\",\"value\":{i}}}"));
+
+        var service = BuildService(BuildClient("Db", "c", "/id", docs.ToArray()));
+        var input = BuildCosmosAnalysis("c", 10, "/id", "value");
+
+        var result = await service.AnalyzeDataQualityAsync(input, "Db", CancellationToken.None);
+
+        var typeResult = result.ContainerAnalyses.Single()
+            .TypeConsistency.Should().ContainSingle(t => t.FieldName == "value").Subject;
+        typeResult.IsConsistent.Should().BeFalse();
+        typeResult.DominantType.Should().Be("string");
+        typeResult.Mismatches.Should().NotBeEmpty();
+        typeResult.RecommendedSqlType.Should().Be("NVARCHAR(MAX)");
+    }
+
+    [Fact]
+    public async Task Type_consistency_above_threshold_emits_nothing()
+    {
+        var docs = Enumerable.Range(1, 100)
+            .Select(i => JObject.Parse($"{{\"id\":\"d{i}\",\"value\":{i}}}"))
+            .ToArray();
+
+        var service = BuildService(BuildClient("Db", "c", "/id", docs));
+        var input = BuildCosmosAnalysis("c", 100, "/id", "value");
+
+        var result = await service.AnalyzeDataQualityAsync(input, "Db", CancellationToken.None);
+
+        result.ContainerAnalyses.Single()
+            .TypeConsistency.Should().NotContain(t => t.FieldName == "value");
+    }
+
+    // -------------------------------------------------------------------
+    // String-length analyzer
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public async Task String_length_recommendation_picks_NVARCHAR_max_for_large_strings()
+    {
+        var big = new string('a', 5000);
+        var docs = Enumerable.Range(1, 10)
+            .Select(i => new JObject
+            {
+                ["id"] = $"d{i}",
+                ["description"] = big
+            })
+            .ToArray();
+
+        var service = BuildService(BuildClient("Db", "c", "/id", docs));
+        var input = BuildCosmosAnalysis("c", 10, "/id", "description");
+
+        var result = await service.AnalyzeDataQualityAsync(input, "Db", CancellationToken.None);
+
+        var len = result.ContainerAnalyses.Single()
+            .StringLengthAnalysis.Should().ContainSingle(l => l.FieldName == "description").Subject;
+        len.RecommendedSqlType.Should().Be("NVARCHAR(MAX)");
+        len.RecommendedAction.Should().Contain("NVARCHAR(MAX)");
+        result.ContainerAnalyses.Single()
+            .AllIssues.Should().Contain(i => i.Category == "Length" && i.FieldName == "description");
+    }
+
+    [Fact]
+    public async Task String_length_recommendation_picks_NVARCHAR_with_p95_below_4000()
+    {
+        var lengths = new[] { 10, 20, 30, 40, 50, 60, 80, 100, 150, 200 };
+        var docs = lengths.Select((l, i) => new JObject
+        {
+            ["id"] = $"d{i}",
+            ["name"] = new string('n', l)
+        }).ToArray();
+
+        var service = BuildService(BuildClient("Db", "c", "/id", docs));
+        var input = BuildCosmosAnalysis("c", lengths.Length, "/id", "name");
+
+        var result = await service.AnalyzeDataQualityAsync(input, "Db", CancellationToken.None);
+
+        var len = result.ContainerAnalyses.Single()
+            .StringLengthAnalysis.Should().ContainSingle(l => l.FieldName == "name").Subject;
+        len.RecommendedSqlType.Should().StartWith("NVARCHAR(");
+        len.RecommendedSqlType.Should().NotBe("NVARCHAR(MAX)");
+        len.MaxLength.Should().Be(200);
+        len.MinLength.Should().Be(10);
+    }
+
+    [Fact]
+    public async Task String_length_skips_when_below_minimum_strings()
+    {
+        var docs = Enumerable.Range(1, 4)
+            .Select(i => new JObject
+            {
+                ["id"] = $"d{i}",
+                ["name"] = $"value{i}"
+            })
+            .ToArray();
+
+        var service = BuildService(BuildClient("Db", "c", "/id", docs));
+        var input = BuildCosmosAnalysis("c", 4, "/id", "name");
+
+        var result = await service.AnalyzeDataQualityAsync(input, "Db", CancellationToken.None);
+
+        result.ContainerAnalyses.Single()
+            .StringLengthAnalysis.Should().NotContain(l => l.FieldName == "name");
+    }
+
+    // -------------------------------------------------------------------
+    // Outlier analyzer
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public async Task Outlier_detection_disabled_skips_analyzer()
+    {
+        var docs = new List<JObject>();
+        for (var i = 1; i <= 50; i++)
+            docs.Add(JObject.Parse($"{{\"id\":\"d{i}\",\"value\":100}}"));
+        docs.Add(JObject.Parse("{\"id\":\"hi\",\"value\":1000000}"));
+
+        var options = new DataQualityAnalysisOptions { IncludeOutlierDetection = false };
+        var service = BuildService(BuildClient("Db", "c", "/id", docs.ToArray()), options);
+        var input = BuildCosmosAnalysis("c", docs.Count, "/id", "value");
+
+        var result = await service.AnalyzeDataQualityAsync(input, "Db", CancellationToken.None);
+
+        result.ContainerAnalyses.Single().OutlierAnalysis.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Outlier_detection_finds_iqr_outliers_above_minimum_samples()
+    {
+        var docs = new List<JObject>();
+        var rng = new Random(42);
+        for (var i = 1; i <= 50; i++)
+            docs.Add(JObject.Parse($"{{\"id\":\"d{i}\",\"value\":{100 + rng.Next(-2, 3)}}}"));
+        docs.Add(JObject.Parse("{\"id\":\"hi\",\"value\":10000}"));
+        docs.Add(JObject.Parse("{\"id\":\"lo\",\"value\":-10000}"));
+
+        var service = BuildService(BuildClient("Db", "c", "/id", docs.ToArray()));
+        var input = BuildCosmosAnalysis("c", docs.Count, "/id", "value");
+
+        var result = await service.AnalyzeDataQualityAsync(input, "Db", CancellationToken.None);
+
+        var outlier = result.ContainerAnalyses.Single()
+            .OutlierAnalysis.Should().ContainSingle(o => o.FieldName == "value").Subject;
+        outlier.OutlierCount.Should().BeGreaterThanOrEqualTo(2);
+        outlier.OutlierPercentage.Should().BeGreaterThan(1.0);
+        outlier.OutlierSamples.Select(s => s.OutlierType).Should()
+            .Contain("High").And.Contain("Low");
+    }
+
+    // -------------------------------------------------------------------
+    // Encoding analyzer
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public async Task Encoding_analyzer_detects_non_ascii_control_and_emoji()
+    {
+        // U+2600 (☀) is in ContainsEmoji's 0x2600-0x26FF BMP range AND non-ASCII
+        // U+0001 is a control char (and ASCII), excluded from \n\r\t guard
+        // "café" is non-ASCII but no emoji / control
+        var docs = new[]
+        {
+            JObject.Parse("{\"id\":\"d1\",\"text\":\"café\"}"),
+            JObject.Parse("{\"id\":\"d2\",\"text\":\"line\\u0001separator\"}"),
+            new JObject { ["id"] = "d3", ["text"] = "weather \u2600 today" },
+            JObject.Parse("{\"id\":\"d4\",\"text\":\"plain\"}"),
+            JObject.Parse("{\"id\":\"d5\",\"text\":\"another\"}"),
+        };
+
+        var service = BuildService(BuildClient("Db", "c", "/id", docs));
+        var input = BuildCosmosAnalysis("c", docs.Length, "/id", "text");
+
+        var result = await service.AnalyzeDataQualityAsync(input, "Db", CancellationToken.None);
+
+        var encoding = result.ContainerAnalyses.Single().EncodingIssues
+            .Where(e => e.FieldName == "text")
+            .ToList();
+        var types = encoding.Select(e => e.IssueType).Distinct().ToList();
+        types.Should().Contain(new[] { "NonASCII", "ControlCharacters", "Emoji" });
+    }
+
+    [Fact]
+    public async Task Encoding_checks_disabled_skips_analyzer()
+    {
+        var docs = new[]
+        {
+            new JObject { ["id"] = "d1", ["text"] = "café" },
+            new JObject { ["id"] = "d2", ["text"] = "weather \u2600 today" },
+            new JObject { ["id"] = "d3", ["text"] = "plain1" },
+            new JObject { ["id"] = "d4", ["text"] = "plain2" },
+            new JObject { ["id"] = "d5", ["text"] = "plain3" },
+        };
+
+        var options = new DataQualityAnalysisOptions { IncludeEncodingChecks = false };
+        var service = BuildService(BuildClient("Db", "c", "/id", docs), options);
+        var input = BuildCosmosAnalysis("c", docs.Length, "/id", "text");
+
+        var result = await service.AnalyzeDataQualityAsync(input, "Db", CancellationToken.None);
+
+        result.ContainerAnalyses.Single().EncodingIssues.Should().BeEmpty();
+    }
+
+    // -------------------------------------------------------------------
+    // Date validation
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public async Task Date_validation_flags_invalid_future_and_old_dates()
+    {
+        var docs = new[]
+        {
+            JObject.Parse("{\"id\":\"valid\",\"when\":\"2010-06-15\"}"),
+            JObject.Parse("{\"id\":\"invalid\",\"when\":\"2024-13-99\"}"),
+            JObject.Parse("{\"id\":\"future\",\"when\":\"2050-01-01\"}"),
+            JObject.Parse("{\"id\":\"old\",\"when\":\"1850-01-01\"}"),
+            JObject.Parse("{\"id\":\"valid2\",\"when\":\"2015-12-25\"}"),
+        };
+
+        // Deterministic window: future = > 2020, very-old = < 2000
+        var options = new DataQualityAnalysisOptions
+        {
+            MinReasonableDate = new DateTime(2000, 1, 1),
+            MaxReasonableDate = new DateTime(2020, 12, 31)
+        };
+
+        var service = BuildService(BuildClient("Db", "c", "/id", docs), options);
+        var input = BuildCosmosAnalysis("c", docs.Length, "/id", "when");
+
+        var result = await service.AnalyzeDataQualityAsync(input, "Db", CancellationToken.None);
+
+        var dateResult = result.ContainerAnalyses.Single()
+            .DateValidation.Should().ContainSingle(d => d.FieldName == "when").Subject;
+        dateResult.InvalidDateCount.Should().Be(1);
+        dateResult.FutureDateCount.Should().Be(1);
+        dateResult.VeryOldDateCount.Should().Be(1);
+        result.ContainerAnalyses.Single().AllIssues
+            .Should().Contain(i => i.Category == "Date" && i.Severity == DataQualitySeverity.Critical);
+    }
+
+    // -------------------------------------------------------------------
+    // Malformed documents
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public async Task Malformed_document_without_id_uses_unknown_marker_in_samples()
+    {
+        var docs = new[]
+        {
+            JObject.Parse("{\"value\":\"v1\"}"),
+            JObject.Parse("{\"value\":null}"),
+            JObject.Parse("{\"value\":null}"),
+            JObject.Parse("{\"value\":\"v2\"}"),
+            JObject.Parse("{\"value\":null}"),
+        };
+
+        var service = BuildService(BuildClient("Db", "c", "/id", docs));
+        var input = BuildCosmosAnalysis("c", docs.Length, "/id", "value");
+
+        var result = await service.AnalyzeDataQualityAsync(input, "Db", CancellationToken.None);
+
+        var nullEntry = result.ContainerAnalyses.Single()
+            .NullAnalysis.Should().Contain(n => n.FieldName == "value").Subject;
+        nullEntry.SampleNullDocumentIds.Should().NotBeEmpty();
+        nullEntry.SampleNullDocumentIds.Should().Contain("unknown");
+    }
+
+    // -------------------------------------------------------------------
+    // TopIssues ordering (replaces original #19 per rubber-duck R6)
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public async Task Top_issues_are_sorted_with_critical_first()
+    {
+        // Field "criticalNull" gets 20 % nulls -> Critical
+        // Field "warningNull"  gets 10 % nulls -> Warning
+        // Field "infoNull"     gets 3  % nulls -> Info
+        var docs = new List<JObject>();
+        for (var i = 1; i <= 100; i++)
+        {
+            var critical = i <= 80 ? $"\"c{i}\"" : "null";
+            var warning  = i <= 90 ? $"\"w{i}\"" : "null";
+            var info     = i <= 97 ? $"\"f{i}\"" : "null";
+            docs.Add(JObject.Parse(
+                $"{{\"id\":\"d{i}\",\"criticalNull\":{critical},\"warningNull\":{warning},\"infoNull\":{info}}}"));
+        }
+
+        var service = BuildService(BuildClient("Db", "c", "/id", docs.ToArray()));
+        var input = BuildCosmosAnalysis("c", 100, "/id", "criticalNull", "warningNull", "infoNull");
+
+        var result = await service.AnalyzeDataQualityAsync(input, "Db", CancellationToken.None);
+
+        result.TopIssues.Should().NotBeEmpty();
+        result.TopIssues.Count.Should().BeLessThanOrEqualTo(20);
+        result.TopIssues[0].Severity.Should().Be(DataQualitySeverity.Critical);
+
+        var severities = result.TopIssues.Select(i => (int)i.Severity).ToList();
+        severities.Should().BeInDescendingOrder();
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/DataQualityAnalysisServiceMockedTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/DataQualityAnalysisServiceMockedTests.cs
@@ -1,0 +1,95 @@
+using CosmosToSqlAssessment.Models;
+using CosmosToSqlAssessment.Services;
+using CosmosToSqlAssessment.Tests.Infrastructure;
+using CosmosToSqlAssessment.Tests.Mocks;
+using Newtonsoft.Json.Linq;
+
+namespace CosmosToSqlAssessment.Tests.Services;
+
+/// <summary>
+/// Smoke tests proving the harness can drive the real
+/// <see cref="DataQualityAnalysisService"/> end-to-end without Azure access.
+/// Deeper edge-case coverage (nulls, duplicates, malformed docs, big strings)
+/// lands in sub-issue #183 on top of this same harness.
+/// </summary>
+public class DataQualityAnalysisServiceMockedTests : TestBase
+{
+    private static CosmosDbAnalysis BuildCosmosAnalysisWithContainer(string containerName, int documentCount)
+        => new()
+        {
+            Containers = new List<ContainerAnalysis>
+            {
+                new()
+                {
+                    ContainerName = containerName,
+                    DocumentCount = documentCount,
+                    PartitionKey = "/id",
+                    DetectedSchemas = new List<DocumentSchema>
+                    {
+                        new()
+                        {
+                            SchemaName = "Default",
+                            Fields = new Dictionary<string, CosmosToSqlAssessment.Models.FieldInfo>
+                            {
+                                ["id"] = new() { FieldName = "id", DetectedTypes = new List<string> { "string" } },
+                                ["value"] = new() { FieldName = "value", DetectedTypes = new List<string> { "number" } }
+                            },
+                            SampleCount = documentCount,
+                            Prevalence = 1.0
+                        }
+                    }
+                }
+            }
+        };
+
+    [Fact]
+    public async Task AnalyzeDataQualityAsync_with_clean_documents_reports_no_critical_issues()
+    {
+        var docs = Enumerable.Range(1, 5)
+            .Select(i => JObject.Parse($"{{\"id\":\"d{i}\",\"value\":{i * 10}}}"))
+            .ToArray();
+
+        var cosmosClient = new CosmosClientMockBuilder()
+            .WithDatabase("QualityDb", db => db
+                .WithContainer("clean", c => c.WithPartitionKey("/id").WithDocuments(docs)))
+            .Build();
+
+        var service = new DataQualityAnalysisService(
+            MockConfiguration.Object,
+            CreateMockLogger<DataQualityAnalysisService>().Object,
+            cosmosClient);
+
+        var input = BuildCosmosAnalysisWithContainer("clean", documentCount: 5);
+
+        var result = await service.AnalyzeDataQualityAsync(input, "QualityDb", CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.ContainerAnalyses.Should().ContainSingle();
+        result.ContainerAnalyses[0].ContainerName.Should().Be("clean");
+        result.ContainerAnalyses[0].SampleSize.Should().Be(5);
+        result.TotalDocumentsAnalyzed.Should().Be(5);
+        result.CriticalIssuesCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task AnalyzeDataQualityAsync_with_empty_container_emits_warning_and_skips_analysis()
+    {
+        var cosmosClient = new CosmosClientMockBuilder()
+            .WithDatabase("QualityDb", db => db
+                .WithContainer("empty", c => c.WithPartitionKey("/id")))
+            .Build();
+
+        var service = new DataQualityAnalysisService(
+            MockConfiguration.Object,
+            CreateMockLogger<DataQualityAnalysisService>().Object,
+            cosmosClient);
+
+        var input = BuildCosmosAnalysisWithContainer("empty", documentCount: 0);
+
+        var result = await service.AnalyzeDataQualityAsync(input, "QualityDb", CancellationToken.None);
+
+        result.ContainerAnalyses.Should().ContainSingle();
+        result.ContainerAnalyses[0].SampleSize.Should().Be(0);
+        result.TotalDocumentsAnalyzed.Should().Be(0);
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/SqlProjectGenerationServiceEdgeCaseTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/SqlProjectGenerationServiceEdgeCaseTests.cs
@@ -1,0 +1,474 @@
+using System.Xml.Linq;
+using CosmosToSqlAssessment.Models;
+using CosmosToSqlAssessment.Services;
+using CosmosToSqlAssessment.Tests.Infrastructure;
+
+namespace CosmosToSqlAssessment.Tests.Services;
+
+/// <summary>
+/// Edge-case tests for <see cref="SqlProjectGenerationService"/> targeting
+/// production branches that the happy-path test suite in
+/// <see cref="SqlProjectGenerationServiceTests"/> does not reach:
+/// nested-object / array child tables, mixed-type fields rendered as
+/// <c>NVARCHAR(MAX)</c>, shared-schema deduplication, every index type,
+/// assessment-level foreign keys, non-default schemas, identifier
+/// sanitisation, and the orphan-shared-child FK leak.
+/// </summary>
+public class SqlProjectGenerationServiceEdgeCaseTests : TestBase, IDisposable
+{
+    private readonly SqlProjectGenerationService _service;
+    private readonly string _tempDirectory;
+
+    public SqlProjectGenerationServiceEdgeCaseTests()
+    {
+        _service = new SqlProjectGenerationService(
+            MockConfiguration.Object,
+            CreateMockLogger<SqlProjectGenerationService>().Object);
+        _tempDirectory = Directory.CreateTempSubdirectory("sqlgen-edge-").FullName;
+    }
+
+    private static AssessmentResult BuildBase(string targetDb = "EdgeDb_SQL") =>
+        new()
+        {
+            CosmosAccountName = "test",
+            DatabaseName = "EdgeDb",
+            SqlAssessment = new SqlMigrationAssessment
+            {
+                DatabaseMappings = new List<DatabaseMapping>
+                {
+                    new()
+                    {
+                        SourceDatabase = "EdgeDb",
+                        TargetDatabase = targetDb,
+                        ContainerMappings = new List<ContainerMapping>()
+                    }
+                }
+            }
+        };
+
+    private async Task<string> RunAndGetProjectDirectoryAsync(AssessmentResult assessment)
+    {
+        await _service.GenerateSqlProjectsAsync(assessment, _tempDirectory);
+        var sqlProjectsDir = Path.Combine(_tempDirectory, "sql-projects");
+        return Directory.EnumerateDirectories(sqlProjectsDir).Single();
+    }
+
+    [Fact]
+    public async Task Nested_object_child_table_generates_table_header_with_field_path()
+    {
+        var assessment = BuildBase();
+        var container = new ContainerMapping
+        {
+            SourceContainer = "users",
+            TargetTable = "Users",
+            FieldMappings =
+            {
+                new FieldMapping { TargetColumn = "Name", TargetType = "NVARCHAR(255)", IsNullable = false }
+            },
+            ChildTableMappings =
+            {
+                new ChildTableMapping
+                {
+                    SourceFieldPath = "users.address",
+                    ChildTableType = "NestedObject",
+                    TargetTable = "UserAddresses",
+                    ParentKeyColumn = "UserCosmosId",
+                    FieldMappings =
+                    {
+                        new FieldMapping { TargetColumn = "Id", TargetType = "BIGINT IDENTITY(1,1)", IsNullable = false },
+                        new FieldMapping { TargetColumn = "UserCosmosId", TargetType = "NVARCHAR(255)", IsNullable = false },
+                        new FieldMapping { TargetColumn = "Street", TargetType = "NVARCHAR(255)" }
+                    }
+                }
+            }
+        };
+        assessment.SqlAssessment.DatabaseMappings[0].ContainerMappings.Add(container);
+
+        var projectDir = await RunAndGetProjectDirectoryAsync(assessment);
+        var childFile = Path.Combine(projectDir, "Tables", "UserAddresses.sql");
+        var sql = await File.ReadAllTextAsync(childFile);
+
+        sql.Should().Contain("-- Child table for NestedObject: users.address");
+        sql.Should().Contain("-- Parent container: users");
+        sql.Should().Contain("CREATE TABLE [dbo].[UserAddresses]");
+        sql.Should().Contain("[UserCosmosId]");
+        sql.Should().Contain("Foreign key to Users");
+        sql.Should().Contain("PRIMARY KEY");
+    }
+
+    [Fact]
+    public async Task Array_child_table_header_distinguishes_from_nested_object()
+    {
+        var assessment = BuildBase();
+        assessment.SqlAssessment.DatabaseMappings[0].ContainerMappings.Add(new ContainerMapping
+        {
+            SourceContainer = "users",
+            TargetTable = "Users",
+            ChildTableMappings =
+            {
+                new ChildTableMapping
+                {
+                    SourceFieldPath = "users.tags",
+                    ChildTableType = "Array",
+                    TargetTable = "UserTags",
+                    ParentKeyColumn = "UserCosmosId",
+                    FieldMappings =
+                    {
+                        new FieldMapping { TargetColumn = "Id", TargetType = "BIGINT IDENTITY(1,1)", IsNullable = false },
+                        new FieldMapping { TargetColumn = "UserCosmosId", TargetType = "NVARCHAR(255)", IsNullable = false },
+                        new FieldMapping { TargetColumn = "Tag", TargetType = "NVARCHAR(100)" }
+                    }
+                }
+            }
+        });
+
+        var projectDir = await RunAndGetProjectDirectoryAsync(assessment);
+        var sql = await File.ReadAllTextAsync(Path.Combine(projectDir, "Tables", "UserTags.sql"));
+
+        sql.Should().Contain("-- Child table for Array: users.tags");
+        sql.Should().Contain("CREATE TABLE [dbo].[UserTags]");
+    }
+
+    [Fact]
+    public async Task Field_mapping_with_NVARCHAR_MAX_target_type_is_emitted_verbatim()
+    {
+        var assessment = BuildBase();
+        assessment.SqlAssessment.DatabaseMappings[0].ContainerMappings.Add(new ContainerMapping
+        {
+            SourceContainer = "events",
+            TargetTable = "Events",
+            FieldMappings =
+            {
+                new FieldMapping
+                {
+                    SourceField = "payload",
+                    SourceType = "object|number|string", // mixed Cosmos source
+                    TargetColumn = "Payload",
+                    TargetType = "NVARCHAR(MAX)",
+                    IsNullable = true
+                }
+            }
+        });
+
+        var projectDir = await RunAndGetProjectDirectoryAsync(assessment);
+        var sql = await File.ReadAllTextAsync(Path.Combine(projectDir, "Tables", "Events.sql"));
+
+        sql.Should().Contain("[Payload] NVARCHAR(MAX) NULL");
+    }
+
+    [Fact]
+    public async Task Shared_schema_dedup_collapses_duplicate_target_table_to_one_file()
+    {
+        var assessment = BuildBase();
+        assessment.SqlAssessment.DatabaseMappings[0].ContainerMappings.Add(new ContainerMapping
+        {
+            SourceContainer = "users",
+            TargetTable = "Users",
+            FieldMappings = { new FieldMapping { TargetColumn = "Name", TargetType = "NVARCHAR(255)" } }
+        });
+
+        // Two shared schemas with the same TargetTable trigger both dedup
+        // gates: the .sqlproj addedTables HashSet AND the
+        // generatedSharedTables HashSet inside GenerateTableScriptsAsync.
+        assessment.SqlAssessment.SharedSchemas.Add(new SharedSchema
+        {
+            SchemaId = "addr-v1",
+            SchemaName = "Address",
+            TargetTable = "SharedAddress",
+            SchemaHash = "h1",
+            UsageCount = 2,
+            SourceContainers = { "users" },
+            SourceFieldPaths = { "users.address" },
+            FieldMappings = { new FieldMapping { TargetColumn = "Street", TargetType = "NVARCHAR(255)" } }
+        });
+        assessment.SqlAssessment.SharedSchemas.Add(new SharedSchema
+        {
+            SchemaId = "addr-v2",
+            SchemaName = "Address",
+            TargetTable = "SharedAddress", // same target -> must dedup
+            SchemaHash = "h2",
+            UsageCount = 1,
+            SourceContainers = { "orders" },
+            SourceFieldPaths = { "orders.shippingAddress" },
+            FieldMappings = { new FieldMapping { TargetColumn = "City", TargetType = "NVARCHAR(100)" } }
+        });
+
+        var projectDir = await RunAndGetProjectDirectoryAsync(assessment);
+        var tablesDir = Path.Combine(projectDir, "Tables");
+
+        Directory.EnumerateFiles(tablesDir, "SharedAddress.sql").Should().ContainSingle();
+
+        var sqlproj = XDocument.Load(Directory.EnumerateFiles(projectDir, "*.sqlproj").Single());
+        var ns = sqlproj.Root!.Name.Namespace;
+        var sharedBuildItems = sqlproj.Descendants(ns + "Build")
+            .Where(b => string.Equals((string?)b.Attribute("Include"), @"Tables\SharedAddress.sql", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        sharedBuildItems.Should().ContainSingle("the .sqlproj's addedTables HashSet should dedup duplicate shared targets");
+    }
+
+    [Fact]
+    public async Task Index_recommendations_render_each_index_type_with_correct_keyword()
+    {
+        var assessment = BuildBase();
+        assessment.SqlAssessment.DatabaseMappings[0].ContainerMappings.Add(new ContainerMapping
+        {
+            SourceContainer = "users",
+            TargetTable = "Users",
+            FieldMappings = { new FieldMapping { TargetColumn = "Name", TargetType = "NVARCHAR(255)" } }
+        });
+        assessment.SqlAssessment.IndexRecommendations.AddRange(new[]
+        {
+            new IndexRecommendation { TableName = "Users", IndexName = "PK_Users_Id",   IndexType = "CLUSTERED",    Columns = { "Id" },        Priority = 1, Justification = "PK" },
+            new IndexRecommendation { TableName = "Users", IndexName = "UX_Users_Email",IndexType = "UNIQUE",       Columns = { "Email" },      Priority = 2, Justification = "Unique email" },
+            new IndexRecommendation { TableName = "Users", IndexName = "CS_Users_All",  IndexType = "COLUMNSTORE",  Columns = { "Id", "Name" }, Priority = 3, Justification = "Analytics" },
+            new IndexRecommendation { TableName = "Users", IndexName = "IX_Users_Name", IndexType = "WHATEVER",     Columns = { "Name" }, IncludedColumns = { "Email" }, Priority = 4, Justification = "Lookup" }
+        });
+
+        var projectDir = await RunAndGetProjectDirectoryAsync(assessment);
+        var indexes = await File.ReadAllTextAsync(Path.Combine(projectDir, "Indexes", "Indexes.sql"));
+
+        indexes.Should().Contain("CREATE CLUSTERED INDEX [PK_Users_Id] ON [Users]");
+        indexes.Should().Contain("CREATE UNIQUE NONCLUSTERED INDEX [UX_Users_Email] ON [Users]");
+        indexes.Should().Contain("CREATE CLUSTERED COLUMNSTORE INDEX [CS_Users_All] ON [Users]");
+        indexes.Should().Contain("CREATE NONCLUSTERED INDEX [IX_Users_Name] ON [Users] ([Name]) INCLUDE ([Email])");
+    }
+
+    [Fact]
+    public async Task Assessment_level_foreign_key_is_emitted_in_foreign_keys_script()
+    {
+        var assessment = BuildBase();
+        assessment.SqlAssessment.DatabaseMappings[0].ContainerMappings.AddRange(new[]
+        {
+            new ContainerMapping { SourceContainer = "users",  TargetTable = "Users",  FieldMappings = { new FieldMapping { TargetColumn = "Name", TargetType = "NVARCHAR(255)" } } },
+            new ContainerMapping { SourceContainer = "orders", TargetTable = "Orders", FieldMappings = { new FieldMapping { TargetColumn = "Total", TargetType = "DECIMAL(18,2)" } } }
+        });
+        assessment.SqlAssessment.ForeignKeyConstraints.Add(new ForeignKeyConstraint
+        {
+            ConstraintName = "FK_Orders_Users",
+            ChildTable = "Orders",
+            ChildColumn = "UserCosmosId",
+            ParentTable = "Users",
+            ParentColumn = "CosmosId",
+            OnDeleteAction = "NO ACTION",
+            OnUpdateAction = "CASCADE",
+            Justification = "Each order belongs to a user"
+        });
+
+        var projectDir = await RunAndGetProjectDirectoryAsync(assessment);
+        var fk = await File.ReadAllTextAsync(Path.Combine(projectDir, "ForeignKeys", "ForeignKeys.sql"));
+
+        fk.Should().Contain("FK_Orders_Users");
+        fk.Should().Contain("ALTER TABLE [Orders]");
+        fk.Should().Contain("FOREIGN KEY ([UserCosmosId])");
+        fk.Should().Contain("REFERENCES [Users] ([CosmosId])");
+        fk.Should().Contain("ON DELETE NO ACTION ON UPDATE CASCADE");
+        fk.Should().Contain("Each order belongs to a user");
+    }
+
+    [Fact]
+    public async Task Sanitize_name_prefixes_leading_digit_and_replaces_invalid_chars()
+    {
+        var assessment = BuildBase("1-data warehouse.test");
+        assessment.SqlAssessment.DatabaseMappings[0].ContainerMappings.Add(new ContainerMapping
+        {
+            SourceContainer = "x",
+            TargetTable = "X",
+            FieldMappings = { new FieldMapping { TargetColumn = "Y", TargetType = "INT" } }
+        });
+
+        await _service.GenerateSqlProjectsAsync(assessment, _tempDirectory);
+        var sqlProjectsDir = Path.Combine(_tempDirectory, "sql-projects");
+        var dirs = Directory.EnumerateDirectories(sqlProjectsDir).ToList();
+
+        dirs.Should().ContainSingle();
+        var folderName = Path.GetFileName(dirs[0]);
+        // Spaces, dashes, dots replaced with underscores; leading digit forces DB_ prefix.
+        folderName.Should().Be("DB_1_data_warehouse_test.Database");
+    }
+
+    [Fact]
+    public async Task Child_table_required_transformations_render_as_comments()
+    {
+        var assessment = BuildBase();
+        assessment.SqlAssessment.DatabaseMappings[0].ContainerMappings.Add(new ContainerMapping
+        {
+            SourceContainer = "users",
+            TargetTable = "Users",
+            ChildTableMappings =
+            {
+                new ChildTableMapping
+                {
+                    SourceFieldPath = "users.tags",
+                    ChildTableType = "Array",
+                    TargetTable = "UserTags",
+                    ParentKeyColumn = "UserCosmosId",
+                    FieldMappings =
+                    {
+                        new FieldMapping { TargetColumn = "Id", TargetType = "BIGINT IDENTITY(1,1)", IsNullable = false },
+                        new FieldMapping { TargetColumn = "UserCosmosId", TargetType = "NVARCHAR(255)", IsNullable = false },
+                        new FieldMapping { TargetColumn = "Tag", TargetType = "NVARCHAR(100)" }
+                    },
+                    RequiredTransformations =
+                    {
+                        "Trim whitespace from tag values",
+                        "Lowercase before insert"
+                    }
+                }
+            }
+        });
+
+        var projectDir = await RunAndGetProjectDirectoryAsync(assessment);
+        var sql = await File.ReadAllTextAsync(Path.Combine(projectDir, "Tables", "UserTags.sql"));
+
+        sql.Should().Contain("-- Required Transformations:");
+        sql.Should().Contain("-- * Trim whitespace from tag values");
+        sql.Should().Contain("-- * Lowercase before insert");
+    }
+
+    [Fact]
+    public async Task Child_with_matching_shared_schema_skips_local_table_and_emits_shared_one()
+    {
+        var assessment = BuildBase();
+        assessment.SqlAssessment.DatabaseMappings[0].ContainerMappings.Add(new ContainerMapping
+        {
+            SourceContainer = "users",
+            TargetTable = "Users",
+            FieldMappings = { new FieldMapping { TargetColumn = "Name", TargetType = "NVARCHAR(255)" } },
+            ChildTableMappings =
+            {
+                new ChildTableMapping
+                {
+                    SourceFieldPath = "users.address",
+                    ChildTableType = "NestedObject",
+                    TargetTable = "UserAddresses_Local", // would generate as local if SharedSchemaId were null
+                    ParentKeyColumn = "UserCosmosId",
+                    SharedSchemaId = "shared-address",
+                    FieldMappings =
+                    {
+                        new FieldMapping { TargetColumn = "UserCosmosId", TargetType = "NVARCHAR(255)" }
+                    }
+                }
+            }
+        });
+        assessment.SqlAssessment.SharedSchemas.Add(new SharedSchema
+        {
+            SchemaId = "shared-address",
+            SchemaName = "Address",
+            TargetTable = "SharedAddress",
+            SchemaHash = "h-addr",
+            UsageCount = 1,
+            SourceContainers = { "users" },
+            SourceFieldPaths = { "users.address" },
+            FieldMappings = { new FieldMapping { TargetColumn = "Street", TargetType = "NVARCHAR(255)" } }
+        });
+
+        var projectDir = await RunAndGetProjectDirectoryAsync(assessment);
+        var tablesDir = Path.Combine(projectDir, "Tables");
+
+        File.Exists(Path.Combine(tablesDir, "UserAddresses_Local.sql")).Should().BeFalse(
+            "the local child table should be skipped when SharedSchemaId is set and a SharedSchema entry exists");
+        File.Exists(Path.Combine(tablesDir, "SharedAddress.sql")).Should().BeTrue();
+
+        var sqlproj = XDocument.Load(Directory.EnumerateFiles(projectDir, "*.sqlproj").Single());
+        var ns = sqlproj.Root!.Name.Namespace;
+        var includes = sqlproj.Descendants(ns + "Build")
+            .Select(b => (string?)b.Attribute("Include"))
+            .ToList();
+        includes.Should().Contain(@"Tables\SharedAddress.sql");
+        includes.Should().NotContain(@"Tables\UserAddresses_Local.sql");
+    }
+
+    [Fact]
+    public async Task Shared_child_mapping_currently_leaks_into_foreign_key_script()
+    {
+        // Documents current behaviour: GenerateForeignKeyScriptsAsync iterates
+        // ALL ChildTableMappings regardless of SharedSchemaId, so an FK is
+        // emitted even though the local child table was intentionally not
+        // generated. If/when production checks SharedSchemaId in the FK loop,
+        // this test should flip to assert the FK is NOT emitted.
+        var assessment = BuildBase();
+        assessment.SqlAssessment.DatabaseMappings[0].ContainerMappings.Add(new ContainerMapping
+        {
+            SourceContainer = "users",
+            TargetTable = "Users",
+            FieldMappings = { new FieldMapping { TargetColumn = "Name", TargetType = "NVARCHAR(255)" } },
+            ChildTableMappings =
+            {
+                new ChildTableMapping
+                {
+                    SourceFieldPath = "users.address",
+                    ChildTableType = "NestedObject",
+                    TargetTable = "UserAddresses_Local",
+                    ParentKeyColumn = "UserCosmosId",
+                    SharedSchemaId = "shared-address",
+                    FieldMappings =
+                    {
+                        new FieldMapping { TargetColumn = "UserCosmosId", TargetType = "NVARCHAR(255)" }
+                    }
+                }
+            }
+        });
+        assessment.SqlAssessment.SharedSchemas.Add(new SharedSchema
+        {
+            SchemaId = "shared-address",
+            SchemaName = "Address",
+            TargetTable = "SharedAddress",
+            SchemaHash = "h-addr",
+            UsageCount = 1,
+            FieldMappings = { new FieldMapping { TargetColumn = "Street", TargetType = "NVARCHAR(255)" } }
+        });
+
+        var projectDir = await RunAndGetProjectDirectoryAsync(assessment);
+        var fkPath = Path.Combine(projectDir, "ForeignKeys", "ForeignKeys.sql");
+
+        // Current behaviour: FK file is created and references the skipped local child table.
+        File.Exists(fkPath).Should().BeTrue();
+        var fk = await File.ReadAllTextAsync(fkPath);
+        fk.Should().Contain("FK_UserAddresses_Local_Users");
+    }
+
+    [Fact]
+    public async Task Non_default_target_schema_flows_into_create_table_statement()
+    {
+        var assessment = BuildBase();
+        assessment.SqlAssessment.DatabaseMappings[0].ContainerMappings.Add(new ContainerMapping
+        {
+            SourceContainer = "events",
+            TargetSchema = "audit",
+            TargetTable = "Events",
+            FieldMappings =
+            {
+                new FieldMapping { TargetColumn = "Payload", TargetType = "NVARCHAR(MAX)" }
+            }
+        });
+
+        var projectDir = await RunAndGetProjectDirectoryAsync(assessment);
+        var sql = await File.ReadAllTextAsync(Path.Combine(projectDir, "Tables", "Events.sql"));
+
+        sql.Should().Contain("CREATE TABLE [audit].[Events]");
+        sql.Should().Contain("ALTER TABLE [audit].[Events]");
+    }
+
+    public void Dispose()
+    {
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                if (Directory.Exists(_tempDirectory))
+                {
+                    Directory.Delete(_tempDirectory, recursive: true);
+                }
+                return;
+            }
+            catch (IOException) when (attempt < 2)
+            {
+                Thread.Sleep(50 * (attempt + 1));
+            }
+            catch (UnauthorizedAccessException) when (attempt < 2)
+            {
+                Thread.Sleep(50 * (attempt + 1));
+            }
+        }
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/TransientFailureRetryTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/TransientFailureRetryTests.cs
@@ -1,0 +1,508 @@
+using Azure;
+using Azure.Monitor.Query;
+using CosmosToSqlAssessment.Models;
+using CosmosToSqlAssessment.Services;
+using CosmosToSqlAssessment.Tests.Infrastructure;
+using CosmosToSqlAssessment.Tests.Mocks;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using System.Net;
+
+namespace CosmosToSqlAssessment.Tests.Services;
+
+/// <summary>
+/// Transient-failure / retry tests for the Azure SDK call sites in
+/// <see cref="CosmosDbAnalysisService"/> and
+/// <see cref="DataQualityAnalysisService"/>. Documents which exceptions
+/// propagate, which are absorbed by inner try/catch blocks, and which
+/// degrade gracefully into a default result.
+///
+/// <para>
+/// This file is the canonical reference for Wave-2+ parents that need to
+/// test their own Azure SDK call sites against transient failures. Pattern:
+/// pick a <see cref="CosmosExceptionFactory"/> static, inject via the
+/// corresponding <c>With*Error</c> mock-builder hook, assert one of
+/// propagation / absorption / graceful degradation.
+/// </para>
+/// </summary>
+public class TransientFailureRetryTests : TestBase
+{
+    // ============================================================
+    // ReadThroughputAsync — swallowed vs propagating cases
+    // ============================================================
+
+    [Fact]
+    public async Task ReadThroughputAsync_BadRequest_is_swallowed_and_analysis_continues()
+    {
+        // Production: catch (CosmosException ex) when (ex.StatusCode == BadRequest)
+        // swallows the throw (shared-database-throughput path) and continues.
+        var loggerMock = CreateMockLogger<CosmosDbAnalysisService>();
+        var cosmosClient = new CosmosClientMockBuilder()
+            .WithDatabase("Db", db => db.WithContainer("c", c => c
+                .WithPartitionKey("/id")
+                .WithThroughputError(CosmosExceptionFactory.BadRequest("shared throughput"))))
+            .Build();
+
+        var service = new CosmosDbAnalysisService(MockConfiguration.Object, loggerMock.Object, cosmosClient);
+
+        var result = await service.AnalyzeDatabaseAsync("Db", CancellationToken.None);
+
+        result.Containers.Should().ContainSingle();
+        result.Containers[0].PartitionKey.Should().Be("/id");
+        loggerMock.Invocations.Should().Contain(i =>
+            i.Arguments.Count >= 1 && (LogLevel)i.Arguments[0] == LogLevel.Information);
+    }
+
+    [Fact]
+    public async Task ReadThroughputAsync_Forbidden_is_swallowed_and_analysis_continues()
+    {
+        // Production: catch (CosmosException ex) when (ex.StatusCode == Forbidden)
+        // logs a warning and continues with ProvisionedRUs = 0.
+        var loggerMock = CreateMockLogger<CosmosDbAnalysisService>();
+        var cosmosClient = new CosmosClientMockBuilder()
+            .WithDatabase("Db", db => db.WithContainer("c", c => c
+                .WithPartitionKey("/id")
+                .WithThroughputError(CosmosExceptionFactory.Forbidden())))
+            .Build();
+
+        var service = new CosmosDbAnalysisService(MockConfiguration.Object, loggerMock.Object, cosmosClient);
+
+        var result = await service.AnalyzeDatabaseAsync("Db", CancellationToken.None);
+
+        result.Containers.Should().ContainSingle();
+        result.Containers[0].PartitionKey.Should().Be("/id");
+        loggerMock.Invocations.Should().Contain(i =>
+            i.Arguments.Count >= 1 && (LogLevel)i.Arguments[0] == LogLevel.Warning);
+    }
+
+    [Fact]
+    public async Task ReadThroughputAsync_Throttled_propagates_as_CosmosException()
+    {
+        var cosmosClient = new CosmosClientMockBuilder()
+            .WithDatabase("Db", db => db.WithContainer("c", c => c
+                .WithThroughputError(CosmosExceptionFactory.Throttled())))
+            .Build();
+
+        var service = new CosmosDbAnalysisService(
+            MockConfiguration.Object,
+            CreateMockLogger<CosmosDbAnalysisService>().Object,
+            cosmosClient);
+
+        var act = async () => await service.AnalyzeDatabaseAsync("Db", CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<CosmosException>();
+        thrown.Which.StatusCode.Should().Be((HttpStatusCode)429);
+    }
+
+    [Fact]
+    public async Task ReadThroughputAsync_ServiceUnavailable_propagates_as_CosmosException()
+    {
+        var cosmosClient = new CosmosClientMockBuilder()
+            .WithDatabase("Db", db => db.WithContainer("c", c => c
+                .WithThroughputError(CosmosExceptionFactory.ServiceUnavailable())))
+            .Build();
+
+        var service = new CosmosDbAnalysisService(
+            MockConfiguration.Object,
+            CreateMockLogger<CosmosDbAnalysisService>().Object,
+            cosmosClient);
+
+        var act = async () => await service.AnalyzeDatabaseAsync("Db", CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<CosmosException>();
+        thrown.Which.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+    }
+
+    [Fact]
+    public async Task ReadThroughputAsync_Timeout_propagates_as_CosmosException()
+    {
+        var cosmosClient = new CosmosClientMockBuilder()
+            .WithDatabase("Db", db => db.WithContainer("c", c => c
+                .WithThroughputError(CosmosExceptionFactory.Timeout())))
+            .Build();
+
+        var service = new CosmosDbAnalysisService(
+            MockConfiguration.Object,
+            CreateMockLogger<CosmosDbAnalysisService>().Object,
+            cosmosClient);
+
+        var act = async () => await service.AnalyzeDatabaseAsync("Db", CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<CosmosException>();
+        thrown.Which.StatusCode.Should().Be(HttpStatusCode.RequestTimeout);
+    }
+
+    // ============================================================
+    // ReadContainerAsync — propagation
+    // ============================================================
+
+    [Fact]
+    public async Task ReadContainerAsync_NotFound_propagates()
+    {
+        var cosmosClient = new CosmosClientMockBuilder()
+            .WithDatabase("Db", db => db.WithContainer("c", c => c
+                .WithReadContainerError(CosmosExceptionFactory.NotFound())))
+            .Build();
+
+        var service = new CosmosDbAnalysisService(
+            MockConfiguration.Object,
+            CreateMockLogger<CosmosDbAnalysisService>().Object,
+            cosmosClient);
+
+        var act = async () => await service.AnalyzeDatabaseAsync("Db", CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<CosmosException>();
+        thrown.Which.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ReadContainerAsync_Throttled_propagates()
+    {
+        var cosmosClient = new CosmosClientMockBuilder()
+            .WithDatabase("Db", db => db.WithContainer("c", c => c
+                .WithReadContainerError(CosmosExceptionFactory.Throttled())))
+            .Build();
+
+        var service = new CosmosDbAnalysisService(
+            MockConfiguration.Object,
+            CreateMockLogger<CosmosDbAnalysisService>().Object,
+            cosmosClient);
+
+        var act = async () => await service.AnalyzeDatabaseAsync("Db", CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<CosmosException>();
+        thrown.Which.StatusCode.Should().Be((HttpStatusCode)429);
+    }
+
+    // ============================================================
+    // Query iterator — count query propagates after schema query swallows
+    // ============================================================
+
+    [Fact]
+    public async Task Count_query_Throttled_propagates_after_schema_query_swallowed()
+    {
+        // WithQueryError makes every GetItemQueryIterator<T> throw. The schema
+        // sampling call (<dynamic>) is wrapped in a bare catch inside
+        // AnalyzeDocumentSchemasAsync and is silently absorbed — see test
+        // Schema_query_Throttled_is_swallowed_... for the isolated proof.
+        // The count query (<int>) has no inner catch, so the second throw
+        // propagates up to AnalyzeContainerAsync's catch which re-throws.
+        var cosmosClient = new CosmosClientMockBuilder()
+            .WithDatabase("Db", db => db.WithContainer("c", c => c
+                .WithQueryError(CosmosExceptionFactory.Throttled())))
+            .Build();
+
+        var service = new CosmosDbAnalysisService(
+            MockConfiguration.Object,
+            CreateMockLogger<CosmosDbAnalysisService>().Object,
+            cosmosClient);
+
+        var act = async () => await service.AnalyzeDatabaseAsync("Db", CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<CosmosException>();
+        thrown.Which.StatusCode.Should().Be((HttpStatusCode)429);
+    }
+
+    [Fact]
+    public async Task Schema_query_Throttled_is_swallowed_and_analysis_continues_with_empty_schemas()
+    {
+        // Typed-overload WithQueryError<dynamic>(...) fails only the schema-sample
+        // call; the count query (<int>) keeps returning the configured count.
+        // Confirms AnalyzeDocumentSchemasAsync's bare catch absorbs the throw
+        // and analysis proceeds with empty schemas.
+        var docs = new[] { JObject.Parse("{\"id\":\"a\"}"), JObject.Parse("{\"id\":\"b\"}") };
+        var cosmosClient = new CosmosClientMockBuilder()
+            .WithDatabase("Db", db => db.WithContainer("c", c => c
+                .WithPartitionKey("/id")
+                .WithDocuments(docs)
+                .WithQueryError<dynamic>(CosmosExceptionFactory.Throttled())))
+            .Build();
+
+        var service = new CosmosDbAnalysisService(
+            MockConfiguration.Object,
+            CreateMockLogger<CosmosDbAnalysisService>().Object,
+            cosmosClient);
+
+        var result = await service.AnalyzeDatabaseAsync("Db", CancellationToken.None);
+
+        result.Containers.Should().ContainSingle();
+        result.Containers[0].DetectedSchemas.Should().BeEmpty();
+        result.Containers[0].ChildTables.Should().BeEmpty();
+        result.Containers[0].DocumentCount.Should().Be(2);
+    }
+
+    // ============================================================
+    // Container-loop bail-out: first failure aborts the whole loop
+    // ============================================================
+
+    [Fact]
+    public async Task First_container_failure_aborts_loop_no_second_container_analyzed()
+    {
+        // Production loop has no per-container catch -- a single throw aborts.
+        // The mock harness builds a fresh Container instance every call to
+        // GetContainer, so we cannot Mock.Verify a specific Container's
+        // ReadContainerAsync. Instead, we assert via observable side effect:
+        // analysis was never returned (exception thrown) AND no second
+        // container's setup was exercised because we use WithThroughput on
+        // the second one and the analysis result is unreachable.
+        var cosmosClient = new CosmosClientMockBuilder()
+            .WithDatabase("Db", db => db
+                .WithContainer("bad", c => c
+                    .WithReadContainerError(CosmosExceptionFactory.Throttled()))
+                .WithContainer("good", c => c
+                    .WithPartitionKey("/id")
+                    .WithThroughput(400)))
+            .Build();
+
+        var service = new CosmosDbAnalysisService(
+            MockConfiguration.Object,
+            CreateMockLogger<CosmosDbAnalysisService>().Object,
+            cosmosClient);
+
+        var act = async () => await service.AnalyzeDatabaseAsync("Db", CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<CosmosException>();
+        thrown.Which.StatusCode.Should().Be((HttpStatusCode)429);
+        // The analysis never returns, so result.Containers[0] for "good" is
+        // unreachable. If a future maintainer adds per-container resilience
+        // (try/catch per iteration), update this test to assert both
+        // containers appear in result.Containers with the bad one marked.
+    }
+
+    // ============================================================
+    // Container-discovery iterator throttle
+    // ============================================================
+
+    [Fact]
+    public async Task Container_listing_Throttled_propagates_from_database_iterator()
+    {
+        // GetContainersToAnalyzeAsync has no try/catch around the dynamic
+        // iterator's ReadNextAsync. A 429 there propagates straight up to
+        // AnalyzeDatabaseAsync's catch (CosmosException) which re-throws.
+        var cosmosClient = new CosmosClientMockBuilder()
+            .WithDatabase("Db", db => db
+                .WithContainerListError(CosmosExceptionFactory.Throttled())
+                .WithContainer("c", c => c.WithPartitionKey("/id")))
+            .Build();
+
+        var service = new CosmosDbAnalysisService(
+            MockConfiguration.Object,
+            CreateMockLogger<CosmosDbAnalysisService>().Object,
+            cosmosClient);
+
+        var act = async () => await service.AnalyzeDatabaseAsync("Db", CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<CosmosException>();
+        thrown.Which.StatusCode.Should().Be((HttpStatusCode)429);
+    }
+
+    // ============================================================
+    // Azure Monitor: every failure absorbed, analysis continues
+    // ============================================================
+
+    [Fact]
+    public async Task LogsQuery_Throttled_does_not_fail_overall_analysis()
+    {
+        MockConfiguration.Setup(c => c["AzureMonitor:WorkspaceId"]).Returns("ws-1");
+        MockConfiguration.Setup(c => c["AzureMonitor:CosmosAccountName"]).Returns("acct-1");
+
+        var cosmosClient = new CosmosClientMockBuilder()
+            .WithDatabase("Db", db => db.WithContainer("c", c => c.WithPartitionKey("/id")))
+            .Build();
+
+        var logsClient = new LogsQueryClientMockBuilder()
+            .WithError(new RequestFailedException(429, "Too Many Requests"))
+            .Build();
+
+        var service = new CosmosDbAnalysisService(
+            MockConfiguration.Object,
+            CreateMockLogger<CosmosDbAnalysisService>().Object,
+            cosmosClient,
+            logsClient);
+
+        var result = await service.AnalyzeDatabaseAsync("Db", CancellationToken.None);
+
+        result.PerformanceMetrics.Should().NotBeNull();
+        result.PerformanceMetrics.AverageRUsPerSecond.Should().Be(0);
+        result.PerformanceMetrics.PeakRUsPerSecond.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task LogsQuery_ServiceUnavailable_does_not_fail_overall_analysis()
+    {
+        MockConfiguration.Setup(c => c["AzureMonitor:WorkspaceId"]).Returns("ws-1");
+        MockConfiguration.Setup(c => c["AzureMonitor:CosmosAccountName"]).Returns("acct-1");
+
+        var cosmosClient = new CosmosClientMockBuilder()
+            .WithDatabase("Db", db => db.WithContainer("c", c => c.WithPartitionKey("/id")))
+            .Build();
+
+        var logsClient = new LogsQueryClientMockBuilder()
+            .WithError(new RequestFailedException(503, "Service Unavailable"))
+            .Build();
+
+        var service = new CosmosDbAnalysisService(
+            MockConfiguration.Object,
+            CreateMockLogger<CosmosDbAnalysisService>().Object,
+            cosmosClient,
+            logsClient);
+
+        var result = await service.AnalyzeDatabaseAsync("Db", CancellationToken.None);
+
+        result.PerformanceMetrics.Should().NotBeNull();
+        result.PerformanceMetrics.AverageRUsPerSecond.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task LogsQuery_generic_exception_does_not_fail_overall_analysis()
+    {
+        // CollectPerformanceMetricsAsync has a bare catch (Exception), so any
+        // throw type from the LogsQueryClient is absorbed.
+        MockConfiguration.Setup(c => c["AzureMonitor:WorkspaceId"]).Returns("ws-1");
+        MockConfiguration.Setup(c => c["AzureMonitor:CosmosAccountName"]).Returns("acct-1");
+
+        var cosmosClient = new CosmosClientMockBuilder()
+            .WithDatabase("Db", db => db.WithContainer("c", c => c.WithPartitionKey("/id")))
+            .Build();
+
+        var logsClient = new LogsQueryClientMockBuilder()
+            .WithError(new InvalidOperationException("boom"))
+            .Build();
+
+        var service = new CosmosDbAnalysisService(
+            MockConfiguration.Object,
+            CreateMockLogger<CosmosDbAnalysisService>().Object,
+            cosmosClient,
+            logsClient);
+
+        var result = await service.AnalyzeDatabaseAsync("Db", CancellationToken.None);
+
+        result.PerformanceMetrics.Should().NotBeNull();
+        result.Containers.Should().ContainSingle();
+    }
+
+    // ============================================================
+    // DataQualityAnalysisService: sampling failure propagates
+    // ============================================================
+
+    [Fact]
+    public async Task DataQuality_query_Throttled_propagates_to_caller()
+    {
+        // SampleDocumentsAsync re-throws on any Exception; AnalyzeDataQualityAsync
+        // has no outer try/catch, so the 429 reaches the caller.
+        var cosmosClient = new CosmosClientMockBuilder()
+            .WithDatabase("Db", db => db.WithContainer("c", c => c
+                .WithPartitionKey("/id")
+                .WithQueryError(CosmosExceptionFactory.Throttled())))
+            .Build();
+
+        var service = new DataQualityAnalysisService(
+            MockConfiguration.Object,
+            CreateMockLogger<DataQualityAnalysisService>().Object,
+            cosmosClient);
+
+        var input = new CosmosDbAnalysis
+        {
+            Containers = new List<ContainerAnalysis>
+            {
+                new()
+                {
+                    ContainerName = "c",
+                    DocumentCount = 1,
+                    PartitionKey = "/id",
+                    DetectedSchemas = new List<DocumentSchema>
+                    {
+                        new()
+                        {
+                            SchemaName = "Default",
+                            Fields = new Dictionary<string, CosmosToSqlAssessment.Models.FieldInfo>
+                            {
+                                ["id"] = new() { FieldName = "id", DetectedTypes = new List<string> { "string" } }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        var act = async () => await service.AnalyzeDataQualityAsync(input, "Db", CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<CosmosException>();
+        thrown.Which.StatusCode.Should().Be((HttpStatusCode)429);
+    }
+
+    [Fact]
+    public async Task DataQuality_query_ServiceUnavailable_propagates()
+    {
+        var cosmosClient = new CosmosClientMockBuilder()
+            .WithDatabase("Db", db => db.WithContainer("c", c => c
+                .WithPartitionKey("/id")
+                .WithQueryError(CosmosExceptionFactory.ServiceUnavailable())))
+            .Build();
+
+        var service = new DataQualityAnalysisService(
+            MockConfiguration.Object,
+            CreateMockLogger<DataQualityAnalysisService>().Object,
+            cosmosClient);
+
+        var input = new CosmosDbAnalysis
+        {
+            Containers = new List<ContainerAnalysis>
+            {
+                new()
+                {
+                    ContainerName = "c",
+                    DocumentCount = 1,
+                    PartitionKey = "/id",
+                    DetectedSchemas = new List<DocumentSchema>
+                    {
+                        new()
+                        {
+                            SchemaName = "Default",
+                            Fields = new Dictionary<string, CosmosToSqlAssessment.Models.FieldInfo>
+                            {
+                                ["id"] = new() { FieldName = "id", DetectedTypes = new List<string> { "string" } }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        var act = async () => await service.AnalyzeDataQualityAsync(input, "Db", CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<CosmosException>();
+        thrown.Which.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+    }
+
+    // ============================================================
+    // Harness sanity: custom BadRequest message reaches the catch
+    // ============================================================
+
+    [Fact]
+    public async Task Container_BadRequest_throughput_with_text_message_preserved()
+    {
+        var loggerMock = CreateMockLogger<CosmosDbAnalysisService>();
+        var cosmosClient = new CosmosClientMockBuilder()
+            .WithDatabase("Db", db => db.WithContainer("c", c => c
+                .WithPartitionKey("/id")
+                .WithThroughputError(CosmosExceptionFactory.BadRequest("custom-shared-throughput-marker"))))
+            .Build();
+
+        var service = new CosmosDbAnalysisService(MockConfiguration.Object, loggerMock.Object, cosmosClient);
+
+        var result = await service.AnalyzeDatabaseAsync("Db", CancellationToken.None);
+
+        // BadRequest was swallowed, analysis proceeded.
+        result.Containers.Should().ContainSingle();
+
+        // Capture every log invocation's rendered message and confirm at least
+        // one Information-level entry was produced for the container.
+        // Production logs "Container {ContainerName} uses shared database throughput".
+        var infoLogs = loggerMock.Invocations
+            .Where(i => i.Arguments.Count >= 1 && (LogLevel)i.Arguments[0] == LogLevel.Information)
+            .ToList();
+        infoLogs.Should().NotBeEmpty();
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/coverage.runsettings
+++ b/tests/CosmosToSqlAssessment.Tests/coverage.runsettings
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Coverage configuration for CosmosToSqlAssessment tests.
-     Azure-SDK-dependent files are excluded because they require live Azure connections
-     and cannot be meaningfully unit-tested without integration infrastructure. -->
+     Excludes the application entry point only; all services are exercised via mocks
+     installed by the harness in tests/CosmosToSqlAssessment.Tests/Mocks/. -->
 <RunSettings>
   <DataCollectionRunSettings>
     <DataCollectors>
       <DataCollector friendlyName="XPlat Code Coverage">
         <Configuration>
           <Format>cobertura</Format>
-          <!-- Exclude the main program entry point and Azure SDK-dependent services that
-               require live Cosmos DB / Azure Monitor connections to execute. -->
-          <Exclude>[CosmosToSqlAssessment]CosmosToSqlAssessment.Program,[CosmosToSqlAssessment]CosmosToSqlAssessment.Services.CosmosDbAnalysisService,[CosmosToSqlAssessment]CosmosToSqlAssessment.Services.DataQualityAnalysisService</Exclude>
+          <!-- Program is the CLI entry point and is exercised by manual smoke runs only. -->
+          <Exclude>[CosmosToSqlAssessment]CosmosToSqlAssessment.Program</Exclude>
           <ExcludeByAttribute>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
           <SingleHit>false</SingleHit>
           <UseSourceLink>true</UseSourceLink>


### PR DESCRIPTION
Closes #125

## Sub-issue checklist

- [x] #180 Add mock Azure services (Cosmos DB SDK, Azure Monitor) for offline / hermetic testing
- [x] #181 E2E workflow tests covering full assessment -> SQL project generation pipeline
- [x] #182 Edge case tests for `SqlProjectGenerationService` (complex nested schemas, arrays of objects, mixed-type fields)
- [x] #183 Edge case tests for `DataQualityAnalysisService` (nulls, duplicates, malformed documents, large strings)
- [x] #184 Transient failure / retry tests for Azure SDK calls (throttling, network errors, 429s)
- [x] #185 Update CI coverage threshold from 76.9% to 95% with regression enforcement (delivered as a ratchet: 70% -> 78% line + new 55% branch; honest gap analysis in #185)

## Implementation approach

This parent delivers the **reusable smoke-test harness** that all Wave 2+ parents (multi-agent orchestration, incremental migration, adaptive loops, etc.) will depend on before refactoring production code. Key deliverables:

- `tests/CosmosToSqlAssessment.Tests/Mocks/` -- Cosmos DB SDK + Azure Monitor mock harness (README included).
- `tests/CosmosToSqlAssessment.Tests/EndToEnd/` -- Full-pipeline E2E harness (README included).
- 45 net-new tests across 5 sub-issues (#180-#184) covering happy paths, edge cases, transient failures, and per-class POCO coverage.
- Coverage gate ratcheted from 70% line to **78% line + 55% branch** with strict regression enforcement; service excludes removed so the gate measures the full testable surface area.

## Testing

- #180 (mock harness): `dotnet test` -> 214 / 214 passing.
- #181 (E2E harness): `dotnet test` -> 220 / 220 passing.
- #182 (`SqlProjectGenerationService` edge cases): `dotnet test` -> 231 / 231 passing.
- #183 (`DataQualityAnalysisService` edge cases): `dotnet test` -> 250 / 250 passing.
- #184 (transient failure / retry): `dotnet test` -> 267 / 267 passing (250 + 17 new transient-failure tests covering ReadThroughputAsync swallow/propagate paths, ReadContainerAsync propagation, count-query propagation after schema swallow, isolated schema-only swallow via `WithQueryError<T>`, container-loop bail-out, container-listing throttle via `WithContainerListError`, Azure Monitor absorption of 429/503/generic, and DataQuality sampling propagation).
- #185 (coverage ratchet): `dotnet test` -> 274 / 274 passing (267 + 7 new POCO round-trip tests). Local cobertura: **80.13% line / 59.53% branch**. Local negative test (gate at 99%) correctly exits 1 for both gates.

### Coverage gap to the 95% headline target

Measured on this branch after #180-#185 landed: **80.13% line / 59.53% branch**. The 95% target was not achievable in this PR alone. The dominant gap is structural:

| Class | Line | Branch | Approx LOC |
| --- | ---: | ---: | ---: |
| `CosmosDbAnalysisService` | 29.0% | 19.5% | 1087 |
| `SqlMigrationAssessmentService` | 63.6% | 56.3% | 1110 |
| `ReportGenerationService` | 69.4% | 48.6% | 2003 |

The new CI gate is a **ratchet that prevents regression** while a future Wave-2 parent (to be scheduled by the orchestrator) drives the remaining ~15 percentage points of line coverage.

## Branch-protection changes

`main` had no branch protection before this PR. As part of Phase C the worker session **created branch protection** on `main` with the following required status checks (so the new coverage gate is enforced on every future PR):

- `build` — compiles the solution
- `test` — runs `dotnet test` with coverage collection and enforces the **78 % line / 55 % branch** gate

`strict = true` is enabled so PRs must be up-to-date with `main` before merging. Force-push and branch deletion are blocked. Admin enforcement is left off.

---

This PR was driven autonomously by a worker session for parent issue #125. Sub-issues were implemented one-at-a-time, in numeric order, with each landing as its own commit on this branch.
