### PR TITLE
Parent #79: Create performance benchmarking framework

### DIFF
--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -1,0 +1,141 @@
+name: Performance Regression
+
+# Runs the BenchmarkDotNet harness and the `compare-baseline` regression check from #177.
+# Phase C of parent #79 will register the `Benchmark regression` job as a required status
+# check on `main`, so this workflow MUST run on every PR to `main` regardless of `paths:`
+# (a required check with a paths filter would otherwise leave PRs blocked with an
+# "expected but never reported" check).
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+    paths:
+      - 'tests/Performance/**'
+      - 'Services/**'
+      - 'Reporting/**'
+      - 'Models/**'
+      - 'SqlProject/**'
+      - 'Configuration/**'
+      - 'Program.cs'
+      - 'appsettings.json'
+      - 'CosmosToSqlAssessment.csproj'
+      - 'CosmosToSqlAssessment.sln'
+      - '.github/workflows/performance-regression.yml'
+  workflow_dispatch:
+    inputs:
+      update_baseline:
+        description: 'Refresh the baseline from this run and upload as an artifact for manual review/commit. Skips the regression check when true.'
+        required: false
+        default: 'false'
+
+concurrency:
+  group: perf-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  DOTNET_VERSION: '8.0.x'
+  BENCHMARK_PROJECT: tests/Performance/CosmosToSqlAssessment.Benchmarks/CosmosToSqlAssessment.Benchmarks.csproj
+  BENCHMARK_DIR: tests/Performance/CosmosToSqlAssessment.Benchmarks
+  RESULTS_DIR: tests/Performance/CosmosToSqlAssessment.Benchmarks/BenchmarkDotNet.Artifacts/results
+
+jobs:
+  benchmark:
+    name: Benchmark regression
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore benchmarks project
+        run: dotnet restore "${{ env.BENCHMARK_PROJECT }}"
+
+      - name: Build benchmarks project (Release)
+        run: dotnet build "${{ env.BENCHMARK_PROJECT }}" --configuration Release --no-restore
+
+      # Invoke with no `--job` flag so the in-process toolchain pin in BuildConfig()
+      # is guaranteed to apply (BDN's CLI `--job` can replace/append jobs in ways that
+      # bypass the pin and reintroduce the apphost workaround that #173 originally fixed).
+      - name: Run benchmarks
+        working-directory: ${{ env.BENCHMARK_DIR }}
+        run: dotnet run --configuration Release --no-build -- --filter "*"
+
+      - name: Compare against tracked baseline
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.update_baseline != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          reports=("${RESULTS_DIR}"/*-report-full.json)
+
+          if [ ${#reports[@]} -eq 0 ]; then
+            echo "::error::No BenchmarkDotNet *-report-full.json reports found under ${RESULTS_DIR}."
+            exit 2
+          fi
+
+          echo "Found ${#reports[@]} report file(s)."
+
+          WORST=0
+          set +e
+          for report in "${reports[@]}"; do
+            dotnet run --configuration Release --no-build \
+              --project "${BENCHMARK_PROJECT}" \
+              -- compare-baseline --report "${report}"
+            rc=$?
+            if [ "${rc}" -gt "${WORST}" ]; then
+              WORST=${rc}
+            fi
+          done
+          set -e
+
+          echo "Worst compare-baseline exit code: ${WORST}"
+          exit "${WORST}"
+
+      - name: Refresh baseline (manual dispatch only)
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.update_baseline == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          reports=("${RESULTS_DIR}"/*-report-full.json)
+
+          if [ ${#reports[@]} -eq 0 ]; then
+            echo "::error::No BenchmarkDotNet *-report-full.json reports to update from."
+            exit 2
+          fi
+
+          for report in "${reports[@]}"; do
+            dotnet run --configuration Release --no-build \
+              --project "${BENCHMARK_PROJECT}" \
+              -- compare-baseline --update --report "${report}"
+          done
+
+          echo "Refreshed baseline:"
+          cat "${BENCHMARK_DIR}/baselines/baseline.json"
+
+      - name: Upload refreshed baseline (manual dispatch only)
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.update_baseline == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: refreshed-baseline
+          path: ${{ env.BENCHMARK_DIR }}/baselines/baseline.json
+          retention-days: 30
+          if-no-files-found: error
+
+      - name: Upload BenchmarkDotNet artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-artifacts
+          path: ${{ env.BENCHMARK_DIR }}/BenchmarkDotNet.Artifacts/
+          retention-days: 14
+          if-no-files-found: error

--- a/CosmosToSqlAssessment.csproj
+++ b/CosmosToSqlAssessment.csproj
@@ -35,6 +35,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="CosmosToSqlAssessment.Tests" />
+    <InternalsVisibleTo Include="CosmosToSqlAssessment.Benchmarks" />
   </ItemGroup>
 
 </Project>

--- a/CosmosToSqlAssessment.sln
+++ b/CosmosToSqlAssessment.sln
@@ -9,6 +9,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CosmosToSqlAssessment.Tests", "tests\CosmosToSqlAssessment.Tests\CosmosToSqlAssessment.Tests.csproj", "{C8F9E1B4-3D72-4A5E-B8C1-9F2E4D6A7B3C}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Performance", "Performance", "{59F13AC0-48F4-1EAA-233F-95B7C7A91E1D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CosmosToSqlAssessment.Benchmarks", "tests\Performance\CosmosToSqlAssessment.Benchmarks\CosmosToSqlAssessment.Benchmarks.csproj", "{D5D8613C-6FC3-4F48-A1B6-57E37F29A1BE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -43,11 +47,25 @@ Global
 		{C8F9E1B4-3D72-4A5E-B8C1-9F2E4D6A7B3C}.Release|x64.Build.0 = Release|Any CPU
 		{C8F9E1B4-3D72-4A5E-B8C1-9F2E4D6A7B3C}.Release|x86.ActiveCfg = Release|Any CPU
 		{C8F9E1B4-3D72-4A5E-B8C1-9F2E4D6A7B3C}.Release|x86.Build.0 = Release|Any CPU
+		{D5D8613C-6FC3-4F48-A1B6-57E37F29A1BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D5D8613C-6FC3-4F48-A1B6-57E37F29A1BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D5D8613C-6FC3-4F48-A1B6-57E37F29A1BE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D5D8613C-6FC3-4F48-A1B6-57E37F29A1BE}.Debug|x64.Build.0 = Debug|Any CPU
+		{D5D8613C-6FC3-4F48-A1B6-57E37F29A1BE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D5D8613C-6FC3-4F48-A1B6-57E37F29A1BE}.Debug|x86.Build.0 = Debug|Any CPU
+		{D5D8613C-6FC3-4F48-A1B6-57E37F29A1BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D5D8613C-6FC3-4F48-A1B6-57E37F29A1BE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D5D8613C-6FC3-4F48-A1B6-57E37F29A1BE}.Release|x64.ActiveCfg = Release|Any CPU
+		{D5D8613C-6FC3-4F48-A1B6-57E37F29A1BE}.Release|x64.Build.0 = Release|Any CPU
+		{D5D8613C-6FC3-4F48-A1B6-57E37F29A1BE}.Release|x86.ActiveCfg = Release|Any CPU
+		{D5D8613C-6FC3-4F48-A1B6-57E37F29A1BE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{C8F9E1B4-3D72-4A5E-B8C1-9F2E4D6A7B3C} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{59F13AC0-48F4-1EAA-233F-95B7C7A91E1D} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{D5D8613C-6FC3-4F48-A1B6-57E37F29A1BE} = {59F13AC0-48F4-1EAA-233F-95B7C7A91E1D}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/workflows/Build/badge.svg)](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/actions)
 [![CodeQL](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/workflows/CodeQL/badge.svg)](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/actions)
+[![Performance Regression](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/workflows/Performance%20Regression/badge.svg)](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/actions/workflows/performance-regression.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![.NET 8.0](https://img.shields.io/badge/.NET-8.0-purple.svg)](https://dotnet.microsoft.com/)
 
@@ -164,6 +165,7 @@ The tool supports multiple authentication methods through Azure DefaultAzureCred
 - ⚙️ [Configuration Options](docs/configuration.md)
 - 🏗️ [Architecture Details](docs/architecture.md)
 - 🔧 [Troubleshooting](docs/troubleshooting.md)
+- ⚡ [Performance Benchmarks](tests/Performance/CosmosToSqlAssessment.Benchmarks/README.md)
 
 ## 🤝 Contributing
 
@@ -337,6 +339,153 @@ The tool generates several outputs:
 - **Cost Optimization**: Detailed cost analysis and optimization suggestions
 - **Timeline Estimation**: Realistic migration duration estimates
 - **Regional Considerations**: Network and latency impact analysis
+
+## ⚡ Performance & Benchmarking
+
+The repository ships a BenchmarkDotNet harness under
+[`tests/Performance/CosmosToSqlAssessment.Benchmarks/`](tests/Performance/CosmosToSqlAssessment.Benchmarks/README.md)
+that covers the three hot paths in the assessment pipeline:
+
+- **Cosmos analysis** — JSON schema discovery, type mapping, array shape detection.
+- **SQL assessment** — the 8-phase migration-recommendation pipeline.
+- **Report generation** — Excel (ClosedXML) + Word (OpenXml) writes to disk.
+
+CI runs the harness on every PR to `main` and on every push to `main` that touches
+perf-relevant code (see the
+[`Performance Regression` workflow](.github/workflows/performance-regression.yml)).
+A regression-detection step compares each run against a tracked baseline; the job
+fails when any benchmark exceeds the configured tolerance. The harness's
+operational deep dive — quickstart, baseline schema, exit codes, CI seed/refresh
+workflow — lives in the [benchmarks project README](tests/Performance/CosmosToSqlAssessment.Benchmarks/README.md).
+
+### Running benchmarks locally
+
+> ⚠️ Always run benchmarks with `-c Release`. BenchmarkDotNet refuses to run a Debug build.
+
+List every benchmark:
+
+```bash
+dotnet run -c Release \
+  --project tests/Performance/CosmosToSqlAssessment.Benchmarks/CosmosToSqlAssessment.Benchmarks.csproj \
+  -- --list flat
+```
+
+Smoke check (single warmup + single iteration, seconds not minutes):
+
+```bash
+dotnet run -c Release \
+  --project tests/Performance/CosmosToSqlAssessment.Benchmarks/CosmosToSqlAssessment.Benchmarks.csproj \
+  -- --filter "*SmokeBenchmarks*" --job dry --warmupCount 1 --iterationCount 1
+```
+
+Real measurement (matches the CI configuration — minutes per benchmark class):
+
+```bash
+dotnet run -c Release \
+  --project tests/Performance/CosmosToSqlAssessment.Benchmarks/CosmosToSqlAssessment.Benchmarks.csproj \
+  -- --filter "*"
+```
+
+### Indicative allocation envelopes
+
+> The CI-enforced regression budgets live in
+> [`baselines/baseline.json`](tests/Performance/CosmosToSqlAssessment.Benchmarks/baselines/baseline.json)
+> once a maintainer seeds them from a representative CI run (tracked by #234).
+> The table below is a **bootstrap sizing guide, not an SLO** — values are from
+> single-iteration dry runs during initial development, rounded to one
+> significant figure, and intended to give a sense of order of magnitude.
+
+**Why allocated bytes and not mean?** Cosmos analysis is allocation-bound
+(JsonDocument parsing); SQL assessment and report generation are I/O-bound.
+Mean numbers vary significantly across hardware and shared-runner load, which
+makes them misleading to publish as project-wide targets. The harness still
+tracks mean against the seeded baseline; the `compare-baseline` CLI flags
+regressions on both axes.
+
+| Benchmark class | Scope | Allocated (Small → Medium → Large) | Notes |
+|---|---|---|---|
+| `SmokeBenchmarks.BuildAssessmentResult` | model construction | ~4 KB | not parameterised |
+| `CosmosAnalysisBenchmarks.ExtractFieldsFlat_Document` | flat-doc field extraction | ~4 KB → ~10 KB → ~20 KB | scales linearly |
+| `CosmosAnalysisBenchmarks.MapJsonTypeToSqlTypeEnhanced_Primitives` | type-mapping micro | constant, small | `OperationsPerInvoke=11` |
+| `CosmosAnalysisBenchmarks.AnalyzeArrayStructure_Tags` | tag-array shape | constant, small | not parameterised |
+| `CosmosAnalysisBenchmarks.AnalyzeArrayStructure_Objects` | object-array shape | constant, small | not parameterised |
+| `CosmosAnalysisBenchmarks.GetRecommendedSqlType_Mixed` | type-recommendation | constant, small | not parameterised |
+| `SqlAssessmentBenchmarks.AssessMigrationAsync_EndToEnd` | full SQL assessment | ~40 KB → ~250 KB → ~1 MB | 8-phase orchestration |
+| `SqlAssessmentBenchmarks.GenerateIndexScript_Bank` | index DDL generation | constant, small | `OperationsPerInvoke=100` |
+| `SqlAssessmentBenchmarks.SanitizeName_Bank` | identifier sanitisation | constant, small | `OperationsPerInvoke=100` |
+| `ReportGenerationBenchmarks.GenerateAssessmentReportAsync_EndToEnd` | Excel + Word write | ~4 MB → ~30 MB → ~340 MB | I/O-bound; high variance |
+| `ReportGenerationBenchmarks.SanitizeFileName_Bank` | filename sanitisation | constant, small | `OperationsPerInvoke=100` |
+| `ReportGenerationBenchmarks.CreateValidWorksheetName_Bank` | worksheet-name validation | constant, small | `OperationsPerInvoke=100` |
+
+### Regression detection
+
+> ⚠️ **The shipped `baselines/baseline.json` is empty**, which makes the CI
+> regression check an intentional no-op until a maintainer seeds it. Run the
+> `Performance Regression` workflow with `update_baseline=true` from the Actions
+> tab, review the `refreshed-baseline` artifact, and commit it in a follow-up PR.
+> See the [benchmarks README's seeding/refreshing section](tests/Performance/CosmosToSqlAssessment.Benchmarks/README.md#seeding--refreshing-the-baseline)
+> for the full walkthrough. Tracked by #234.
+
+The `compare-baseline` CLI fails a benchmark when:
+
+- `actualMean > baselineMean × toleranceFactor`, **or**
+- `actualAllocated > max(baselineAllocated × toleranceFactor, baselineAllocated + allocationFloorBytes)`
+
+Shipped defaults:
+
+| Setting | Value | Purpose |
+|---|---|---|
+| `defaultToleranceFactor` | `2.00` | 100% headroom on mean and allocated. **Intentionally loose** for first-day false-positive safety; see #234 for the path to the parent target of 1.10. |
+| `defaultAllocationFloorBytes` | `1024` | Protects near-zero baselines from brittle alarms. |
+
+Per-benchmark `toleranceFactor` overrides in `baselines/baseline.json` are
+preserved across `--update` runs, so micro-benchmarks (low variance) can be
+tightened toward `1.10` while I/O-bound macro-benchmarks (e.g.
+`ReportGenerationBenchmarks.GenerateAssessmentReportAsync_EndToEnd`) stay
+looser until a stable runner SKU is locked in. See #234 for the planned
+tightening rollout.
+
+`compare-baseline` exit codes:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | All compared benchmarks within tolerance (also returned for an empty baseline). |
+| `1` | At least one benchmark regressed. |
+| `2` | Bad invocation, missing/malformed files, or baseline-vs-report key drift. |
+
+### CI integration
+
+The [`Performance Regression`](.github/workflows/performance-regression.yml)
+workflow runs on:
+
+- Every pull request targeting `main` (no `paths:` filter — keeps the required
+  status check consistently reportable on every PR).
+- Every push to `main` that touches the benchmarks project, the main project's
+  services / models / SqlProject, the csproj/sln/`Program.cs`, or the workflow
+  file itself.
+- Manual `workflow_dispatch`, optionally with `update_baseline=true` to refresh
+  the tracked baseline (uploaded as a `refreshed-baseline` artifact — no
+  auto-commit; review and commit in a follow-up PR).
+
+Every run uploads the full `BenchmarkDotNet.Artifacts/` directory (HTML, CSV,
+JSON, log) as a `benchmark-artifacts` workflow artifact with 14-day retention.
+The badge at the top of this README reflects the latest default-branch run;
+immediately after the workflow first lands on `main` it may briefly show
+"no status" until the first push-to-`main` run completes.
+
+### Deferred parent acceptance criteria
+
+Two parent #79 acceptance criteria are intentionally deferred. Both have
+dedicated follow-up issues so the deferral is traceable:
+
+- **>10% degradation fails CI** — the shipped default is `2.00x` (100%
+  headroom). Tightening requires a seeded baseline and per-benchmark variance
+  characterisation on the CI runner. Tracked by **#234**.
+- **Benchmark results published to GitHub Pages** — the current design uploads
+  artifacts on every run (sufficient for inspection); a Pages dashboard
+  (`benchmark-action/github-action-benchmark` is the likely choice) is the
+  natural next step but requires `gh-pages` write permissions and a pinned
+  runner SKU. Tracked by **#233**.
 
 ## 🛠️ Troubleshooting
 

--- a/Reporting/ReportGenerationService.cs
+++ b/Reporting/ReportGenerationService.cs
@@ -119,7 +119,9 @@ namespace CosmosToSqlAssessment.Reporting
         /// <summary>
         /// Sanitizes a file name by removing invalid characters
         /// </summary>
-        private string SanitizeFileName(string fileName)
+        // internal static so the Benchmarks project can drive this hot string helper
+        // directly (parent #79 / #176). Pure: only uses Path.GetInvalidFileNameChars() + string ops.
+        internal static string SanitizeFileName(string fileName)
         {
             var invalidChars = Path.GetInvalidFileNameChars();
             var sanitized = string.Join("_", fileName.Split(invalidChars, StringSplitOptions.RemoveEmptyEntries));
@@ -2038,7 +2040,9 @@ namespace CosmosToSqlAssessment.Reporting
         /// <summary>
         /// Creates a valid Excel worksheet name that stays within Excel's constraints
         /// </summary>
-        private string CreateValidWorksheetName(string baseName, string suffix = "")
+        // internal static so the Benchmarks project can exercise the worksheet-name
+        // sanitiser directly (parent #79 / #176). Pure: char filtering + regex + length truncation.
+        internal static string CreateValidWorksheetName(string baseName, string suffix = "")
         {
             // Remove invalid characters for Excel worksheet names
             var invalidChars = new char[] { ':', '\\', '/', '?', '*', '[', ']' };

--- a/Services/CosmosDbAnalysisService.cs
+++ b/Services/CosmosDbAnalysisService.cs
@@ -793,7 +793,10 @@ namespace CosmosToSqlAssessment.Services
             }
         }
 
-        private void ExtractFieldsFlat(JsonElement element, string prefix, Dictionary<string, FieldInfo> fields)
+        // Pure recursive JSON traversal. Touches no instance state, so static. Exposed as
+        // internal so the benchmarks project (#174 / parent #79) can call it directly via
+        // [InternalsVisibleTo].
+        internal static void ExtractFieldsFlat(JsonElement element, string prefix, Dictionary<string, FieldInfo> fields)
         {
             switch (element.ValueKind)
             {
@@ -845,10 +848,10 @@ namespace CosmosToSqlAssessment.Services
             }
         }
 
-        /// <summary>
-        /// Analyzes array structure to determine optimal storage strategy
-        /// </summary>
-        private ArrayAnalysis AnalyzeArrayStructure(JsonElement arrayElement, string arrayName)
+        // Pure JSON-element-to-SQL-type mapping (and supporting helpers). Touch no instance
+        // state, so static. Exposed as internal so the benchmarks project (#174 / parent #79)
+        // can call them directly via [InternalsVisibleTo].
+        internal static ArrayAnalysis AnalyzeArrayStructure(JsonElement arrayElement, string arrayName)
         {
             var analysis = new ArrayAnalysis
             {
@@ -961,7 +964,7 @@ namespace CosmosToSqlAssessment.Services
             return analysis;
         }
 
-        private int CountObjectProperties(JsonElement objectElement)
+        internal static int CountObjectProperties(JsonElement objectElement)
         {
             try
             {
@@ -973,7 +976,7 @@ namespace CosmosToSqlAssessment.Services
             }
         }
 
-        private bool IsLikelyTagsOrCategories(string fieldName)
+        internal static bool IsLikelyTagsOrCategories(string fieldName)
         {
             var lowerName = fieldName.ToLowerInvariant();
             return lowerName.Contains("tag") || 
@@ -1162,7 +1165,7 @@ namespace CosmosToSqlAssessment.Services
             }
         }
 
-        private string MapJsonTypeToSqlType(JsonElement element)
+        internal static string MapJsonTypeToSqlType(JsonElement element)
         {
             return element.ValueKind switch
             {
@@ -1176,7 +1179,7 @@ namespace CosmosToSqlAssessment.Services
             };
         }
 
-        private string MapJsonTypeToSqlTypeEnhanced(JsonElement element)
+        internal static string MapJsonTypeToSqlTypeEnhanced(JsonElement element)
         {
             return element.ValueKind switch
             {
@@ -1190,7 +1193,7 @@ namespace CosmosToSqlAssessment.Services
             };
         }
 
-        private string AnalyzeStringType(JsonElement element)
+        internal static string AnalyzeStringType(JsonElement element)
         {
             var value = element.GetString();
             if (string.IsNullOrEmpty(value))
@@ -1215,7 +1218,7 @@ namespace CosmosToSqlAssessment.Services
             };
         }
 
-        private string AnalyzeNumberType(JsonElement element)
+        internal static string AnalyzeNumberType(JsonElement element)
         {
             if (element.TryGetInt32(out var intValue))
             {
@@ -1249,7 +1252,7 @@ namespace CosmosToSqlAssessment.Services
             return "DECIMAL(18,2)";
         }
 
-        private string GetRecommendedSqlType(List<string> detectedTypes)
+        internal static string GetRecommendedSqlType(List<string> detectedTypes)
         {
             if (!detectedTypes.Any())
                 return "NVARCHAR(MAX)";

--- a/Services/SqlProjectGenerationService.cs
+++ b/Services/SqlProjectGenerationService.cs
@@ -590,7 +590,9 @@ namespace CosmosToSqlAssessment.Services
         /// <summary>
         /// Generates an individual index creation script
         /// </summary>
-        private string GenerateIndexScript(IndexRecommendation indexRecommendation)
+        // internal static so the Benchmarks project can drive this string-builder hot path
+        // directly (parent #79 / #175). Pure: only touches its argument and a local StringBuilder.
+        internal static string GenerateIndexScript(IndexRecommendation indexRecommendation)
         {
             var script = new StringBuilder();
             
@@ -621,7 +623,9 @@ namespace CosmosToSqlAssessment.Services
         /// <summary>
         /// Sanitizes names for use in file system and SQL identifiers
         /// </summary>
-        private string SanitizeName(string name)
+        // internal static so the Benchmarks project can exercise the sanitiser directly
+        // (parent #79 / #175). Pure: only touches its string argument.
+        internal static string SanitizeName(string name)
         {
             if (string.IsNullOrWhiteSpace(name))
                 return "Database";

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/Benchmarks/CosmosAnalysisBenchmarks.cs
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/Benchmarks/CosmosAnalysisBenchmarks.cs
@@ -1,0 +1,155 @@
+using System.Text.Json;
+using BenchmarkDotNet.Attributes;
+using CosmosToSqlAssessment.Benchmarks.Fixtures;
+using CosmosToSqlAssessment.Models;
+using CosmosToSqlAssessment.Services;
+
+namespace CosmosToSqlAssessment.Benchmarks.Benchmarks;
+
+/// <summary>
+/// Microbenchmarks for the pure CPU-bound hot paths of
+/// <see cref="CosmosDbAnalysisService"/> — per-document JSON schema inference, SQL type
+/// mapping, and array-shape classification. These run against synthetic in-memory fixtures so
+/// no live Cosmos endpoint is required. Owned by parent #79 (performance benchmarking
+/// framework) / sub-issue #174.
+/// </summary>
+[MemoryDiagnoser]
+public class CosmosAnalysisBenchmarks
+{
+    // Owning JsonDocuments — held in fields so JsonElement views remain valid for the lifetime
+    // of the benchmark run. Disposed in [GlobalCleanup].
+    private JsonDocument? _smallDoc;
+    private JsonDocument? _mediumDoc;
+    private JsonDocument? _largeDoc;
+    private JsonDocument? _primitiveBank;
+    private JsonDocument? _tagArray;
+    private JsonDocument? _objectArray;
+
+    private JsonElement[] _primitives = Array.Empty<JsonElement>();
+    private JsonElement _documentRoot;
+    private JsonElement _tagArrayRoot;
+    private JsonElement _objectArrayRoot;
+    private List<string>[] _detectedTypeSamples = Array.Empty<List<string>>();
+
+    // Per-call cost reporting: BDN divides measured iteration time by this count, so the
+    // reported Mean is "per primitive mapping" rather than "per loop over the bank".
+    private const int PrimitivesPerInvocation = 11;
+
+    [Params(
+        JsonDocumentFixtures.DocumentSize.Small,
+        JsonDocumentFixtures.DocumentSize.Medium,
+        JsonDocumentFixtures.DocumentSize.Large)]
+    public JsonDocumentFixtures.DocumentSize Size { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _smallDoc = JsonDocumentFixtures.BuildDocument(JsonDocumentFixtures.DocumentSize.Small);
+        _mediumDoc = JsonDocumentFixtures.BuildDocument(JsonDocumentFixtures.DocumentSize.Medium);
+        _largeDoc = JsonDocumentFixtures.BuildDocument(JsonDocumentFixtures.DocumentSize.Large);
+        _primitiveBank = JsonDocumentFixtures.BuildPrimitiveBank();
+        _tagArray = JsonDocumentFixtures.BuildTagArray();
+        _objectArray = JsonDocumentFixtures.BuildObjectArray();
+
+        _primitives = _primitiveBank.RootElement.EnumerateArray().ToArray();
+        _tagArrayRoot = _tagArray.RootElement;
+        _objectArrayRoot = _objectArray.RootElement;
+        _detectedTypeSamples = JsonDocumentFixtures.BuildDetectedTypeSamples();
+
+        _documentRoot = Size switch
+        {
+            JsonDocumentFixtures.DocumentSize.Small => _smallDoc.RootElement,
+            JsonDocumentFixtures.DocumentSize.Medium => _mediumDoc.RootElement,
+            JsonDocumentFixtures.DocumentSize.Large => _largeDoc.RootElement,
+            _ => _smallDoc.RootElement
+        };
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _smallDoc?.Dispose();
+        _mediumDoc?.Dispose();
+        _largeDoc?.Dispose();
+        _primitiveBank?.Dispose();
+        _tagArray?.Dispose();
+        _objectArray?.Dispose();
+    }
+
+    /// <summary>
+    /// Measures the per-primitive cost of <see cref="CosmosDbAnalysisService.MapJsonTypeToSqlTypeEnhanced"/>.
+    /// Loops over the primitive bank inside the benchmark and uses
+    /// <see cref="BenchmarkAttribute.OperationsPerInvoke"/> so BDN reports cost per call.
+    /// </summary>
+    [Benchmark(OperationsPerInvoke = PrimitivesPerInvocation)]
+    public int MapJsonTypeToSqlTypeEnhanced_Primitives()
+    {
+        var digest = 0;
+        for (var i = 0; i < _primitives.Length; i++)
+        {
+            digest += CosmosDbAnalysisService.MapJsonTypeToSqlTypeEnhanced(_primitives[i]).Length;
+        }
+
+        return digest;
+    }
+
+    /// <summary>
+    /// Measures the recursive per-document field-extraction hot path. Allocates a fresh
+    /// dictionary per invocation so allocations attributable to the traversal are correctly
+    /// counted by MemoryDiagnoser.
+    /// </summary>
+    [Benchmark]
+    public int ExtractFieldsFlat_Document()
+    {
+        var fields = new Dictionary<string, FieldInfo>(capacity: 32);
+        CosmosDbAnalysisService.ExtractFieldsFlat(_documentRoot, string.Empty, fields);
+
+        // Digest that depends on both field count AND inferred types — catches accidental
+        // type-inference regressions, not just field-count drift.
+        var digest = fields.Count;
+        foreach (var field in fields.Values)
+        {
+            digest += field.DetectedTypes.Count;
+        }
+
+        return digest;
+    }
+
+    /// <summary>
+    /// Exercises the delimited-string branch of <see cref="CosmosDbAnalysisService.AnalyzeArrayStructure"/>
+    /// (string-only array whose name matches the tags/categories heuristic).
+    /// </summary>
+    [Benchmark]
+    public int AnalyzeArrayStructure_Tags()
+    {
+        var analysis = CosmosDbAnalysisService.AnalyzeArrayStructure(_tagArrayRoot, "categories");
+        return analysis.RecommendedStorage.Length + analysis.ItemCount;
+    }
+
+    /// <summary>
+    /// Exercises the complex-structure branch (object array → ShouldCreateTable = true).
+    /// </summary>
+    [Benchmark]
+    public int AnalyzeArrayStructure_Objects()
+    {
+        var analysis = CosmosDbAnalysisService.AnalyzeArrayStructure(_objectArrayRoot, "items");
+        return analysis.RecommendedStorage.Length + analysis.ItemCount;
+    }
+
+    /// <summary>
+    /// Exercises the priority-lookup logic in
+    /// <see cref="CosmosDbAnalysisService.GetRecommendedSqlType"/> across the representative
+    /// detected-type lists that the production code actually produces.
+    /// </summary>
+    [Benchmark]
+    public int GetRecommendedSqlType_Mixed()
+    {
+        var digest = 0;
+        for (var i = 0; i < _detectedTypeSamples.Length; i++)
+        {
+            digest += CosmosDbAnalysisService.GetRecommendedSqlType(_detectedTypeSamples[i]).Length;
+        }
+
+        return digest;
+    }
+}

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/Benchmarks/ReportGenerationBenchmarks.cs
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/Benchmarks/ReportGenerationBenchmarks.cs
@@ -1,0 +1,168 @@
+using BenchmarkDotNet.Attributes;
+using CosmosToSqlAssessment.Benchmarks.Fixtures;
+using CosmosToSqlAssessment.Models;
+using CosmosToSqlAssessment.Reporting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CosmosToSqlAssessment.Benchmarks.Benchmarks;
+
+/// <summary>
+/// Microbenchmarks for the report-generation pipeline exercised by parent #79 / #176.
+///
+/// Three benchmarks:
+/// * <see cref="GenerateAssessmentReportAsync_EndToEnd"/> — runs the full public
+///   <c>ReportGenerationService.GenerateAssessmentReportAsync</c> pipeline (Excel + Word writes to
+///   disk via ClosedXML and OpenXml) over Small / Medium / Large <see cref="AssessmentResult"/>
+///   fixtures.
+///
+///   This benchmark includes filesystem I/O and document serialisation, so wall-clock variance is
+///   higher than CPU-only benchmarks (filesystem cache, OS write-back, AV / indexer interference).
+///   Use it for large-regression detection (e.g. tracking trends across releases), not tight
+///   percentage comparisons between runs. <c>MemoryDiagnoser</c> captures managed allocation
+///   pressure only — native and filesystem-cache pressure are not measured.
+///
+///   The benchmark covers the single-database report path (fixture leaves
+///   <c>IndividualDatabaseResults</c> empty). A multi-database benchmark could be added as a
+///   follow-up if profiling shows different scaling characteristics.
+///
+/// * <see cref="SanitizeFileName_Bank"/> — pure-CPU bank loop over realistic database names.
+/// * <see cref="CreateValidWorksheetName_Bank"/> — pure-CPU bank loop covering every branch of
+///   the worksheet-name sanitiser (invalid chars, length > 31, "Multiple Databases (N)" regex,
+///   name + suffix truncation).
+///
+/// All three return a digest so BenchmarkDotNet cannot dead-code-eliminate the work.
+/// </summary>
+[MemoryDiagnoser]
+public class ReportGenerationBenchmarks
+{
+    private const int FileNamesPerInvoke = 100;
+    private const int WorksheetNamesPerInvoke = 100;
+
+    private ReportGenerationService _service = null!;
+    private AssessmentResult _smallResult = null!;
+    private AssessmentResult _mediumResult = null!;
+    private AssessmentResult _largeResult = null!;
+    private string[] _fileNameBank = null!;
+    private (string baseName, string suffix)[] _worksheetNameBank = null!;
+    private string _tempDir = null!;
+    private int _reportRunId;
+
+    [Params(SqlAssessmentFixtures.AnalysisSize.Small, SqlAssessmentFixtures.AnalysisSize.Medium, SqlAssessmentFixtures.AnalysisSize.Large)]
+    public SqlAssessmentFixtures.AnalysisSize Size { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        IConfiguration configuration = new ConfigurationBuilder().Build();
+        _service = new ReportGenerationService(configuration, NullLogger<ReportGenerationService>.Instance);
+
+        _smallResult = ReportGenerationFixtures.BuildAssessmentResult(SqlAssessmentFixtures.AnalysisSize.Small);
+        _mediumResult = ReportGenerationFixtures.BuildAssessmentResult(SqlAssessmentFixtures.AnalysisSize.Medium);
+        _largeResult = ReportGenerationFixtures.BuildAssessmentResult(SqlAssessmentFixtures.AnalysisSize.Large);
+
+        _fileNameBank = ReportGenerationFixtures.BuildFileNameInputs();
+        _worksheetNameBank = ReportGenerationFixtures.BuildWorksheetNameInputs();
+
+        _tempDir = Path.Combine(Path.GetTempPath(), $"cosmos-bench-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    [IterationCleanup(Target = nameof(GenerateAssessmentReportAsync_EndToEnd))]
+    public void CleanupRuns()
+    {
+        // Delete accumulated per-run subdirectories so disk usage stays bounded across BDN's
+        // many measurement iterations. Tolerant of transient AV / indexer file-handle locks.
+        try
+        {
+            if (!Directory.Exists(_tempDir))
+            {
+                return;
+            }
+
+            foreach (var subDir in Directory.EnumerateDirectories(_tempDir))
+            {
+                try
+                {
+                    Directory.Delete(subDir, recursive: true);
+                }
+                catch (IOException)
+                {
+                }
+                catch (UnauthorizedAccessException)
+                {
+                }
+            }
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    [GlobalCleanup]
+    public void Teardown()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    [Benchmark]
+    public string GenerateAssessmentReportAsync_EndToEnd()
+    {
+        // Unique per-invocation directory so each call writes to its own folder. Avoids the
+        // timestamp-collision bug in ReportGenerationService (folder name derived from
+        // DateTime.Now.ToString("yyyy-MM-dd__HH-mm-ss") — multiple iterations within the same
+        // second would otherwise overwrite each other and bias the measurement.
+        var runDir = Path.Combine(_tempDir, Interlocked.Increment(ref _reportRunId).ToString("D8"));
+
+        var fixture = Size switch
+        {
+            SqlAssessmentFixtures.AnalysisSize.Small => _smallResult,
+            SqlAssessmentFixtures.AnalysisSize.Medium => _mediumResult,
+            _ => _largeResult
+        };
+
+        var (_, wordPath, _) = _service.GenerateAssessmentReportAsync(fixture, runDir).GetAwaiter().GetResult();
+        return wordPath;
+    }
+
+    [Benchmark(OperationsPerInvoke = FileNamesPerInvoke)]
+    public int SanitizeFileName_Bank()
+    {
+        var digest = 0;
+        for (var i = 0; i < FileNamesPerInvoke; i++)
+        {
+            var input = _fileNameBank[i % _fileNameBank.Length];
+            var sanitized = ReportGenerationService.SanitizeFileName(input);
+            digest ^= sanitized.Length ^ (sanitized.Length > 0 ? sanitized[0] : 0) ^ (sanitized.Length > 0 ? sanitized[^1] : 0);
+        }
+        return digest;
+    }
+
+    [Benchmark(OperationsPerInvoke = WorksheetNamesPerInvoke)]
+    public int CreateValidWorksheetName_Bank()
+    {
+        var digest = 0;
+        for (var i = 0; i < WorksheetNamesPerInvoke; i++)
+        {
+            var (baseName, suffix) = _worksheetNameBank[i % _worksheetNameBank.Length];
+            var name = ReportGenerationService.CreateValidWorksheetName(baseName, suffix);
+            digest ^= name.Length ^ (name.Length > 0 ? name[0] : 0) ^ (name.Length > 0 ? name[^1] : 0);
+        }
+        return digest;
+    }
+}

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/Benchmarks/SmokeBenchmarks.cs
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/Benchmarks/SmokeBenchmarks.cs
@@ -1,0 +1,40 @@
+using BenchmarkDotNet.Attributes;
+using CosmosToSqlAssessment.Models;
+
+namespace CosmosToSqlAssessment.Benchmarks.Benchmarks;
+
+/// <summary>
+/// Harness smoke benchmark. Does not exercise any production hot path — its sole purpose is to
+/// prove that BenchmarkDotNet can discover and execute benchmarks and that the project
+/// reference to <c>CosmosToSqlAssessment</c> loads at runtime. Real service benchmarks live in
+/// sibling files added by the follow-up sub-issues (#174 Cosmos analysis, #175 SQL assessment,
+/// #176 report generation).
+/// </summary>
+[MemoryDiagnoser]
+public class SmokeBenchmarks
+{
+    private const int RecommendationCount = 16;
+
+    [Benchmark]
+    public int BuildAssessmentResult()
+    {
+        var result = new AssessmentResult
+        {
+            CosmosAccountName = "benchmark-account",
+            DatabaseName = "benchmark-db"
+        };
+
+        for (var i = 0; i < RecommendationCount; i++)
+        {
+            result.Recommendations.Add(new RecommendationItem
+            {
+                Title = $"Recommendation {i}",
+                Description = "Smoke-test recommendation used only to exercise the model graph.",
+                Priority = "Low",
+                Category = "Smoke"
+            });
+        }
+
+        return result.Recommendations.Count;
+    }
+}

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/Benchmarks/SqlAssessmentBenchmarks.cs
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/Benchmarks/SqlAssessmentBenchmarks.cs
@@ -1,0 +1,100 @@
+using BenchmarkDotNet.Attributes;
+using CosmosToSqlAssessment.Benchmarks.Fixtures;
+using CosmosToSqlAssessment.Models;
+using CosmosToSqlAssessment.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CosmosToSqlAssessment.Benchmarks.Benchmarks;
+
+/// <summary>
+/// Microbenchmarks for the SQL assessment hot paths exercised by parent #79 / #175.
+///
+/// Three benchmarks:
+/// * <see cref="AssessMigrationAsync_EndToEnd"/> — runs the full public
+///   <c>SqlMigrationAssessmentService.AssessMigrationAsync</c> pipeline (platform recommendation,
+///   container mappings, schema deduplication, index / FK / unique constraint generation,
+///   complexity assessment, transformation rules) over Small / Medium / Large
+///   <see cref="CosmosDbAnalysis"/> fixtures. This is the public-API cost users care about; the
+///   measurement includes <c>NullLogger</c> extension-method boxing, which is intentional.
+/// * <see cref="GenerateIndexScript_Bank"/> — loops over a fixed bank of
+///   <see cref="IndexRecommendation"/>s exercising every branch in
+///   <c>SqlProjectGenerationService.GenerateIndexScript</c> (each index type, with and without
+///   <c>IncludedColumns</c>).
+/// * <see cref="SanitizeName_Bank"/> — loops over a fixed bank of db/container names
+///   exercising every branch in <c>SqlProjectGenerationService.SanitizeName</c>.
+///
+/// All three return a digest so BenchmarkDotNet cannot dead-code-eliminate the work.
+/// </summary>
+[MemoryDiagnoser]
+public class SqlAssessmentBenchmarks
+{
+    private const int IndexScriptsPerInvoke = 100;
+    private const int SanitizeNamesPerInvoke = 100;
+
+    private SqlMigrationAssessmentService _service = null!;
+    private CosmosDbAnalysis _smallAnalysis = null!;
+    private CosmosDbAnalysis _mediumAnalysis = null!;
+    private CosmosDbAnalysis _largeAnalysis = null!;
+    private IndexRecommendation[] _indexBank = null!;
+    private string[] _nameBank = null!;
+
+    [Params(SqlAssessmentFixtures.AnalysisSize.Small, SqlAssessmentFixtures.AnalysisSize.Medium, SqlAssessmentFixtures.AnalysisSize.Large)]
+    public SqlAssessmentFixtures.AnalysisSize Size { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        IConfiguration configuration = new ConfigurationBuilder().Build();
+        _service = new SqlMigrationAssessmentService(configuration, NullLogger<SqlMigrationAssessmentService>.Instance);
+
+        _smallAnalysis = SqlAssessmentFixtures.BuildCosmosAnalysis(SqlAssessmentFixtures.AnalysisSize.Small);
+        _mediumAnalysis = SqlAssessmentFixtures.BuildCosmosAnalysis(SqlAssessmentFixtures.AnalysisSize.Medium);
+        _largeAnalysis = SqlAssessmentFixtures.BuildCosmosAnalysis(SqlAssessmentFixtures.AnalysisSize.Large);
+
+        _indexBank = SqlAssessmentFixtures.BuildIndexRecommendations();
+        _nameBank = SqlAssessmentFixtures.BuildSanitizeNameInputs();
+    }
+
+    [Benchmark]
+    public SqlMigrationAssessment AssessMigrationAsync_EndToEnd()
+    {
+        var fixture = Size switch
+        {
+            SqlAssessmentFixtures.AnalysisSize.Small => _smallAnalysis,
+            SqlAssessmentFixtures.AnalysisSize.Medium => _mediumAnalysis,
+            _ => _largeAnalysis
+        };
+
+        // AssessMigrationAsync is synchronous-internally (returns Task.FromResult). Using
+        // GetAwaiter().GetResult() measures exactly the work the service does without adding
+        // async-state-machine noise from an `async Task<T>` benchmark wrapper.
+        return _service.AssessMigrationAsync(fixture, "BenchmarkDb").GetAwaiter().GetResult();
+    }
+
+    [Benchmark(OperationsPerInvoke = IndexScriptsPerInvoke)]
+    public int GenerateIndexScript_Bank()
+    {
+        var digest = 0;
+        for (var i = 0; i < IndexScriptsPerInvoke; i++)
+        {
+            var rec = _indexBank[i % _indexBank.Length];
+            var script = SqlProjectGenerationService.GenerateIndexScript(rec);
+            digest ^= script.Length;
+        }
+        return digest;
+    }
+
+    [Benchmark(OperationsPerInvoke = SanitizeNamesPerInvoke)]
+    public int SanitizeName_Bank()
+    {
+        var digest = 0;
+        for (var i = 0; i < SanitizeNamesPerInvoke; i++)
+        {
+            var name = _nameBank[i % _nameBank.Length];
+            var sanitized = SqlProjectGenerationService.SanitizeName(name);
+            digest ^= sanitized.Length;
+        }
+        return digest;
+    }
+}

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/CosmosToSqlAssessment.Benchmarks.csproj
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/CosmosToSqlAssessment.Benchmarks.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>CosmosToSqlAssessment.Benchmarks</RootNamespace>
+    <AssemblyName>CosmosToSqlAssessment.Benchmarks</AssemblyName>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\CosmosToSqlAssessment.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/Fixtures/JsonDocumentFixtures.cs
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/Fixtures/JsonDocumentFixtures.cs
@@ -1,0 +1,232 @@
+using System.Text;
+using System.Text.Json;
+
+namespace CosmosToSqlAssessment.Benchmarks.Fixtures;
+
+/// <summary>
+/// Deterministic synthetic <see cref="JsonDocument"/> generator used by the Cosmos analysis
+/// benchmarks. Document sizes are calibrated to be representative of real Cosmos workloads
+/// without ballooning benchmark run time. Generators are deterministic (seeded loops, no
+/// <see cref="Random"/>) so benchmark results are reproducible across runs.
+/// </summary>
+public static class JsonDocumentFixtures
+{
+    public enum DocumentSize
+    {
+        Small,
+        Medium,
+        Large
+    }
+
+    /// <summary>
+    /// Returns a parsed <see cref="JsonDocument"/>. Callers own the document and must dispose it.
+    /// </summary>
+    public static JsonDocument BuildDocument(DocumentSize size)
+    {
+        var json = size switch
+        {
+            DocumentSize.Small => BuildSmallJson(),
+            DocumentSize.Medium => BuildMediumJson(),
+            DocumentSize.Large => BuildLargeJson(),
+            _ => throw new ArgumentOutOfRangeException(nameof(size))
+        };
+
+        return JsonDocument.Parse(json);
+    }
+
+    /// <summary>
+    /// Builds a parsed JSON array of mixed primitive values used by the type-mapping benchmark.
+    /// Caller owns the document.
+    /// </summary>
+    public static JsonDocument BuildPrimitiveBank()
+    {
+        return JsonDocument.Parse(
+            """
+            [
+              "short string",
+              "this is a moderately longer string used to push the AnalyzeStringType length switch",
+              "8f14e45f-ceea-467a-9575-d5b3c4ed83f3",
+              "2024-09-15T08:30:00Z",
+              42,
+              2147483648,
+              3.14159,
+              123.4567,
+              true,
+              false,
+              null
+            ]
+            """);
+    }
+
+    /// <summary>
+    /// Returns a tag-style array (string primitives, names matching the
+    /// IsLikelyTagsOrCategories heuristic) used by the array-structure benchmark.
+    /// </summary>
+    public static JsonDocument BuildTagArray()
+    {
+        return JsonDocument.Parse(
+            """
+            ["billing","marketing","ops","support","engineering","legal","hr","finance"]
+            """);
+    }
+
+    /// <summary>
+    /// Returns an object array used by the array-structure benchmark to exercise the
+    /// complex-structure branch (each item is an object → ShouldCreateTable = true).
+    /// </summary>
+    public static JsonDocument BuildObjectArray()
+    {
+        return JsonDocument.Parse(
+            """
+            [
+              {"id": 1, "label": "alpha", "weight": 1.1},
+              {"id": 2, "label": "beta",  "weight": 2.2},
+              {"id": 3, "label": "gamma", "weight": 3.3},
+              {"id": 4, "label": "delta", "weight": 4.4},
+              {"id": 5, "label": "epsilon","weight": 5.5}
+            ]
+            """);
+    }
+
+    /// <summary>
+    /// Representative detected-type lists matching what AnalyzeStringType /
+    /// AnalyzeNumberType actually emit in production. Used by the GetRecommendedSqlType
+    /// benchmark.
+    /// </summary>
+    public static List<string>[] BuildDetectedTypeSamples()
+    {
+        return new[]
+        {
+            new List<string> { "NVARCHAR(50)" },
+            new List<string> { "NVARCHAR(50)", "NVARCHAR(255)" },
+            new List<string> { "TINYINT", "SMALLINT", "INT" },
+            new List<string> { "DECIMAL(18,2)", "DECIMAL(18,4)" },
+            new List<string> { "DATETIME2" },
+            new List<string> { "UNIQUEIDENTIFIER" },
+            new List<string> { "BIT" },
+            new List<string> { "NVARCHAR(MAX)" }
+        };
+    }
+
+    private static string BuildSmallJson()
+    {
+        // 5 simple top-level fields; no nesting; no arrays.
+        return """
+            {
+              "id": "doc-1",
+              "name": "Acme widget",
+              "createdAt": "2024-09-15T08:30:00Z",
+              "quantity": 17,
+              "active": true
+            }
+            """;
+    }
+
+    private static string BuildMediumJson()
+    {
+        // ~22 fields, 2 levels of nesting, one small array.
+        return """
+            {
+              "id": "doc-medium-2",
+              "tenantId": "8f14e45f-ceea-467a-9575-d5b3c4ed83f3",
+              "name": "Wholesale order",
+              "description": "Medium fixture exercising the recursive object traversal path.",
+              "createdAt": "2024-09-15T08:30:00Z",
+              "updatedAt": "2024-09-15T12:01:00Z",
+              "status": "shipped",
+              "total": 1247.95,
+              "currency": "USD",
+              "lineCount": 14,
+              "isPriority": false,
+              "customer": {
+                "customerId": "C-9281",
+                "displayName": "Globex Corporation",
+                "tier": "Gold",
+                "address": {
+                  "street": "742 Evergreen Terrace",
+                  "city": "Springfield",
+                  "state": "IL",
+                  "postalCode": "62704",
+                  "country": "USA"
+                }
+              },
+              "shipping": {
+                "carrier": "UPS",
+                "service": "Ground",
+                "trackingCode": "1Z999AA10123456784"
+              },
+              "tags": ["billing","priority","international","oversized"]
+            }
+            """;
+    }
+
+    private static string BuildLargeJson()
+    {
+        // ~100 fields with deep nesting and several arrays. Built programmatically so it stays
+        // representative without bloating the test source. Deterministic — no Random.
+        var builder = new StringBuilder(8192);
+        builder.Append('{');
+        for (var i = 0; i < 40; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append(',');
+            }
+            builder.Append('"').Append("field").Append(i).Append("\":");
+            switch (i % 6)
+            {
+                case 0:
+                    builder.Append('"').Append("string-value-").Append(i).Append('"');
+                    break;
+                case 1:
+                    builder.Append(i * 17);
+                    break;
+                case 2:
+                    builder.Append((i * 0.5).ToString("0.0", System.Globalization.CultureInfo.InvariantCulture));
+                    break;
+                case 3:
+                    builder.Append(i % 2 == 0 ? "true" : "false");
+                    break;
+                case 4:
+                    builder.Append('"').Append("2024-09-15T08:30:0").Append(i % 10).Append("Z\"");
+                    break;
+                case 5:
+                    builder.Append('"').Append("8f14e45f-ceea-467a-9575-d5b3c4ed83f").Append(i % 10).Append('"');
+                    break;
+            }
+        }
+
+        // Nested object 5 levels deep.
+        builder.Append(",\"nested\":");
+        for (var depth = 0; depth < 5; depth++)
+        {
+            builder.Append("{\"level").Append(depth).Append("\":");
+        }
+        builder.Append("\"leaf-value\"");
+        for (var depth = 0; depth < 5; depth++)
+        {
+            builder.Append('}');
+        }
+
+        // Object array (10 items).
+        builder.Append(",\"items\":[");
+        for (var i = 0; i < 10; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append(',');
+            }
+            builder.Append("{\"sku\":\"SKU-").Append(i).Append("\",\"qty\":").Append(i + 1)
+                .Append(",\"unitPrice\":")
+                .Append((9.99 + i).ToString("0.00", System.Globalization.CultureInfo.InvariantCulture))
+                .Append('}');
+        }
+        builder.Append(']');
+
+        // Tag array.
+        builder.Append(",\"categories\":[\"alpha\",\"beta\",\"gamma\",\"delta\",\"epsilon\"]");
+
+        builder.Append('}');
+        return builder.ToString();
+    }
+}

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/Fixtures/ReportGenerationFixtures.cs
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/Fixtures/ReportGenerationFixtures.cs
@@ -1,0 +1,168 @@
+using CosmosToSqlAssessment.Models;
+using CosmosToSqlAssessment.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CosmosToSqlAssessment.Benchmarks.Fixtures;
+
+/// <summary>
+/// Deterministic synthetic fixtures for the report-generation benchmarks. Reuses
+/// <see cref="SqlAssessmentFixtures.BuildCosmosAnalysis"/> for the Cosmos-side shape and runs
+/// <see cref="SqlMigrationAssessmentService.AssessMigrationAsync"/> once per size to produce a
+/// realistic <see cref="SqlMigrationAssessment"/>. The resulting <see cref="AssessmentResult"/>
+/// has a fixed <c>AssessmentId</c> so re-runs are stable.
+/// </summary>
+public static class ReportGenerationFixtures
+{
+    public static AssessmentResult BuildAssessmentResult(SqlAssessmentFixtures.AnalysisSize size)
+    {
+        var cosmosAnalysis = SqlAssessmentFixtures.BuildCosmosAnalysis(size);
+
+        IConfiguration configuration = new ConfigurationBuilder().Build();
+        var sqlService = new SqlMigrationAssessmentService(configuration, NullLogger<SqlMigrationAssessmentService>.Instance);
+        var sqlAssessment = sqlService.AssessMigrationAsync(cosmosAnalysis, $"BenchmarkDb_{size}").GetAwaiter().GetResult();
+
+        return new AssessmentResult
+        {
+            AssessmentId = $"benchmark-{size}-00000000-0000-0000-0000-000000000000",
+            AssessmentDate = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc),
+            CosmosAccountName = "benchmark-cosmos-account",
+            DatabaseName = $"BenchmarkDb_{size}",
+            CosmosAnalysis = cosmosAnalysis,
+            SqlAssessment = sqlAssessment,
+            DataFactoryEstimate = BuildDataFactoryEstimate(size),
+            Recommendations = BuildRecommendations()
+        };
+    }
+
+    private static DataFactoryEstimate BuildDataFactoryEstimate(SqlAssessmentFixtures.AnalysisSize size)
+    {
+        // The Migration Estimates worksheet renders aggregate fields plus Prerequisites and
+        // Recommendations — PipelineEstimates is not currently iterated by the service, so keep
+        // it minimal and pad the rendered lists instead.
+        var scale = size switch
+        {
+            SqlAssessmentFixtures.AnalysisSize.Small => 1,
+            SqlAssessmentFixtures.AnalysisSize.Medium => 5,
+            _ => 20
+        };
+
+        return new DataFactoryEstimate
+        {
+            EstimatedDuration = TimeSpan.FromHours(2 * scale),
+            TotalDataSizeGB = 10 * scale,
+            RecommendedDIUs = 4 + scale,
+            RecommendedParallelCopies = Math.Min(8, 2 + scale),
+            EstimatedCostUSD = 15.50m * scale,
+            PipelineEstimates = new List<PipelineEstimate>
+            {
+                new()
+                {
+                    SourceContainer = "container_000",
+                    TargetTable = "container_000",
+                    DataSizeGB = 5,
+                    EstimatedDuration = TimeSpan.FromHours(1),
+                    RequiresTransformation = true,
+                    TransformationComplexity = "Medium"
+                }
+            },
+            Prerequisites = new List<string>
+            {
+                "Azure Data Factory instance provisioned in the target subscription",
+                "Source Cosmos DB account configured with read permissions for the integration runtime",
+                "Target Azure SQL Database created with sufficient compute tier",
+                "Network connectivity validated between source, ADF, and target",
+                "Service principal or managed identity configured for credential-free access",
+                "Monitoring and alerting endpoints established"
+            },
+            Recommendations = new List<string>
+            {
+                "Use incremental copy patterns for large containers exceeding 50 GB",
+                "Monitor RU consumption on source during migration windows",
+                "Enable staging tables for transformation-heavy migrations",
+                "Schedule migration runs during low-traffic windows",
+                "Validate row counts and aggregate checksums post-migration",
+                "Plan rollback procedures before cutover"
+            }
+        };
+    }
+
+    private static List<RecommendationItem> BuildRecommendations()
+    {
+        return new List<RecommendationItem>
+        {
+            new()
+            {
+                Category = "Performance",
+                Title = "Tune indexing strategy",
+                Description = "Review query patterns and add covering indexes for the top 10 most-frequent queries.",
+                Priority = "High",
+                Impact = "Reduces per-request RU consumption by 30-50%",
+                ActionItems = new List<string> { "Capture query metrics", "Generate index DDL", "Test in staging" }
+            },
+            new()
+            {
+                Category = "Schema",
+                Title = "Normalize nested collections",
+                Description = "Identified nested arrays that should become separate tables for relational integrity.",
+                Priority = "Medium",
+                Impact = "Improves query performance and reduces storage overhead",
+                ActionItems = new List<string> { "Identify nested arrays", "Design child-table DDL", "Plan migration cutover" }
+            },
+            new()
+            {
+                Category = "Security",
+                Title = "Enable Azure SQL Auditing",
+                Description = "Configure auditing to track database events and identify anomalies.",
+                Priority = "High",
+                Impact = "Strengthens compliance posture",
+                ActionItems = new List<string> { "Enable auditing", "Configure log retention", "Set up alerts" }
+            }
+        };
+    }
+
+    /// <summary>
+    /// Bank of realistic database names exercising every branch of
+    /// <c>ReportGenerationService.SanitizeFileName</c>: whitespace, invalid filesystem chars,
+    /// leading dot, mixed-case Unicode.
+    /// </summary>
+    public static string[] BuildFileNameInputs()
+    {
+        return new[]
+        {
+            "CustomersDB",
+            "Customer Profiles",
+            "orders/archive",
+            "tenant:billing",
+            ".hidden_db",
+            "audit\\logs",
+            "data?store",
+            "results*final",
+            "report<draft>",
+            "MultiTenant DB (prod)"
+        };
+    }
+
+    /// <summary>
+    /// Bank of realistic worksheet names exercising every branch of
+    /// <c>ReportGenerationService.CreateValidWorksheetName</c>: short names, invalid Excel chars,
+    /// long names &gt; 31 chars, the "Multiple Databases (N)" regex pattern, and name + suffix
+    /// pairs that trigger truncation.
+    /// </summary>
+    public static (string baseName, string suffix)[] BuildWorksheetNameInputs()
+    {
+        return new (string, string)[]
+        {
+            ("Summary", ""),
+            ("Container:001", ""),
+            ("ImportPath/Settings", "Details"),
+            ("ThisIsAReallyLongWorksheetNameThatExceedsThirtyOneChars", ""),
+            ("ThisIsAReallyLongWorksheetNameThatExceedsThirtyOneChars", "Indexes"),
+            ("Multiple Databases (11)", ""),
+            ("Multiple Databases (3)", "Summary"),
+            ("Multiple Databases (42)", "VeryLongSuffixThatNeedsTruncating"),
+            ("ShortName", "MediumSuffix"),
+            ("Audit[Logs]?", "X")
+        };
+    }
+}

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/Fixtures/SqlAssessmentFixtures.cs
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/Fixtures/SqlAssessmentFixtures.cs
@@ -1,0 +1,377 @@
+using CosmosToSqlAssessment.Models;
+
+namespace CosmosToSqlAssessment.Benchmarks.Fixtures;
+
+/// <summary>
+/// Deterministic synthetic fixtures used by the SQL assessment benchmarks. Generators are
+/// seeded loops (no <see cref="Random"/>) so benchmark results are reproducible across runs.
+/// Sizing is calibrated to exercise the full <c>SqlMigrationAssessmentService</c> pipeline —
+/// platform recommendation, container mappings, schema deduplication, index / FK / unique
+/// constraint generation, complexity assessment, and transformation rules — without ballooning
+/// benchmark run time.
+///
+/// Important: <c>DeduplicateSchemas</c> operates on <c>ChildTableMapping</c> instances (not
+/// top-level container schemas), so Medium and Large fixtures deliberately share a handful of
+/// common child-table shapes across containers (<c>addresses</c>, <c>contacts</c>,
+/// <c>lineItems</c>, <c>tags</c>) — that mix of shared + distinct child tables is what real
+/// workloads look like and is what makes the dedupe branch do meaningful work.
+/// </summary>
+public static class SqlAssessmentFixtures
+{
+    public enum AnalysisSize
+    {
+        Small,
+        Medium,
+        Large
+    }
+
+    public static CosmosDbAnalysis BuildCosmosAnalysis(AnalysisSize size)
+    {
+        var (containerCount, schemasPerContainer, fieldsPerSchema, sharedChildRatio) = size switch
+        {
+            AnalysisSize.Small => (1, 2, 5, 0.0),
+            AnalysisSize.Medium => (5, 3, 15, 0.5),
+            AnalysisSize.Large => (20, 5, 30, 0.4),
+            _ => throw new ArgumentOutOfRangeException(nameof(size))
+        };
+
+        var analysis = new CosmosDbAnalysis
+        {
+            DatabaseMetrics = new DatabaseMetrics
+            {
+                TotalDocuments = containerCount * 1_000_000L,
+                TotalSizeBytes = containerCount * 10_000_000_000L,
+                ContainerCount = containerCount,
+                ConsistencyLevel = "Session",
+                IsServerlessAccount = false,
+                ProvisionedThroughput = 4000
+            },
+            PerformanceMetrics = BuildPerformanceMetrics(containerCount)
+        };
+
+        for (var c = 0; c < containerCount; c++)
+        {
+            analysis.Containers.Add(BuildContainer(c, schemasPerContainer, fieldsPerSchema, sharedChildRatio));
+        }
+
+        return analysis;
+    }
+
+    private static ContainerAnalysis BuildContainer(int containerIndex, int schemaCount, int fieldsPerSchema, double sharedChildRatio)
+    {
+        var containerName = $"container_{containerIndex:D3}";
+
+        var container = new ContainerAnalysis
+        {
+            ContainerName = containerName,
+            DocumentCount = 500_000 + containerIndex * 50_000,
+            SizeBytes = 5_000_000_000L + containerIndex * 250_000_000L,
+            PartitionKey = "/tenantId",
+            ProvisionedRUs = 400,
+            IndexingPolicy = BuildIndexingPolicy(containerIndex),
+            Performance = BuildContainerPerformance(containerIndex)
+        };
+
+        for (var s = 0; s < schemaCount; s++)
+        {
+            container.DetectedSchemas.Add(BuildSchema(containerName, s, fieldsPerSchema, schemaCount));
+        }
+
+        // Shared child tables exercise DeduplicateSchemas. Pick from a fixed catalog so identical
+        // shapes recur across containers.
+        var sharedCatalog = SharedChildCatalog();
+        var useShared = containerIndex < (int)Math.Round(sharedChildRatio * 10);
+        if (useShared)
+        {
+            var sharedName = sharedCatalog[containerIndex % sharedCatalog.Length];
+            container.ChildTables[sharedName] = BuildSharedChildTable(sharedName);
+        }
+
+        // Plus one container-unique child table so distinct-schema bookkeeping also runs.
+        container.ChildTables[$"{containerName}_audit"] = BuildUniqueChildTable($"{containerName}_audit");
+
+        return container;
+    }
+
+    private static string[] SharedChildCatalog() => new[] { "addresses", "contacts", "lineItems", "tags" };
+
+    private static DocumentSchema BuildSchema(string containerName, int schemaIndex, int fieldCount, int totalSchemas)
+    {
+        var schema = new DocumentSchema
+        {
+            SchemaName = $"{containerName}_schema_{schemaIndex:D2}",
+            SampleCount = 100 + schemaIndex * 10,
+            Prevalence = 1.0 - (double)schemaIndex / Math.Max(totalSchemas, 1)
+        };
+
+        for (var f = 0; f < fieldCount; f++)
+        {
+            var fieldName = $"{containerName}_field_{schemaIndex:D2}_{f:D2}";
+            schema.Fields[fieldName] = BuildField(fieldName, f);
+        }
+
+        // Include a nested field marker so non-trivial mapping paths run.
+        var nestedName = $"{containerName}_profile_{schemaIndex:D2}";
+        schema.Fields[nestedName] = new FieldInfo
+        {
+            FieldName = nestedName,
+            DetectedTypes = new List<string> { "object" },
+            RecommendedSqlType = "NVARCHAR(MAX)",
+            IsRequired = false,
+            IsNested = true,
+            MaxLength = 0,
+            Selectivity = 0.5
+        };
+
+        return schema;
+    }
+
+    private static FieldInfo BuildField(string fieldName, int fieldIndex)
+    {
+        // Rotate across primitive types so type-mapping and business-key detection both have data.
+        var (types, sqlType, maxLength, selectivity) = (fieldIndex % 5) switch
+        {
+            0 => (new List<string> { "string" }, "NVARCHAR(255)", 255, 0.95),
+            1 => (new List<string> { "integer" }, "BIGINT", 0, 0.85),
+            2 => (new List<string> { "number" }, "DECIMAL(18,2)", 0, 0.75),
+            3 => (new List<string> { "boolean" }, "BIT", 0, 0.10),
+            _ => (new List<string> { "string" }, "NVARCHAR(100)", 100, 0.99)
+        };
+
+        return new FieldInfo
+        {
+            FieldName = fieldName,
+            DetectedTypes = types,
+            RecommendedSqlType = sqlType,
+            IsRequired = fieldIndex % 3 == 0,
+            IsNested = false,
+            MaxLength = maxLength,
+            Selectivity = selectivity
+        };
+    }
+
+    private static ChildTableSchema BuildSharedChildTable(string name)
+    {
+        // Same field layout for the same name across containers → DeduplicateSchemas can collapse.
+        var table = new ChildTableSchema
+        {
+            TableName = name,
+            SourceFieldPath = name,
+            ChildTableType = "Array",
+            SampleCount = 250,
+            ParentKeyField = "ParentId"
+        };
+
+        table.Fields["id"] = SharedField("id", "string", "NVARCHAR(100)", 100, true);
+        table.Fields["label"] = SharedField("label", "string", "NVARCHAR(255)", 255, false);
+        table.Fields["value"] = SharedField("value", "string", "NVARCHAR(500)", 500, false);
+        table.Fields["sortOrder"] = SharedField("sortOrder", "integer", "INT", 0, false);
+
+        return table;
+    }
+
+    private static ChildTableSchema BuildUniqueChildTable(string name)
+    {
+        var table = new ChildTableSchema
+        {
+            TableName = name,
+            SourceFieldPath = name,
+            ChildTableType = "Array",
+            SampleCount = 100,
+            ParentKeyField = "ParentId"
+        };
+
+        // Unique fields force each instance into its own SharedSchema group.
+        table.Fields[$"{name}_id"] = SharedField($"{name}_id", "string", "NVARCHAR(100)", 100, true);
+        table.Fields[$"{name}_event"] = SharedField($"{name}_event", "string", "NVARCHAR(255)", 255, false);
+        table.Fields[$"{name}_at"] = SharedField($"{name}_at", "string", "NVARCHAR(50)", 50, false);
+
+        return table;
+    }
+
+    private static FieldInfo SharedField(string name, string type, string sqlType, int maxLength, bool required)
+    {
+        return new FieldInfo
+        {
+            FieldName = name,
+            DetectedTypes = new List<string> { type },
+            RecommendedSqlType = sqlType,
+            IsRequired = required,
+            IsNested = false,
+            MaxLength = maxLength,
+            Selectivity = required ? 1.0 : 0.7
+        };
+    }
+
+    private static ContainerIndexingPolicy BuildIndexingPolicy(int containerIndex)
+    {
+        var policy = new ContainerIndexingPolicy
+        {
+            IncludedPaths = new List<string> { "/*" },
+            ExcludedPaths = new List<string> { "/_etag/?" }
+        };
+
+        // One composite index per container so GenerateIndexRecommendations has something to mine.
+        policy.CompositeIndexes.Add(new CompositeIndex
+        {
+            Paths = new List<IndexPath>
+            {
+                new() { Path = "/tenantId" },
+                new() { Path = $"/field_{containerIndex % 5}" }
+            }
+        });
+
+        return policy;
+    }
+
+    private static ContainerPerformanceMetrics BuildContainerPerformance(int containerIndex)
+    {
+        var perf = new ContainerPerformanceMetrics
+        {
+            AverageRUConsumption = 10.0 + containerIndex,
+            PeakRUConsumption = 50.0 + containerIndex * 5,
+            AverageLatencyMs = 5.0 + containerIndex * 0.1,
+            TotalRequestCount = 1_000_000 + containerIndex * 100_000,
+            ThrottlingRate = 0.01
+        };
+
+        // Two query patterns per container so GenerateQueryBasedIndexRecommendation has work.
+        perf.TopQueries[$"query_{containerIndex}_a"] = new QueryMetrics
+        {
+            QueryPattern = "SELECT * FROM c WHERE c.tenantId = @id AND c.status = 'active'",
+            ExecutionCount = 50_000 + containerIndex * 1_000,
+            AverageRUs = 5.5,
+            AverageLatencyMs = 8.2
+        };
+
+        perf.TopQueries[$"query_{containerIndex}_b"] = new QueryMetrics
+        {
+            QueryPattern = "SELECT * FROM c WHERE c.createdAt > @since",
+            ExecutionCount = 20_000 + containerIndex * 500,
+            AverageRUs = 9.1,
+            AverageLatencyMs = 12.5
+        };
+
+        return perf;
+    }
+
+    private static PerformanceMetrics BuildPerformanceMetrics(int containerCount)
+    {
+        return new PerformanceMetrics
+        {
+            AnalysisPeriod = new TimeRange
+            {
+                StartTime = DateTime.UtcNow.AddDays(-180),
+                EndTime = DateTime.UtcNow
+            },
+            TotalRUConsumption = 1_000_000 * containerCount,
+            AverageRUsPerSecond = 15.5,
+            PeakRUsPerSecond = 100.0,
+            AverageRequestLatencyMs = 10.5,
+            TotalRequests = 5_000_000L * containerCount,
+            ErrorRate = 0.001,
+            ThrottlingRate = 0.01
+        };
+    }
+
+    /// <summary>
+    /// Bank of representative <see cref="IndexRecommendation"/> instances covering every branch
+    /// in <c>SqlProjectGenerationService.GenerateIndexScript</c>: each index type (NonClustered,
+    /// Unique, Clustered, ColumnStore), single- and multi-column key lists, and the
+    /// IncludedColumns.Any() = false / true branches with varying include sizes.
+    /// </summary>
+    public static IndexRecommendation[] BuildIndexRecommendations()
+    {
+        return new[]
+        {
+            new IndexRecommendation
+            {
+                TableName = "Users",
+                IndexName = "IX_Users_Email",
+                IndexType = "NonClustered",
+                Columns = new List<string> { "Email" },
+                IncludedColumns = new List<string>(),
+                Justification = "Email lookup",
+                Priority = 1,
+                EstimatedImpactRUs = 50
+            },
+            new IndexRecommendation
+            {
+                TableName = "Orders",
+                IndexName = "IX_Orders_Customer_Date",
+                IndexType = "NonClustered",
+                Columns = new List<string> { "CustomerId", "OrderDate" },
+                IncludedColumns = new List<string> { "Status" },
+                Justification = "Customer order history",
+                Priority = 2,
+                EstimatedImpactRUs = 120
+            },
+            new IndexRecommendation
+            {
+                TableName = "Products",
+                IndexName = "UX_Products_Sku",
+                IndexType = "Unique",
+                Columns = new List<string> { "Sku" },
+                IncludedColumns = new List<string>(),
+                Justification = "SKU uniqueness",
+                Priority = 1,
+                EstimatedImpactRUs = 0
+            },
+            new IndexRecommendation
+            {
+                TableName = "Audit",
+                IndexName = "IX_Audit_TenantId",
+                IndexType = "Clustered",
+                Columns = new List<string> { "TenantId", "Timestamp" },
+                IncludedColumns = new List<string>(),
+                Justification = "Tenant scan",
+                Priority = 1,
+                EstimatedImpactRUs = 200
+            },
+            new IndexRecommendation
+            {
+                TableName = "Telemetry",
+                IndexName = "CCI_Telemetry",
+                IndexType = "Columnstore",
+                Columns = new List<string> { "EventId" },
+                IncludedColumns = new List<string>(),
+                Justification = "Analytics scan",
+                Priority = 3,
+                EstimatedImpactRUs = 500
+            },
+            new IndexRecommendation
+            {
+                TableName = "Invoices",
+                IndexName = "IX_Invoices_Covering",
+                IndexType = "NonClustered",
+                Columns = new List<string> { "CustomerId", "InvoiceDate" },
+                IncludedColumns = new List<string> { "TotalAmount", "Currency", "Status", "DueDate" },
+                Justification = "Covering index for invoice listing",
+                Priority = 2,
+                EstimatedImpactRUs = 180
+            },
+        };
+    }
+
+    /// <summary>
+    /// Realistic db/container names exercising every branch in
+    /// <c>SqlProjectGenerationService.SanitizeName</c>: whitespace, illegal chars (-, .),
+    /// invalid file-system chars, leading digit / non-letter.
+    /// </summary>
+    public static string[] BuildSanitizeNameInputs()
+    {
+        return new[]
+        {
+            "MyDatabase",
+            "Customer Profiles",
+            "orders-archive",
+            "2024_metrics",
+            "tenant.shared.config",
+            "audit/logs",
+            "cosmos:billing",
+            "Inventory.Warehouse-East",
+            "_internal_db",
+            "9-legacy-system",
+        };
+    }
+}

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/Program.cs
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/Program.cs
@@ -1,0 +1,43 @@
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Toolchains.InProcess.Emit;
+
+namespace CosmosToSqlAssessment.Benchmarks;
+
+/// <summary>
+/// Entry point for the BenchmarkDotNet harness.
+/// Uses <see cref="BenchmarkSwitcher"/> so CLI args (e.g. <c>--filter</c>, <c>--list</c>,
+/// <c>--job dry</c>) drive which benchmarks execute. See the project README for examples.
+/// </summary>
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        BenchmarkSwitcher
+            .FromAssembly(typeof(Program).Assembly)
+            .Run(args, BuildConfig());
+    }
+
+    /// <summary>
+    /// Default config for every benchmark in this assembly.
+    /// <para>
+    /// We pin BenchmarkDotNet to the in-process emit toolchain because the production project
+    /// (<c>CosmosToSqlAssessment.csproj</c>) is itself an <c>OutputType=Exe</c> console app.
+    /// BenchmarkDotNet's default out-of-process toolchain rebuilds the dependency graph in a
+    /// boilerplate project under a generated <c>OutputPath</c>, which fails on Windows because
+    /// the referenced Exe's <c>apphost.exe</c> can't be resolved into that nested path.
+    /// Running in-process sidesteps the issue, is the right trade-off for our
+    /// regression-detection use case (we care about relative deltas, not absolute precision),
+    /// and means individual benchmark classes need no toolchain-specific attributes.
+    /// </para>
+    /// <para>
+    /// Result exporters and baseline tracking are intentionally not configured here — those
+    /// land in sub-issue #177.
+    /// </para>
+    /// </summary>
+    private static IConfig BuildConfig() =>
+        DefaultConfig.Instance.AddJob(
+            Job.Default.WithToolchain(InProcessEmitToolchain.Instance));
+}
+

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/Program.cs
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/Program.cs
@@ -1,7 +1,9 @@
 using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Exporters.Json;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Toolchains.InProcess.Emit;
+using CosmosToSqlAssessment.Benchmarks.Tracking;
 
 namespace CosmosToSqlAssessment.Benchmarks;
 
@@ -9,14 +11,27 @@ namespace CosmosToSqlAssessment.Benchmarks;
 /// Entry point for the BenchmarkDotNet harness.
 /// Uses <see cref="BenchmarkSwitcher"/> so CLI args (e.g. <c>--filter</c>, <c>--list</c>,
 /// <c>--job dry</c>) drive which benchmarks execute. See the project README for examples.
+/// <para>
+/// In addition to running benchmarks, this entry point reserves the first-arg subcommand
+/// <c>compare-baseline</c> for the baseline regression tracking tool added in sub-issue #177.
+/// </para>
 /// </summary>
 public static class Program
 {
-    public static void Main(string[] args)
+    public const string CompareBaselineSubcommand = "compare-baseline";
+
+    public static int Main(string[] args)
     {
+        if (args.Length > 0 &&
+            string.Equals(args[0], CompareBaselineSubcommand, StringComparison.OrdinalIgnoreCase))
+        {
+            return BaselineComparer.Run(args[1..]);
+        }
+
         BenchmarkSwitcher
             .FromAssembly(typeof(Program).Assembly)
             .Run(args, BuildConfig());
+        return 0;
     }
 
     /// <summary>
@@ -32,12 +47,14 @@ public static class Program
     /// and means individual benchmark classes need no toolchain-specific attributes.
     /// </para>
     /// <para>
-    /// Result exporters and baseline tracking are intentionally not configured here — those
-    /// land in sub-issue #177.
+    /// <see cref="JsonExporter.Full"/> is added so every run emits
+    /// <c>BenchmarkDotNet.Artifacts/results/{class}-report-full.json</c>, which the
+    /// <c>compare-baseline</c> subcommand and CI workflow (#178) consume for regression checks.
     /// </para>
     /// </summary>
     private static IConfig BuildConfig() =>
-        DefaultConfig.Instance.AddJob(
-            Job.Default.WithToolchain(InProcessEmitToolchain.Instance));
+        DefaultConfig.Instance
+            .AddJob(Job.Default.WithToolchain(InProcessEmitToolchain.Instance))
+            .AddExporter(JsonExporter.Full);
 }
 

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/README.md
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/README.md
@@ -40,8 +40,96 @@ dotnet run -c Release \
 
 By default BenchmarkDotNet writes results under
 `tests/Performance/CosmosToSqlAssessment.Benchmarks/BenchmarkDotNet.Artifacts/`. That path is
-already covered by the repository `.gitignore`. JSON/Markdown exporters and a stable artifact
-layout will be configured in #177.
+already covered by the repository `.gitignore`. The harness adds `JsonExporter.Full` to the
+default config so every run produces
+`BenchmarkDotNet.Artifacts/results/{benchmark-class}-report-full.json` with per-benchmark
+statistics + allocation data. The `compare-baseline` subcommand (below) reads those files.
+
+## Result tracking
+
+Sub-issue #177 wires in a small baseline tracker that lives entirely inside this project. It is
+local-only at present; CI integration arrives in #178.
+
+### Layout
+
+- `baselines/baseline.json` — committed source of truth. Keys are BenchmarkDotNet `FullName`
+  strings (parameterised entries look like `Namespace.Class.Method(Size: Small)`).
+- `Tracking/BaselineRecord.cs` — POCO shapes (`BaselineFile`, `BenchmarkBaseline`,
+  `ComparisonRow`).
+- `Tracking/BaselineComparer.cs` — `compare-baseline` subcommand implementation.
+
+### Baseline schema
+
+```json
+{
+  "schemaVersion": 1,
+  "capturedAt": "<ISO-8601 timestamp>",
+  "capturedOn": "<machine / OS / runtime description>",
+  "captureCommand": "<command used to produce the report>",
+  "defaultToleranceFactor": 2.00,
+  "defaultAllocationFloorBytes": 1024,
+  "benchmarks": {
+    "Namespace.Class.Method(Size: Small)": {
+      "meanNs": 12345.6,
+      "allocatedBytes": 7890,
+      "toleranceFactor": 2.00
+    }
+  }
+}
+```
+
+A benchmark fails the comparison if:
+
+- `actualMean > baselineMean × tolerance`, **or**
+- `actualAllocated > max(baselineAllocated × tolerance, baselineAllocated + defaultAllocationFloorBytes)`
+
+The allocation floor avoids brittle alarms when a baseline is near zero. Per-benchmark
+`toleranceFactor` overrides the file-level default and is preserved across `--update` runs.
+
+### Seeding / refreshing the baseline
+
+The repo ships with an empty baseline. First-time seed:
+
+```bash
+# 1. Capture a real measurement run (short job — ~minutes, not seconds, but realistic).
+dotnet run -c Release \
+  --project tests/Performance/CosmosToSqlAssessment.Benchmarks/CosmosToSqlAssessment.Benchmarks.csproj \
+  -- --filter "*" --job short
+
+# 2. Promote that report to the baseline file. Default --baseline resolves to
+#    tests/Performance/CosmosToSqlAssessment.Benchmarks/baselines/baseline.json relative to the
+#    benchmark assembly's output directory.
+dotnet run -c Release \
+  --project tests/Performance/CosmosToSqlAssessment.Benchmarks/CosmosToSqlAssessment.Benchmarks.csproj \
+  -- compare-baseline --update \
+     --report tests/Performance/CosmosToSqlAssessment.Benchmarks/BenchmarkDotNet.Artifacts/results/CosmosToSqlAssessment.Benchmarks.Benchmarks.SmokeBenchmarks-report-full.json
+```
+
+Repeat the `--update` invocation for each `*-report-full.json` produced by the run.
+
+### Comparing a new run against the baseline
+
+```bash
+dotnet run -c Release \
+  --project tests/Performance/CosmosToSqlAssessment.Benchmarks/CosmosToSqlAssessment.Benchmarks.csproj \
+  -- compare-baseline \
+     --report tests/Performance/CosmosToSqlAssessment.Benchmarks/BenchmarkDotNet.Artifacts/results/CosmosToSqlAssessment.Benchmarks.Benchmarks.SmokeBenchmarks-report-full.json
+```
+
+Exit codes:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | All compared benchmarks within tolerance. |
+| `1` | At least one benchmark regressed. |
+| `2` | Bad invocation, missing/malformed files, or baseline-vs-report key drift. |
+
+> Cross-machine note: BenchmarkDotNet `Mean` numbers are noticeably hardware-dependent. The
+> shipped tolerance (`2.00` = 100% headroom) is intentionally loose. Tighten per-benchmark
+> values in the baseline once #178 pins a CI runner to one runner SKU.
+>
+> The CI workflow in #178 will invoke `compare-baseline` against the same `*-report-full.json`
+> artifacts; the contract here is intended to stay stable.
 
 ## Adding a new benchmark
 

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/README.md
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/README.md
@@ -131,6 +131,35 @@ Exit codes:
 > The CI workflow in #178 will invoke `compare-baseline` against the same `*-report-full.json`
 > artifacts; the contract here is intended to stay stable.
 
+## CI
+
+The `Performance Regression` workflow (`.github/workflows/performance-regression.yml`, added
+in sub-issue #178) wires the harness above into GitHub Actions.
+
+- **Triggers**: every PR to `main`; pushes to `main` that touch perf-relevant paths (the
+  benchmarks project, the main project's services / reporting / models / SqlProject, the
+  csproj/sln/Program.cs, or the workflow file itself); and a `workflow_dispatch` with an
+  `update_baseline` boolean input.
+- **What it does**: builds the benchmarks project, runs `dotnet run -- --filter "*"`
+  (deliberately omitting `--job` so the in-process toolchain pin from `BuildConfig()` is
+  guaranteed to apply), then iterates each `*-report-full.json` invoking
+  `compare-baseline --report <each>`. CI fails on the worst exit code: `1` if any benchmark
+  regresses past tolerance, `2` if the comparison itself errored (drift, malformed report,
+  missing reports).
+- **Refreshing the baseline from CI**: trigger the workflow manually
+  (`Actions → Performance Regression → Run workflow`) with `update_baseline=true`. The
+  comparison step is skipped; instead the workflow runs `compare-baseline --update` for
+  every report and uploads the refreshed `baseline.json` as an artifact named
+  `refreshed-baseline`. Download it, review the diff, and commit it in a follow-up PR.
+  (The workflow intentionally does **not** auto-commit — it stays read-only.)
+- **Artifacts**: the full `BenchmarkDotNet.Artifacts/` directory is uploaded as
+  `benchmark-artifacts` (retention 14 days) on every run, so the raw reports and HTML/CSV
+  exports are available for inspection.
+
+> Phase C of parent #79 will register `Benchmark regression` as a required status check on
+> `main`. That's why the PR trigger has no `paths:` filter — a required check that can't
+> report on certain PRs would otherwise leave them blocked.
+
 ## Adding a new benchmark
 
 1. Add a class under `Benchmarks/` with `[MemoryDiagnoser]` on the class and one or more

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/README.md
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/README.md
@@ -1,0 +1,55 @@
+# CosmosToSqlAssessment.Benchmarks
+
+BenchmarkDotNet harness for the Cosmos → SQL migration assessment tool. Owned by the parent
+issue [#79](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/issues/79).
+
+This project is **scaffolding only** in its current form (sub-issue #173). Real benchmarks for
+the Cosmos analysis, SQL assessment, and report generation services land in sub-issues
+#174–#176. Result tracking, the CI workflow, and the project-level performance targets land in
+#177–#179.
+
+## Quickstart
+
+> ⚠️ Always run benchmarks with `-c Release`. BenchmarkDotNet will refuse to run a Debug build.
+
+List every benchmark discovered in the assembly:
+
+```bash
+dotnet run -c Release \
+  --project tests/Performance/CosmosToSqlAssessment.Benchmarks/CosmosToSqlAssessment.Benchmarks.csproj \
+  -- --list flat
+```
+
+Run every benchmark with default settings (slow — full warmup + multiple iterations):
+
+```bash
+dotnet run -c Release \
+  --project tests/Performance/CosmosToSqlAssessment.Benchmarks/CosmosToSqlAssessment.Benchmarks.csproj \
+  -- --filter "*"
+```
+
+Run a specific benchmark fast — single warmup + single iteration, for plumbing checks:
+
+```bash
+dotnet run -c Release \
+  --project tests/Performance/CosmosToSqlAssessment.Benchmarks/CosmosToSqlAssessment.Benchmarks.csproj \
+  -- --filter "*SmokeBenchmarks*" --job dry --warmupCount 1 --iterationCount 1
+```
+
+## Artifacts
+
+By default BenchmarkDotNet writes results under
+`tests/Performance/CosmosToSqlAssessment.Benchmarks/BenchmarkDotNet.Artifacts/`. That path is
+already covered by the repository `.gitignore`. JSON/Markdown exporters and a stable artifact
+layout will be configured in #177.
+
+## Adding a new benchmark
+
+1. Add a class under `Benchmarks/` with `[MemoryDiagnoser]` on the class and one or more
+   `[Benchmark]`-attributed methods.
+2. Keep benchmarks deterministic and in-memory. Construct any dependencies in a
+   `[GlobalSetup]`-attributed method using test doubles — never call live Azure resources.
+3. Filter against your new class locally before pushing:
+   `--filter "*MyNewBenchmarks*" --job dry`.
+
+See [BenchmarkDotNet docs](https://benchmarkdotnet.org/) for the full attribute / CLI surface.

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/Tracking/BaselineComparer.cs
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/Tracking/BaselineComparer.cs
@@ -1,0 +1,431 @@
+using System.Globalization;
+using System.Text.Json;
+
+namespace CosmosToSqlAssessment.Benchmarks.Tracking;
+
+/// <summary>
+/// Compares a BenchmarkDotNet full-report JSON file against a tracked baseline and reports
+/// regressions. Invoked via <c>compare-baseline</c> subcommand on the benchmark CLI.
+/// Owned by sub-issue #177 (parent #79). CI integration arrives in #178.
+/// </summary>
+public static class BaselineComparer
+{
+    public const int ExitSuccess = 0;
+    public const int ExitRegression = 1;
+    public const int ExitBadInvocation = 2;
+
+    public static int Run(string[] args)
+    {
+        string? reportPath = null;
+        string? baselinePath = null;
+        bool update = false;
+
+        for (int i = 0; i < args.Length; i++)
+        {
+            string a = args[i];
+            switch (a)
+            {
+                case "--report":
+                    if (++i >= args.Length) return Fail("--report requires a path argument.");
+                    reportPath = args[i];
+                    break;
+                case "--baseline":
+                    if (++i >= args.Length) return Fail("--baseline requires a path argument.");
+                    baselinePath = args[i];
+                    break;
+                case "--update":
+                    update = true;
+                    break;
+                case "-h":
+                case "--help":
+                    PrintHelp();
+                    return ExitSuccess;
+                default:
+                    return Fail($"Unknown argument: {a}");
+            }
+        }
+
+        if (string.IsNullOrEmpty(reportPath))
+        {
+            return Fail("--report <path> is required.");
+        }
+
+        baselinePath ??= ResolveDefaultBaselinePath();
+
+        if (!File.Exists(reportPath))
+        {
+            return Fail($"Report file not found: {reportPath}");
+        }
+
+        BaselineFile baseline;
+        try
+        {
+            baseline = LoadBaseline(baselinePath);
+        }
+        catch (FileNotFoundException)
+        {
+            if (!update)
+            {
+                return Fail(
+                    $"Baseline file not found: {baselinePath}. Re-run with --update to seed it from the report.");
+            }
+            baseline = new BaselineFile();
+        }
+        catch (JsonException ex)
+        {
+            return Fail($"Baseline file is not valid JSON ({baselinePath}): {ex.Message}");
+        }
+
+        Dictionary<string, ReportEntry> reportEntries;
+        try
+        {
+            reportEntries = LoadReport(reportPath);
+        }
+        catch (JsonException ex)
+        {
+            return Fail($"Report file is not valid JSON ({reportPath}): {ex.Message}");
+        }
+        catch (InvalidDataException ex)
+        {
+            return Fail($"Report file is malformed ({reportPath}): {ex.Message}");
+        }
+
+        if (reportEntries.Count == 0)
+        {
+            return Fail($"Report file contained no benchmarks: {reportPath}");
+        }
+
+        if (update)
+        {
+            ApplyUpdate(baseline, reportEntries, reportPath);
+            WriteBaseline(baselinePath, baseline);
+            Console.WriteLine($"Wrote {reportEntries.Count} benchmark entries to {baselinePath}.");
+            return ExitSuccess;
+        }
+
+        var outcome = Compare(baseline, reportEntries);
+
+        PrintOutcome(outcome, baselinePath, reportPath);
+
+        if (outcome.Errors.Count > 0)
+        {
+            return ExitBadInvocation;
+        }
+
+        return outcome.Rows.Any(r => r.AnyRegression) ? ExitRegression : ExitSuccess;
+    }
+
+    internal static string ResolveDefaultBaselinePath()
+    {
+        // The benchmark assembly typically lives in bin/Release/net8.0/. Walking up three levels
+        // anchors us at the project root, where the source-tree `baselines/` folder lives. This
+        // means --update edits the committed file (rather than a stray copy in bin/).
+        string projectRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", ".."));
+        string defaultPath = Path.Combine(projectRoot, "baselines", "baseline.json");
+
+        if (File.Exists(defaultPath))
+        {
+            return defaultPath;
+        }
+
+        // Fallback: walk upward from BaseDirectory looking for any baselines/baseline.json.
+        DirectoryInfo? cursor = new(AppContext.BaseDirectory);
+        while (cursor is not null)
+        {
+            string candidate = Path.Combine(cursor.FullName, "baselines", "baseline.json");
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+            cursor = cursor.Parent;
+        }
+
+        return defaultPath;
+    }
+
+    internal static BaselineFile LoadBaseline(string path)
+    {
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException("Baseline file not found.", path);
+        }
+        string json = File.ReadAllText(path);
+        var baseline = JsonSerializer.Deserialize<BaselineFile>(json, BaselineSerialization.Options)
+            ?? throw new JsonException("Baseline file deserialised to null.");
+        baseline.Benchmarks ??= new Dictionary<string, BenchmarkBaseline>(StringComparer.Ordinal);
+        return baseline;
+    }
+
+    internal static void WriteBaseline(string path, BaselineFile baseline)
+    {
+        string? dir = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+        string json = JsonSerializer.Serialize(baseline, BaselineSerialization.Options);
+        File.WriteAllText(path, json);
+    }
+
+    internal static Dictionary<string, ReportEntry> LoadReport(string path)
+    {
+        var entries = new Dictionary<string, ReportEntry>(StringComparer.Ordinal);
+        using var stream = File.OpenRead(path);
+        using var doc = JsonDocument.Parse(stream);
+
+        if (!doc.RootElement.TryGetProperty("Benchmarks", out JsonElement benchmarksEl) ||
+            benchmarksEl.ValueKind != JsonValueKind.Array)
+        {
+            throw new InvalidDataException("Expected top-level 'Benchmarks' array.");
+        }
+
+        foreach (JsonElement entry in benchmarksEl.EnumerateArray())
+        {
+            if (!entry.TryGetProperty("FullName", out JsonElement nameEl) ||
+                nameEl.ValueKind != JsonValueKind.String)
+            {
+                continue;
+            }
+            string fullName = nameEl.GetString()!;
+
+            double? meanNs = null;
+            if (entry.TryGetProperty("Statistics", out JsonElement statsEl) &&
+                statsEl.ValueKind == JsonValueKind.Object &&
+                statsEl.TryGetProperty("Mean", out JsonElement meanEl) &&
+                meanEl.ValueKind == JsonValueKind.Number)
+            {
+                meanNs = meanEl.GetDouble();
+            }
+
+            long? allocBytes = null;
+            if (entry.TryGetProperty("Memory", out JsonElement memEl) &&
+                memEl.ValueKind == JsonValueKind.Object &&
+                memEl.TryGetProperty("BytesAllocatedPerOperation", out JsonElement allocEl) &&
+                allocEl.ValueKind == JsonValueKind.Number)
+            {
+                allocBytes = allocEl.GetInt64();
+            }
+
+            entries[fullName] = new ReportEntry(fullName, meanNs, allocBytes);
+        }
+
+        return entries;
+    }
+
+    internal static ComparisonOutcome Compare(BaselineFile baseline, Dictionary<string, ReportEntry> report)
+    {
+        var outcome = new ComparisonOutcome();
+        var baselineKeys = new HashSet<string>(baseline.Benchmarks.Keys, StringComparer.Ordinal);
+
+        foreach (KeyValuePair<string, ReportEntry> kv in report)
+        {
+            string name = kv.Key;
+            ReportEntry actual = kv.Value;
+
+            if (!baseline.Benchmarks.TryGetValue(name, out BenchmarkBaseline? baselineRow))
+            {
+                outcome.ReportOnlyBenchmarks.Add(name);
+                continue;
+            }
+            baselineKeys.Remove(name);
+
+            if (actual.MeanNs is null)
+            {
+                outcome.Errors.Add($"{name}: report is missing Statistics.Mean (was [MemoryDiagnoser]/measurement disabled?).");
+                continue;
+            }
+            if (actual.AllocatedBytes is null)
+            {
+                outcome.Errors.Add($"{name}: report is missing Memory.BytesAllocatedPerOperation (is [MemoryDiagnoser] applied?).");
+                continue;
+            }
+
+            double tolerance = baselineRow.ToleranceFactor ?? baseline.DefaultToleranceFactor;
+            long floor = baseline.DefaultAllocationFloorBytes;
+
+            double actualMean = actual.MeanNs.Value;
+            long actualAlloc = actual.AllocatedBytes.Value;
+
+            double meanThreshold = baselineRow.MeanNs * tolerance;
+            long allocThreshold = Math.Max(
+                (long)Math.Ceiling(baselineRow.AllocatedBytes * tolerance),
+                baselineRow.AllocatedBytes + floor);
+
+            bool meanRegression = actualMean > meanThreshold;
+            bool allocRegression = actualAlloc > allocThreshold;
+
+            double improveDivisor = tolerance > 1.0 ? tolerance : 1.0;
+            bool meanImproved = baselineRow.MeanNs > 0 && actualMean < baselineRow.MeanNs / improveDivisor;
+            bool allocImproved = baselineRow.AllocatedBytes > 0 && actualAlloc < baselineRow.AllocatedBytes / improveDivisor;
+
+            outcome.Rows.Add(new ComparisonRow(
+                FullName: name,
+                BaselineMeanNs: baselineRow.MeanNs,
+                ActualMeanNs: actualMean,
+                BaselineAllocatedBytes: baselineRow.AllocatedBytes,
+                ActualAllocatedBytes: actualAlloc,
+                ToleranceFactor: tolerance,
+                AllocationFloorBytes: floor,
+                MeanRegression: meanRegression,
+                AllocationRegression: allocRegression,
+                MeanImproved: meanImproved,
+                AllocationImproved: allocImproved));
+        }
+
+        foreach (string remaining in baselineKeys)
+        {
+            outcome.BaselineOnlyBenchmarks.Add(remaining);
+        }
+
+        if (baseline.Benchmarks.Count > 0 && outcome.Rows.Count == 0)
+        {
+            outcome.Errors.Add(
+                "Baseline contains entries but zero benchmarks matched the report (possible FullName/schema drift).");
+        }
+
+        return outcome;
+    }
+
+    internal static void ApplyUpdate(BaselineFile baseline, Dictionary<string, ReportEntry> report, string reportPath)
+    {
+        baseline.CapturedAt = DateTimeOffset.UtcNow;
+        baseline.CapturedOn = $"{Environment.MachineName} / {Environment.OSVersion} / .NET {Environment.Version}";
+        baseline.CaptureCommand = $"compare-baseline --update --report \"{reportPath}\"";
+
+        foreach (KeyValuePair<string, ReportEntry> kv in report)
+        {
+            ReportEntry actual = kv.Value;
+            if (actual.MeanNs is null || actual.AllocatedBytes is null)
+            {
+                // Skip entries missing measurements; --update should only seed complete rows.
+                continue;
+            }
+
+            if (baseline.Benchmarks.TryGetValue(kv.Key, out BenchmarkBaseline? existing))
+            {
+                existing.MeanNs = actual.MeanNs.Value;
+                existing.AllocatedBytes = actual.AllocatedBytes.Value;
+                // Per-row ToleranceFactor preserved across updates.
+            }
+            else
+            {
+                baseline.Benchmarks[kv.Key] = new BenchmarkBaseline
+                {
+                    MeanNs = actual.MeanNs.Value,
+                    AllocatedBytes = actual.AllocatedBytes.Value
+                };
+            }
+        }
+    }
+
+    private static void PrintOutcome(ComparisonOutcome outcome, string baselinePath, string reportPath)
+    {
+        Console.WriteLine($"compare-baseline");
+        Console.WriteLine($"  baseline: {baselinePath}");
+        Console.WriteLine($"  report:   {reportPath}");
+        Console.WriteLine();
+
+        if (outcome.Rows.Count > 0)
+        {
+            Console.WriteLine("Benchmark                                                  Mean(ns)         Δmean   Alloc(B)        Δalloc   Status");
+            Console.WriteLine(new string('-', 130));
+            foreach (ComparisonRow row in outcome.Rows.OrderBy(r => r.FullName, StringComparer.Ordinal))
+            {
+                string name = Truncate(row.FullName, 55);
+                string meanStr = row.ActualMeanNs.ToString("N1", CultureInfo.InvariantCulture);
+                string allocStr = row.ActualAllocatedBytes.ToString("N0", CultureInfo.InvariantCulture);
+                string meanDelta = row.BaselineMeanNs > 0
+                    ? ((row.ActualMeanNs / row.BaselineMeanNs) - 1.0).ToString("+0.0%;-0.0%;0.0%", CultureInfo.InvariantCulture)
+                    : "n/a";
+                string allocDelta = row.BaselineAllocatedBytes > 0
+                    ? ((row.ActualAllocatedBytes / (double)row.BaselineAllocatedBytes) - 1.0).ToString("+0.0%;-0.0%;0.0%", CultureInfo.InvariantCulture)
+                    : "n/a";
+                string status = row.AnyRegression
+                    ? "REGRESSION"
+                    : (row.AnyImprovement ? "improved" : "ok");
+                Console.WriteLine($"{name,-55}  {meanStr,16}  {meanDelta,8}  {allocStr,12}  {allocDelta,8}   {status}");
+                if (row.MeanRegression)
+                {
+                    Console.WriteLine(
+                        $"  ⚠ Mean above threshold: actual={row.ActualMeanNs:N1}ns > " +
+                        $"{row.BaselineMeanNs:N1}ns × {row.ToleranceFactor:N2} = {row.MeanThresholdNs:N1}ns");
+                }
+                if (row.AllocationRegression)
+                {
+                    Console.WriteLine(
+                        $"  ⚠ Allocations above threshold: actual={row.ActualAllocatedBytes:N0}B > " +
+                        $"max(baseline×{row.ToleranceFactor:N2}, baseline+{row.AllocationFloorBytes}) = {row.AllocationThresholdBytes:N0}B");
+                }
+                if (!row.AnyRegression && row.AnyImprovement)
+                {
+                    Console.WriteLine($"  ℹ Improved beyond tolerance; consider refreshing baseline.");
+                }
+            }
+            Console.WriteLine();
+        }
+
+        if (outcome.ReportOnlyBenchmarks.Count > 0)
+        {
+            Console.WriteLine("Benchmarks in report but not in baseline (consider --update):");
+            foreach (string name in outcome.ReportOnlyBenchmarks)
+            {
+                Console.WriteLine($"  + {name}");
+            }
+            Console.WriteLine();
+        }
+
+        if (outcome.BaselineOnlyBenchmarks.Count > 0)
+        {
+            Console.WriteLine("Benchmarks in baseline but missing from this report:");
+            foreach (string name in outcome.BaselineOnlyBenchmarks)
+            {
+                Console.WriteLine($"  - {name}");
+            }
+            Console.WriteLine();
+        }
+
+        if (outcome.Errors.Count > 0)
+        {
+            Console.WriteLine("Errors:");
+            foreach (string err in outcome.Errors)
+            {
+                Console.WriteLine($"  ✗ {err}");
+            }
+            Console.WriteLine();
+        }
+
+        int regressionCount = outcome.Rows.Count(r => r.AnyRegression);
+        int improvedCount = outcome.Rows.Count(r => !r.AnyRegression && r.AnyImprovement);
+        Console.WriteLine($"Summary: {outcome.Rows.Count} compared, {regressionCount} regression(s), {improvedCount} improvement(s).");
+    }
+
+    private static string Truncate(string s, int max) =>
+        s.Length <= max ? s : "…" + s.Substring(s.Length - max + 1);
+
+    private static int Fail(string message)
+    {
+        Console.Error.WriteLine($"compare-baseline: {message}");
+        Console.Error.WriteLine("Run with --help for usage.");
+        return ExitBadInvocation;
+    }
+
+    private static void PrintHelp()
+    {
+        Console.WriteLine("Usage: <benchmark-cli> compare-baseline --report <full.json> [--baseline <path>] [--update]");
+        Console.WriteLine();
+        Console.WriteLine("Compares a BenchmarkDotNet *-report-full.json file against the tracked baseline");
+        Console.WriteLine("and exits non-zero if any benchmark regresses past its tolerance factor.");
+        Console.WriteLine();
+        Console.WriteLine("Options:");
+        Console.WriteLine("  --report <path>     Path to BenchmarkDotNet full-report JSON (required).");
+        Console.WriteLine("  --baseline <path>   Path to baseline.json (default: <project>/baselines/baseline.json).");
+        Console.WriteLine("  --update            Write the report's actuals back as the new baseline.");
+        Console.WriteLine();
+        Console.WriteLine("Exit codes: 0 = pass, 1 = regression detected, 2 = bad invocation / bad data.");
+    }
+
+    /// <summary>
+    /// Minimal projection of one benchmark row from a BenchmarkDotNet full-report JSON file.
+    /// </summary>
+    internal sealed record ReportEntry(string FullName, double? MeanNs, long? AllocatedBytes);
+}

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/Tracking/BaselineRecord.cs
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/Tracking/BaselineRecord.cs
@@ -1,0 +1,89 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace CosmosToSqlAssessment.Benchmarks.Tracking;
+
+/// <summary>
+/// Top-level shape of <c>baselines/baseline.json</c>. Owned by sub-issue #177 (parent #79).
+/// </summary>
+public sealed class BaselineFile
+{
+    public int SchemaVersion { get; set; } = 1;
+
+    public DateTimeOffset? CapturedAt { get; set; }
+
+    public string? CapturedOn { get; set; }
+
+    public string? CaptureCommand { get; set; }
+
+    public double DefaultToleranceFactor { get; set; } = 2.00;
+
+    public long DefaultAllocationFloorBytes { get; set; } = 1024;
+
+    public Dictionary<string, BenchmarkBaseline> Benchmarks { get; set; } = new(StringComparer.Ordinal);
+}
+
+/// <summary>
+/// Recorded values for one benchmark (one row per parameterised invocation, keyed by
+/// BenchmarkDotNet's <c>FullName</c> including parameter suffix e.g. <c>Method(Size: Small)</c>).
+/// </summary>
+public sealed class BenchmarkBaseline
+{
+    public double MeanNs { get; set; }
+
+    public long AllocatedBytes { get; set; }
+
+    public double? ToleranceFactor { get; set; }
+}
+
+/// <summary>
+/// Result of comparing one benchmark's actual run vs its baseline.
+/// </summary>
+public sealed record ComparisonRow(
+    string FullName,
+    double BaselineMeanNs,
+    double ActualMeanNs,
+    long BaselineAllocatedBytes,
+    long ActualAllocatedBytes,
+    double ToleranceFactor,
+    long AllocationFloorBytes,
+    bool MeanRegression,
+    bool AllocationRegression,
+    bool MeanImproved,
+    bool AllocationImproved)
+{
+    public bool AnyRegression => MeanRegression || AllocationRegression;
+    public bool AnyImprovement => MeanImproved || AllocationImproved;
+
+    public double MeanThresholdNs => BaselineMeanNs * ToleranceFactor;
+
+    public long AllocationThresholdBytes => Math.Max(
+        (long)Math.Ceiling(BaselineAllocatedBytes * ToleranceFactor),
+        BaselineAllocatedBytes + AllocationFloorBytes);
+}
+
+/// <summary>
+/// Aggregate outcome of a <c>compare-baseline</c> run.
+/// </summary>
+public sealed class ComparisonOutcome
+{
+    public List<ComparisonRow> Rows { get; } = new();
+    public List<string> ReportOnlyBenchmarks { get; } = new();
+    public List<string> BaselineOnlyBenchmarks { get; } = new();
+    public List<string> Errors { get; } = new();
+}
+
+/// <summary>
+/// Shared JSON options for reading/writing the baseline file (camelCase, indented).
+/// </summary>
+internal static class BaselineSerialization
+{
+    public static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DictionaryKeyPolicy = null,
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/baselines/baseline.json
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/baselines/baseline.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": 1,
+  "capturedAt": null,
+  "capturedOn": "placeholder — seed via 'compare-baseline --update --report <full.json>'",
+  "captureCommand": "dotnet run -c Release --project tests/Performance/CosmosToSqlAssessment.Benchmarks/CosmosToSqlAssessment.Benchmarks.csproj -- --filter \"*\" --job short",
+  "defaultToleranceFactor": 2.00,
+  "defaultAllocationFloorBytes": 1024,
+  "benchmarks": {}
+}


### PR DESCRIPTION
Closes #79

This PR is the worker-session umbrella for parent issue **#79 — Create performance benchmarking framework**. It is opened as a draft and will be marked ready-for-review once all sub-issues are implemented, tested, and closed.

## Sub-issue checklist

- [x] #173 — Create BenchmarkDotNet test project
- [x] #174 — Add benchmarks for Cosmos DB analysis
- [x] #175 — Add benchmarks for SQL assessment
- [x] #176 — Add benchmarks for report generation
- [x] #177 — Set up benchmark result tracking
- [x] #178 — Add performance regression checks to CI
- [x] #179 — Document performance targets in README

## Implementation approach

- **#173 (done):** scaffolded a `tests/Performance/CosmosToSqlAssessment.Benchmarks` Console project targeting `net8.0` (matches the main app — the CI build job only installs the net8 SDK). Wired into `CosmosToSqlAssessment.sln` under a new `Performance` solution folder via `dotnet sln add`. `Program.cs` uses `BenchmarkSwitcher` with a shared in-process-emit toolchain config (works around BenchmarkDotNet's apphost issue when referencing a project that has `OutputType=Exe`). Added a deterministic `SmokeBenchmarks.BuildAssessmentResult` benchmark that exercises a real model from the main project so the project reference is validated end-to-end, plus a quickstart README.
- **#174 (done):** added `<InternalsVisibleTo Include="CosmosToSqlAssessment.Benchmarks" />` to the main csproj and promoted 9 pure helpers in `CosmosDbAnalysisService` from `private` to `internal static` (none touch instance state, so this is a safe refactor with zero call-site churn). Built a `JsonDocumentFixtures` generator producing deterministic Small/Medium/Large `JsonDocument`s plus primitive/tag/object banks, then a `CosmosAnalysisBenchmarks` class (`[MemoryDiagnoser]`) covering `MapJsonTypeToSqlTypeEnhanced_Primitives` (with `OperationsPerInvoke=11`), `ExtractFieldsFlat_Document` (`[Params(Small, Medium, Large)]`), `AnalyzeArrayStructure_Tags`, `AnalyzeArrayStructure_Objects`, and `GetRecommendedSqlType_Mixed`. `[GlobalSetup]` materialises the fixtures; `[GlobalCleanup]` disposes the owned `JsonDocument`s so `JsonElement` views stay valid.
- **#175 (done):** added `SqlAssessmentBenchmarks` (`[MemoryDiagnoser]`) covering the full SQL-assessment subsystem. `AssessMigrationAsync_EndToEnd` runs the public-API 8-phase pipeline (platform recommendation → mappings → schema dedup → index/FK/unique constraints → complexity → transformations) with `[Params(Small, Medium, Large)]`. Two pure helpers in `SqlProjectGenerationService` (`GenerateIndexScript`, `SanitizeName`) were promoted to `internal static` and exercised by bank benchmarks with `OperationsPerInvoke=100`. `SqlAssessmentFixtures` builds deterministic `CosmosDbAnalysis` at three scales — Medium and Large deliberately share `addresses`/`contacts`/`lineItems`/`tags` child-table shapes across containers so `DeduplicateSchemas` (which groups child-table mappings) does real work rather than the all-distinct degenerate case.
- **#176 (done):** added `ReportGenerationBenchmarks` (`[MemoryDiagnoser]`) covering the report-generation pipeline. `GenerateAssessmentReportAsync_EndToEnd` runs the public API with `[Params(Small, Medium, Large)]` — writes Excel (ClosedXML) and Word (OpenXml) to disk in unique per-invocation directories (using an `Interlocked` counter to dodge the timestamp-folder collision bug from the service deriving folder names from `DateTime.Now.ToString("yyyy-MM-dd__HH-mm-ss")`). `[IterationCleanup]` tolerantly deletes accumulated subfolders so disk usage stays bounded. Two pure helpers (`SanitizeFileName`, `CreateValidWorksheetName`) were promoted to `internal static` and exercised by bank benchmarks with `OperationsPerInvoke=100`. Class-level XML comment documents the higher-than-typical variance for the I/O benchmark and the single-database scope (multi-DB could be a follow-up).
- **#177 (done):** wired `JsonExporter.Full` into the BDN config so every run produces `BenchmarkDotNet.Artifacts/results/{class}-report-full.json` (per-benchmark statistics + memory diagnostics). Added a `compare-baseline` subcommand to the benchmark CLI that loads a tracked baseline from `baselines/baseline.json` and reports regressions: exit 0 (within tolerance / empty baseline), exit 1 (regression — `actual > baseline × toleranceFactor` for mean, or `actual > max(baseline × tolerance, baseline + floor)` for allocations), exit 2 (bad invocation, missing/malformed files, baseline-vs-report key drift). `--update` writes the report's actuals back as the new baseline while preserving per-benchmark `toleranceFactor` overrides. Default baseline path resolves to `<project>/baselines/baseline.json` via `AppContext.BaseDirectory` so `--update` edits the committed file directly; walks parent dirs as a fallback. Ships an empty baseline file (`toleranceFactor=2.00`, `allocationFloorBytes=1024`) — the empty state is a safe no-op so the regression check goes live once a maintainer runs `--update` against a representative `--job short` capture. README documents schema, capture/refresh workflow, exit codes, and forward-references CI integration in #178.
- **#178 (done):** added `.github/workflows/performance-regression.yml` — a dedicated workflow that runs the BenchmarkDotNet suite on every PR against `main`, on pushes to `main` (path-filtered to perf-relevant directories), and on `workflow_dispatch` (with an `update_baseline` input for manual seeding). The job (`name: Benchmark regression`, `ubuntu-latest`, `timeout-minutes: 45`) restores + builds the benchmarks project in Release, runs `dotnet run -- --filter "*"` (no `--job` flag, to preserve the InProcess toolchain pin from `BuildConfig()` which dodges BDN's apphost issue for `OutputType=Exe` referenced projects), then loops over every `*-report-full.json` invoking `compare-baseline --report <path>`. The compare step is skipped on `workflow_dispatch` with `update_baseline=true`; instead it invokes `compare-baseline --update` and uploads the refreshed `baselines/baseline.json` as an artifact for human review (no auto-commit — keeps the workflow read-only and avoids token churn). Both BDN artifacts and refreshed-baseline artifacts use `if-no-files-found: error`. Critical design choices: NO `paths:` filter on `pull_request` (required-check + paths filter pitfall would cause PRs not touching perf dirs to show an "expected but never reported" check that blocks merge); concurrency group `perf-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}` with `cancel-in-progress: true` to cancel superseded runs. README adds a "CI" section documenting triggers, manual seed path, artifact locations, and the Phase C required-check forward reference.
- **#179 (done):** added a new top-level `## ⚡ Performance & Benchmarking` section to the root README between "Analysis Capabilities" and "Troubleshooting" (147 lines, 6 subsections: Overview, Running benchmarks locally, Indicative allocation envelopes, Regression detection, CI integration, Deferred parent acceptance criteria). Added the `Performance Regression` workflow status badge alongside Build + CodeQL. Added a bullet to the `📚 Documentation` index linking to the benchmarks project README so readers scanning the index see the perf docs. Targets table covers all 12 benchmarks across the 3 subsystems, framed as a **bootstrap sizing guide, not an SLO** with values rounded to one significant figure (allocation only — explicit "Why no mean targets?" callout cites hardware variance). Most consequential addition: a `Deferred parent acceptance criteria` subsection that explicitly names the two unmet #79 acceptance criteria (`>10% degradation fails CI` and `Benchmark results published to GitHub Pages`) and links the follow-up issues (#234 and #233) that track them — addresses the rubber-duck blocker that `Closes #79` would otherwise silently drop those criteria when the PR merges.

## Testing

| Sub | Validation |
|---|---|
| #173 | `dotnet restore` + `dotnet build CosmosToSqlAssessment.sln -c Release` → succeeds (0 warnings introduced). `dotnet test` → 190 passed, 0 failed. `dotnet run -- --list flat` → discovers `SmokeBenchmarks.BuildAssessmentResult`. `dotnet run -- --filter *SmokeBenchmarks* --job dry --warmupCount 1 --iterationCount 1` → 1 iteration, 1.637 ms, 3.95 KB allocated (MemoryDiagnoser confirmed). |
| #174 | `dotnet build CosmosToSqlAssessment.sln -c Release` → 0 warnings, 0 errors. `dotnet test --no-build` → 190 passed (no regressions from the private → internal static refactor). `dotnet run -- --list flat` → 5 new benchmarks discovered. `dotnet run -- --filter *CosmosAnalysisBenchmarks* --job dry` → all 15 cases (5 benchmarks × 3 `Size` params) execute end-to-end with non-NA means; `ExtractFieldsFlat_Document` allocations scale monotonically with document size (3.8 KB → 10.39 KB → 17.76 KB). |
| #175 | `dotnet build CosmosToSqlAssessment.sln -c Release` → 0 errors (2 pre-existing test warnings unrelated). `dotnet test --no-build` → 190 passed (no regressions from the 2 `SqlProjectGenerationService` visibility promotions). `dotnet run -- --list flat` → 3 new benchmarks discovered. `dotnet run -- --filter *SqlAssessmentBenchmarks* --job dry` → all 9 cases execute end-to-end; `AssessMigrationAsync_EndToEnd` allocated bytes scale monotonically with `CosmosDbAnalysis` size (35.5 KB → 258 KB → 1.17 MB). |
| #176 | `dotnet build CosmosToSqlAssessment.sln -c Release` → 0 errors. `dotnet test --no-build` → 190 passed (no regressions from `SanitizeFileName` / `CreateValidWorksheetName` visibility promotions). `dotnet run -- --list flat` → 3 new benchmarks discovered. `dotnet run -- --filter *ReportGenerationBenchmarks* --job dry` → all 9 cases execute end-to-end; `GenerateAssessmentReportAsync_EndToEnd` allocations scale strongly with input size (4.4 MB → 33.7 MB → 343 MB). |
| #177 | `dotnet build CosmosToSqlAssessment.sln -c Release` → 0 warnings, 0 errors. `dotnet test --no-build` → 190 passed. `dotnet run -- --list flat` → still 12 benchmarks discovered (no regressions). End-to-end round-trip on the `SmokeBenchmarks` dry-run report: (1) compare against empty baseline → exit 0 with "report-only" hint; (2) `--update` → seeds the baseline; (3) re-compare → exit 0, 0.0% delta on both axes; (4) plant a regression (shrink baseline 10× on mean, 100× on allocations) → exit 1 with `+900.0%` mean Δ + `+9934.8%` alloc Δ and an explicit threshold breakdown; (5) missing `--report` → exit 2; (6) report path that doesn't exist → exit 2; (7) baseline with entries but zero report matches → exit 2 ("possible FullName/schema drift"). JsonExporter confirmed writing `BenchmarkDotNet.Artifacts/results/*-report-full.json` for every benchmark class. |
| #178 | Local: `python -c "import yaml; yaml.safe_load(open('.github/workflows/performance-regression.yml'))"` → parses cleanly. End-to-end on PR #231: Actions run [27573637535](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/actions/runs/27573637535) — `Benchmark regression` job completed in **11.4 min** total (Setup .NET 7s, restore 20s, build 21s, run benchmarks 621s, compare 3s exit 0, artifact upload 2s). `workflow_dispatch`-only steps `Refresh baseline` + `Upload refreshed baseline` correctly skipped on the PR trigger. `BenchmarkDotNet.Artifacts` uploaded with all 12 benchmarks' `*-report-full.json` files. Compare step exited 0 against the empty baseline (no-op, as designed in #177). Phase C will register `Benchmark regression` as a required status check on `main` once this PR merges. |
| #179 | `dotnet build CosmosToSqlAssessment.sln -c Release` → succeeds (0 errors, 2 pre-existing warnings unrelated). `dotnet test --no-build` → 190 passed, 0 failed. Manual visual review of README: badge added at line 5, `📚 Documentation` index gains bullet at line 157, new `## ⚡ Performance & Benchmarking` section spans lines 332-478 (147 lines, 6 subsections). All relative links resolved: `tests/Performance/CosmosToSqlAssessment.Benchmarks/README.md`, `.github/workflows/performance-regression.yml`, `baselines/baseline.json`, the `#seeding--refreshing-the-baseline` anchor on the benchmarks README. Badge URL `Performance%20Regression` matches the workflow `name:` field. |

## Branch-protection changes

A new required status check **`Benchmark regression`** (from `.github/workflows/performance-regression.yml`, added in #178) will be added to `main` branch protection in Phase C, after this PR merges and the workflow has executed at least once on `main`. The check fails on `compare-baseline` exit 1 (regression beyond tolerance) or exit 2 (bad invocation / baseline-vs-report schema drift); empty baseline yields a no-op exit 0, so the safety net activates the moment a maintainer commits a seeded `baselines/baseline.json`.

## Deferred parent acceptance criteria

Two parent #79 acceptance criteria are intentionally deferred to keep this PR's scope tight and to avoid shipping a regression check that would generate false-positive blockers on its first day. Both are tracked by dedicated follow-up issues so the deferral is traceable rather than silently dropped:

- **>10% degradation fails CI** → tracked by **#234**. The framework supports this contract (per-benchmark `toleranceFactor` overrides in `baselines/baseline.json`); the shipped default is `2.00x` to avoid first-day false positives on an empty baseline. #234 covers seeding the baseline on the CI runner, characterising runner variance, and stepping `defaultToleranceFactor` down to `1.10` once two consecutive runs are clean.
- **Benchmark results published to GitHub Pages** → tracked by **#233**. The current design uploads `BenchmarkDotNet.Artifacts/` as a workflow artifact on every run (sufficient for inspection); a GitHub Pages dashboard via `benchmark-action/github-action-benchmark` is the natural next step but requires `gh-pages` write permissions and a pinned runner SKU first.

Documented in the root README's new "Deferred parent acceptance criteria" subsection.

---

🤖 Driven by autonomous worker session for parent #79. Wave-1 parent; #129 depends on the BenchmarkDotNet framework produced here.
