### PR TITLE
Parent #77: Replace placeholder security scanning with actual tools

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,0 +1,30 @@
+# Dependency review policy for actions/dependency-review-action.
+#
+# Single source of truth for the dependency-vulnerability threshold —
+# referenced from .github/workflows/dependency-review.yml. Keep the
+# workflow free of inline `with:` policy keys so this file stays the
+# canonical place to tune the gate.
+#
+# See SECURITY.md for the full threshold matrix and rationale.
+
+# Fail the PR check when a dependency change introduces a vulnerability
+# at this severity or above. Tune up (moderate/low) as the project matures.
+fail-on-severity: high
+
+# Apply the threshold to every dependency scope, not just runtime. This
+# keeps test-project and build-tool deps in scope — otherwise dev/unknown
+# CVEs would silently slip past the gate.
+fail-on-scopes:
+  - runtime
+  - development
+  - unknown
+
+# Block on vulnerabilities; do not gate on licenses here (license
+# compliance is a separate concern outside the scope of parent #77).
+vulnerability-check: true
+license-check: false
+
+# Post the dependency-review summary as a PR comment only when the
+# gate fails. Keeps clean PRs uncluttered while still surfacing
+# blockers inline.
+comment-summary-in-pr: on-failure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,38 +124,6 @@ jobs:
           **/*.trx
         retention-days: 30
 
-  code-quality:
-    runs-on: ubuntu-latest
-    needs: build
-    
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: ${{ env.DOTNET_VERSION }}
-        
-    - name: Restore dependencies
-      run: dotnet restore CosmosToSqlAssessment.sln
-      
-    - name: Run security analysis
-      run: |
-        # Install security analysis tools
-        dotnet tool install --global security-scan
-        # Note: This is a placeholder - adjust based on your preferred security scanning tools
-        echo "Security analysis completed"
-      continue-on-error: true
-      
-    - name: Check for sensitive data
-      run: |
-        # Check for common sensitive patterns
-        if grep -r "password\|secret\|key.*=" --include="*.cs" --include="*.json" --exclude-dir=".git" . ; then
-          echo "::warning::Potential sensitive data found"
-        fi
-        echo "Sensitive data check completed"
-
   multi-platform-build:
     strategy:
       matrix:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,49 +1,65 @@
-name: "CodeQL Security Analysis"
+name: CodeQL
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '0 6 * * 1' # Weekly on Mondays at 6 AM UTC
+    - cron: '0 6 * * 1'  # Weekly: Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   analyze:
-    name: Analyze
+    name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
 
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'csharp' ]
+        include:
+          - language: csharp
+            build-mode: manual
+            queries: security-extended,security-and-quality
+          - language: actions
+            build-mode: none
+            queries: security-extended
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-        queries: security-extended,security-and-quality
+      - name: Setup .NET
+        if: matrix.language == 'csharp'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: '8.0.x'
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: ${{ matrix.queries }}
 
-    - name: Restore dependencies
-      run: dotnet restore CosmosToSqlAssessment.csproj
+      - name: Restore dependencies (csharp)
+        if: matrix.language == 'csharp'
+        run: dotnet restore CosmosToSqlAssessment.sln
 
-    - name: Build
-      run: dotnet build CosmosToSqlAssessment.csproj --configuration Release --no-restore
+      - name: Build solution (csharp)
+        if: matrix.language == 'csharp'
+        run: dotnet build CosmosToSqlAssessment.sln --configuration Release --no-restore
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,131 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '30 6 * * 1'  # Weekly Mondays 06:30 UTC (offset from CodeQL)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    name: dependency-review
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure
+
+  nuget-audit:
+    name: nuget-audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+
+      - name: Restore solution
+        run: dotnet restore CosmosToSqlAssessment.sln
+
+      - name: Audit NuGet packages for vulnerabilities (incl. transitive)
+        id: audit
+        shell: bash
+        run: |
+          set +e
+          dotnet list CosmosToSqlAssessment.sln package \
+            --vulnerable --include-transitive \
+            --format json --output-version 1 \
+            > vuln-report.json 2> vuln-report.err
+          rc=$?
+          set -e
+
+          echo "::group::Raw dotnet list output (stderr)"
+          cat vuln-report.err || true
+          echo "::endgroup::"
+          echo "::group::Raw dotnet list output (json)"
+          cat vuln-report.json || true
+          echo "::endgroup::"
+
+          if [ ! -s vuln-report.json ]; then
+            echo "::error::dotnet list produced no JSON output (exit $rc). See stderr above."
+            exit 1
+          fi
+
+          # Threshold matches dependency-review-action: high+ blocks the PR.
+          # jq pulls every vulnerability across every project/framework/package
+          # and filters by severity. Empty result == pass.
+          high_or_critical=$(jq -r '
+            [
+              .projects[]?.frameworks[]?
+              | (.topLevelPackages, .transitivePackages)[]?
+              | .vulnerabilities[]?
+              | select((.severity // "" | ascii_downcase) as $s
+                       | $s == "high" or $s == "critical")
+            ]
+            | length
+          ' vuln-report.json)
+
+          total=$(jq -r '
+            [
+              .projects[]?.frameworks[]?
+              | (.topLevelPackages, .transitivePackages)[]?
+              | .vulnerabilities[]?
+            ]
+            | length
+          ' vuln-report.json)
+
+          echo "Total vulnerabilities found: ${total}"
+          echo "High or Critical: ${high_or_critical}"
+
+          if [ "${high_or_critical}" -gt 0 ]; then
+            echo "::error::Found ${high_or_critical} High/Critical NuGet vulnerabilities (out of ${total} total). Failing."
+            jq -r '
+              .projects[]?
+              | .path as $proj
+              | .frameworks[]?
+              | .framework as $tfm
+              | (.topLevelPackages, .transitivePackages)[]?
+              | . as $pkg
+              | .vulnerabilities[]?
+              | select((.severity // "" | ascii_downcase) as $s
+                       | $s == "high" or $s == "critical")
+              | "  - \($proj) [\($tfm)] \($pkg.id)@\($pkg.resolvedVersion // $pkg.requestedVersion) — \(.severity): \(.advisoryUrl)"
+            ' vuln-report.json
+            exit 1
+          fi
+
+          if [ "${total}" -gt 0 ]; then
+            echo "::warning::Found ${total} lower-severity NuGet vulnerabilities (none High/Critical). Not failing the build."
+          fi
+
+      - name: Upload vulnerability report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nuget-vulnerability-report
+          path: |
+            vuln-report.json
+            vuln-report.err
+          retention-days: 30

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -29,8 +29,7 @@ jobs:
       - name: Dependency Review
         uses: actions/dependency-review-action@v4
         with:
-          fail-on-severity: high
-          comment-summary-in-pr: on-failure
+          config-file: ./.github/dependency-review-config.yml
 
   nuget-audit:
     name: nuget-audit

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,35 @@
+name: Secret Scan
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+  schedule:
+    - cron: '0 7 * * 1'  # Weekly Mondays 07:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  secret-scan:
+    name: secret-scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: gitleaks
+        uses: gitleaks/gitleaks-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,22 @@
+# Gitleaks configuration for cosmosdb-to-sql-migration-tool.
+#
+# Loaded automatically by gitleaks/gitleaks-action@v3 from the repo root.
+# See SECURITY.md for the full threshold matrix and rationale.
+#
+# To allowlist a false positive in the future, add a block like:
+#
+#   [[allowlists]]
+#   description = "Why this match is safe"
+#   paths = ['''^docs/example/sample-config\.json$''']
+#   regexes = ['''dummy-token-[0-9a-f]+''']
+#
+# Use [[allowlists]] (table-of-tables) — the legacy [allowlist] table is
+# deprecated in gitleaks v8.
+
+title = "cosmosdb-to-sql-migration-tool gitleaks config"
+
+[extend]
+# Load the upstream default rule pack (hundreds of detectors for AWS,
+# Azure, GCP, GitHub, OpenAI, etc.). Custom rules and allowlists can
+# be layered in below as needed.
+useDefault = true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,22 +118,88 @@ If you have access to a Cosmos DB account:
 4. Update command-line arguments if needed
 5. Ensure proper error handling and logging
 
-## 🔒 Security Guidelines
+## Security Requirements
 
-### Authentication
-- Use `DefaultAzureCredential` for all Azure authentication
-- Never hardcode credentials or connection strings
-- Support multiple authentication methods
+Every PR to `main` must pass four security checks. The thresholds and full triage matrix live in [SECURITY.md](SECURITY.md); this section is the developer-facing summary.
 
-### Data Handling
-- No sensitive data should be logged
-- Minimize data retention in memory
-- Use secure temporary files when needed
+### Required CI checks
+| Check | Workflow | Fails on |
+| --- | --- | --- |
+| CodeQL SAST (csharp + actions) | [`codeql.yml`](.github/workflows/codeql.yml) | Build/analysis errors only — alerts surface in the **Security → Code scanning** tab |
+| Dependency Review | [`dependency-review.yml`](.github/workflows/dependency-review.yml) | A PR-diff dep change introducing a High/Critical CVE |
+| NuGet Audit | [`dependency-review.yml`](.github/workflows/dependency-review.yml) | A High/Critical CVE anywhere in resolved deps (incl. transitive) |
+| Secret Scan (gitleaks) | [`secret-scan.yml`](.github/workflows/secret-scan.yml) | Any leaked secret in git history |
 
-### Configuration
-- Keep sensitive settings out of `appsettings.json`
-- Use command-line arguments for environment-specific values
-- Validate all input parameters
+### Running scans locally before pushing
+
+**NuGet vulnerability audit** — mirrors the `nuget-audit` CI job:
+```bash
+dotnet list CosmosToSqlAssessment.sln package --vulnerable --include-transitive
+```
+> ℹ️ This command is informational and may exit `0` even when vulnerabilities are listed. Read the output; CI is the authoritative gate.
+
+**Secret scan** — mirrors the `secret-scan` CI job:
+```bash
+# Linux/macOS (Docker)
+docker run --rm -v "$(pwd):/repo" zricethezav/gitleaks:latest detect --source /repo
+
+# Or, if gitleaks is installed locally
+gitleaks detect --source .
+```
+```powershell
+# Windows PowerShell (Docker)
+docker run --rm -v "${PWD}:/repo" zricethezav/gitleaks:latest detect --source /repo
+```
+
+**CodeQL** — impractical to reproduce on a developer laptop. View alerts in the GitHub UI under **Security → Code scanning** after pushing. PR-introduced alerts also appear inline as review comments.
+
+**Dependency Review** — only meaningful against the PR diff, so it cannot be fully reproduced locally. Inspect your dependency changes manually and rely on the CI check for the final verdict.
+
+### Fixing a failing check
+
+- **CodeQL alert** — open the alert in the Security tab, follow **Show paths** to understand the dataflow, then either fix the code or **Dismiss** with a documented reason (`False positive`, `Used in tests`, `Won't fix`). Never dismiss without a reason.
+- **Dependency Review fail** — bump the offending direct dependency to a patched version (`dotnet add package <name>`), push, re-run.
+- **NuGet Audit fail** — same as above. If the vuln is in a transitive dep, bump the parent direct dep or pin the transitive via an explicit `<PackageReference>` in the project file.
+- **Gitleaks fail** — **rotate the leaked credential immediately** — assume any value committed to git history is compromised. Then either remove the offending file or, only if the match is a genuine false positive (e.g., a documentation example), add an `[[allowlists]]` entry as shown below.
+
+### Adding a gitleaks allowlist entry
+
+Edit [`.gitleaks.toml`](.gitleaks.toml) and add a `[[allowlists]]` table-of-tables block (the legacy `[allowlist]` form is deprecated in gitleaks v8):
+
+```toml
+[[allowlists]]
+description = "Sample API key in onboarding docs — not a real credential"
+paths = ['''^docs/getting-started\.md$''']
+regexes = ['''AKIA[0-9A-Z]{16}EXAMPLE''']
+```
+
+**Allowlist discipline:**
+- Keep entries narrow. Prefer specific `paths`, `regexes`, or `commits`. Never use broad wildcards.
+- Always include a `description` explaining *why* the match is safe — the description is the audit trail.
+- If the value is a real secret, **rotate first, then remove from history**. Allowlisting a real secret is not an acceptable fix.
+
+### Reporting a vulnerability
+
+Do not open a public GitHub issue. Use the private reporting flow described in [SECURITY.md → Reporting a Vulnerability](SECURITY.md#reporting-a-vulnerability).
+
+### Secure coding
+
+In addition to passing the automated scans, keep the following in mind:
+
+**Authentication**
+- Use `DefaultAzureCredential` for all Azure authentication.
+- Never hardcode credentials or connection strings.
+- Support multiple authentication methods.
+
+**Data handling**
+- No sensitive data should be logged.
+- Minimize data retention in memory.
+- Use secure temporary files when needed.
+
+**Configuration**
+- Keep sensitive settings out of `appsettings.json`.
+- Use command-line arguments for environment-specific values.
+- Validate all input parameters.
 
 ## 📖 Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Cosmos DB to SQL Migration Assessment Tool
 
-[![Build Status](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/workflows/Build/badge.svg)](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/actions)
-[![CodeQL](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/workflows/CodeQL/badge.svg)](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/actions)
-[![Performance Regression](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/workflows/Performance%20Regression/badge.svg)](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/actions/workflows/performance-regression.yml)
+[![Build and Test](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/actions/workflows/build.yml)
+[![CodeQL](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/actions/workflows/codeql.yml)
+[![Dependency Review](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/actions/workflows/dependency-review.yml/badge.svg?branch=main)](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/actions/workflows/dependency-review.yml)
+[![Secret Scan](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/actions/workflows/secret-scan.yml/badge.svg?branch=main)](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/actions/workflows/secret-scan.yml)
+[![Performance Regression](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/actions/workflows/performance-regression.yml/badge.svg?branch=main)](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/actions/workflows/performance-regression.yml)
+[![Security Policy](https://img.shields.io/github/security-policy-available/JoshLuedeman/cosmosdb-to-sql-migration-tool)](SECURITY.md)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![.NET 8.0](https://img.shields.io/badge/.NET-8.0-purple.svg)](https://dotnet.microsoft.com/)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,53 @@
+# Security Policy
+
+The `cosmosdb-to-sql-migration-tool` repository takes security seriously. This document describes the security scanning we run, the thresholds that gate merges, and how to report a vulnerability privately.
+
+## Supported Versions
+
+Only the latest tagged release of the tool is actively supported with security fixes. Older releases may be patched on a best-effort basis when the fix is trivial.
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in this project, **please do not open a public GitHub issue.** Instead, use GitHub's private vulnerability reporting flow:
+
+1. Go to the repository's [**Security** tab](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/security).
+2. Click **Report a vulnerability**.
+3. Provide a clear description of the issue, including reproduction steps and the affected version.
+
+You should receive an acknowledgement within 7 days. If you do not, please follow up via a GitHub Discussion (without disclosing the vulnerability details).
+
+## Automated security scanning
+
+Every pull request that targets `main` runs four security checks. Each check is also re-run on a weekly schedule against `main` so we catch vulnerabilities that surface in already-merged dependencies.
+
+| # | Tool | Workflow | Triggers | Fails on | Rationale |
+|---|---|---|---|---|---|
+| 1 | **CodeQL SAST** (csharp + actions) | [`codeql.yml`](.github/workflows/codeql.yml) | push/PR to `main`, weekly cron, dispatch | Build/analysis errors only — security alerts surface in the **Security → Code scanning** tab | Tuning false-positives against the `security-extended` + `security-and-quality` suites is best done as alert triage, not as a hard merge gate. PRs that *introduce* new alerts are surfaced inline. |
+| 2 | **Dependency Review** | [`dependency-review.yml`](.github/workflows/dependency-review.yml) (`dependency-review` job) | PR to `main` | A PR-diff dependency change that introduces a **High** or **Critical** CVE in any scope (`runtime`, `development`, `unknown`) | Conventional baseline. Policy lives in [`.github/dependency-review-config.yml`](.github/dependency-review-config.yml) so it is a single source of truth and easy to tighten over time. |
+| 3 | **NuGet Audit** | [`dependency-review.yml`](.github/workflows/dependency-review.yml) (`nuget-audit` job) | PR to `main`, weekly cron, dispatch | Any **High** or **Critical** vulnerability reported by `dotnet list package --vulnerable --include-transitive` (including transitive deps) | Catches CVEs in already-resolved deps that the PR diff didn't touch. Severity threshold matches Dependency Review so the two share one effective baseline. |
+| 4 | **Gitleaks Secret Scan** | [`secret-scan.yml`](.github/workflows/secret-scan.yml) | push/PR to `main`, weekly cron, dispatch | **Any** leaked secret detected anywhere in git history | Secrets are binary — there is no "low severity" leaked credential. Config lives in [`.gitleaks.toml`](.gitleaks.toml). |
+
+GitHub-native push protection and secret scanning are also enabled on this public repository at no cost, providing a second layer of defense before commits even reach the remote.
+
+## Triaging findings
+
+### CodeQL alerts (Security → Code scanning)
+- New alerts on PRs appear inline as PR review comments.
+- Open the alert, follow the **Show paths** link to understand the dataflow, and either fix the code or **Dismiss** with a reason (`False positive`, `Used in tests`, `Won't fix`).
+- Never dismiss without a reason — the reason is the audit trail for future maintainers.
+
+### Dependency Review / NuGet Audit failures
+- Read the PR comment (Dependency Review posts on failure) or the workflow log (NuGet Audit prints each violating package with its CVE link).
+- Preferred fix order:
+  1. Bump the direct dependency to a patched version (`dotnet add package <name>`).
+  2. If the vuln is in a transitive dep, bump the parent direct dep, or pin the transitive via `<PackageReference>` in the project file.
+  3. If no fix is available, comment on the PR explaining the temporary acceptance and open a follow-up issue tagged `security`.
+
+### Gitleaks findings
+- Inspect the leaked credential and **rotate it immediately** if it was ever real. Assume any value committed to git history is compromised.
+- If the match is a genuine false positive (e.g., a documentation example), add an entry to `[[allowlists]]` in `.gitleaks.toml` with a description explaining why.
+- Never bypass a gitleaks failure without rotating + allowlisting.
+
+## Contributor guidance
+
+See [CONTRIBUTING.md](CONTRIBUTING.md#security-requirements) for the developer-facing summary: how to run scans locally, how to fix common findings, and how to add false-positive allowlists in a reviewable way.


### PR DESCRIPTION
Closes #77

This PR replaces the placeholder security scanning with real GitHub-native tools, configures thresholds, adds README badges, and documents the requirements.

## Sub-issues

- [x] #161 — Add SAST scanning (CodeQL) ✅
- [x] #162 — Add dependency vulnerability scanning ✅
- [ ] #163 — Add secrets scanning
- [ ] #164 — Configure scan thresholds
- [ ] #165 — Add security scanning badges to README
- [ ] #166 — Document security requirements in CONTRIBUTING.md

## Implementation approach

### #161 — CodeQL
- Rewrote `.github/workflows/codeql.yml` with a two-language matrix: `csharp` (build-mode: `manual`, builds the full solution) and `actions` (build-mode: `none`, scans workflow YAML; GA April 2025).
- Per-language query suites: `security-extended,security-and-quality` for csharp, `security-extended` for actions.
- Removed placeholder `code-quality` job from `build.yml`.

### #162 — Dependency vulnerability scanning
- New `.github/workflows/dependency-review.yml` with two jobs:
  - `dependency-review` (PR) — `actions/dependency-review-action@v4`, `fail-on-severity: high`, PR comment on failure.
  - `nuget-audit` (PR + weekly schedule) — runs `dotnet list package --vulnerable --include-transitive --format json` and parses with jq; fails on High/Critical, warns on lower; uploads JSON artifact for triage.
- Defensive shell wrapper since `dotnet list --vulnerable` exits 0 even when vulns exist (NuGet/Home#11183).

## Testing

- ✅ #161 — actionlint clean; `dotnet build` Release green; CodeQL matrix (csharp + actions) green on [run 27576413703](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/actions/runs/27576413703).
- ✅ #162 — actionlint clean; both jobs (`dependency-review`, `nuget-audit`) green on [run 27576911641](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/actions/runs/27576911641); zero current NuGet vulnerabilities.

## Branch-protection changes

After all sub-issues land, the following status checks will be added as **required** on `main` (Phase C):

- `Analyze (csharp)` (CodeQL workflow)
- `Analyze (actions)` (CodeQL workflow)
- `dependency-review` (Dependency Review workflow)
- `nuget-audit` (Dependency Review workflow)
- `secret-scan` (Secret Scanning workflow — pending #163)

---
🤖 Worked autonomously by Copilot CLI.