### PR TITLE
Parent #71: Add interactive wizard mode

### DIFF
--- a/Cli/CliArgumentParser.cs
+++ b/Cli/CliArgumentParser.cs
@@ -81,6 +81,10 @@ internal static class CliArgumentParser
                 case "--test-connection":
                     options.TestConnection = true;
                     break;
+                case "--interactive":
+                case "-i":
+                    options.Interactive = true;
+                    break;
                 default:
                     output.WriteLine($"Unknown argument: {args[i]}");
                     DisplayHelp(output);
@@ -103,6 +107,13 @@ internal static class CliArgumentParser
         {
             output.WriteLine("❌ Error: Cannot specify both --assessment-only and --project-only flags.");
             output.WriteLine("   Use one or the other, or omit both for default behavior (generate both).");
+            return false;
+        }
+
+        if (options.Interactive && options.TestConnection)
+        {
+            output.WriteLine("❌ Error: Cannot specify both --interactive and --test-connection flags.");
+            output.WriteLine("   Use --test-connection for a quick connectivity diagnostic, or --interactive for guided wizard mode.");
             return false;
         }
 
@@ -133,6 +144,7 @@ internal static class CliArgumentParser
         output.WriteLine("  --assessment-only         Generate assessment reports only (skip SQL project generation)");
         output.WriteLine("  --project-only            Generate SQL projects only (skip assessment reports)");
         output.WriteLine("  --test-connection         Test connectivity to Cosmos DB and Azure Monitor");
+        output.WriteLine("  -i, --interactive         Launch interactive wizard mode for guided configuration");
         output.WriteLine();
         output.WriteLine("Examples:");
         output.WriteLine("  CosmosToSqlAssessment --all-databases");

--- a/Cli/CliArgumentParser.cs
+++ b/Cli/CliArgumentParser.cs
@@ -98,6 +98,9 @@ internal static class CliArgumentParser
                         options.SaveConfigFile = args[++i];
                     }
                     break;
+                case "--resume":
+                    options.ResumeSession = true;
+                    break;
                 default:
                     output.WriteLine($"Unknown argument: {args[i]}");
                     DisplayHelp(output);
@@ -160,6 +163,7 @@ internal static class CliArgumentParser
         output.WriteLine("  -i, --interactive         Launch interactive wizard mode for guided configuration");
         output.WriteLine("  -c, --config <path>       Load configuration from a saved JSON file");
         output.WriteLine("  --save-config <path>      Save wizard configuration to a JSON file for reuse");
+        output.WriteLine("  --resume                  Resume an interrupted interactive wizard session");
         output.WriteLine();
         output.WriteLine("Examples:");
         output.WriteLine("  CosmosToSqlAssessment --all-databases");

--- a/Cli/CliArgumentParser.cs
+++ b/Cli/CliArgumentParser.cs
@@ -85,6 +85,19 @@ internal static class CliArgumentParser
                 case "-i":
                     options.Interactive = true;
                     break;
+                case "--config":
+                case "-c":
+                    if (i + 1 < args.Length)
+                    {
+                        options.ConfigFile = args[++i];
+                    }
+                    break;
+                case "--save-config":
+                    if (i + 1 < args.Length)
+                    {
+                        options.SaveConfigFile = args[++i];
+                    }
+                    break;
                 default:
                     output.WriteLine($"Unknown argument: {args[i]}");
                     DisplayHelp(output);
@@ -145,6 +158,8 @@ internal static class CliArgumentParser
         output.WriteLine("  --project-only            Generate SQL projects only (skip assessment reports)");
         output.WriteLine("  --test-connection         Test connectivity to Cosmos DB and Azure Monitor");
         output.WriteLine("  -i, --interactive         Launch interactive wizard mode for guided configuration");
+        output.WriteLine("  -c, --config <path>       Load configuration from a saved JSON file");
+        output.WriteLine("  --save-config <path>      Save wizard configuration to a JSON file for reuse");
         output.WriteLine();
         output.WriteLine("Examples:");
         output.WriteLine("  CosmosToSqlAssessment --all-databases");

--- a/Cli/CliOptions.cs
+++ b/Cli/CliOptions.cs
@@ -18,4 +18,5 @@ internal sealed class CliOptions
     public bool Interactive { get; set; }
     public string? ConfigFile { get; set; }
     public string? SaveConfigFile { get; set; }
+    public bool ResumeSession { get; set; }
 }

--- a/Cli/CliOptions.cs
+++ b/Cli/CliOptions.cs
@@ -16,4 +16,6 @@ internal sealed class CliOptions
     public bool ProjectOnly { get; set; }
     public bool TestConnection { get; set; }
     public bool Interactive { get; set; }
+    public string? ConfigFile { get; set; }
+    public string? SaveConfigFile { get; set; }
 }

--- a/Cli/CliOptions.cs
+++ b/Cli/CliOptions.cs
@@ -15,4 +15,5 @@ internal sealed class CliOptions
     public bool AssessmentOnly { get; set; }
     public bool ProjectOnly { get; set; }
     public bool TestConnection { get; set; }
+    public bool Interactive { get; set; }
 }

--- a/Interactive/ConfigurationStore.cs
+++ b/Interactive/ConfigurationStore.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using CosmosToSqlAssessment.Cli;
+
+namespace CosmosToSqlAssessment.Interactive;
+
+/// <summary>
+/// Abstraction for persisting wizard configuration.
+/// </summary>
+internal interface IConfigurationStore
+{
+    /// <summary>Saves configuration to the specified path.</summary>
+    void Save(WizardConfiguration config, string path);
+
+    /// <summary>Loads configuration from the specified path, or null if not found.</summary>
+    WizardConfiguration? Load(string path);
+}
+
+/// <summary>
+/// JSON file-based implementation of <see cref="IConfigurationStore"/>.
+/// </summary>
+internal sealed class JsonConfigurationStore : IConfigurationStore
+{
+    private static readonly JsonSerializerOptions _options = new()
+    {
+        WriteIndented = true
+    };
+
+    public void Save(WizardConfiguration config, string path)
+    {
+        var json = JsonSerializer.Serialize(config, _options);
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+        File.WriteAllText(path, json);
+    }
+
+    public WizardConfiguration? Load(string path)
+    {
+        if (!File.Exists(path))
+            return null;
+
+        var json = File.ReadAllText(path);
+        return JsonSerializer.Deserialize<WizardConfiguration>(json);
+    }
+
+    /// <summary>
+    /// Converts a <see cref="WizardConfiguration"/> to <see cref="CliOptions"/>.
+    /// </summary>
+    public static CliOptions ToCliOptions(WizardConfiguration config)
+    {
+        return new CliOptions
+        {
+            AccountEndpoint = config.Endpoint,
+            AnalyzeAllDatabases = config.AnalyzeAllDatabases,
+            DatabaseName = config.DatabaseName,
+            WorkspaceId = config.WorkspaceId,
+            AutoDiscoverMonitoring = config.AutoDiscover,
+            OutputDirectory = config.OutputDirectory,
+            AssessmentOnly = config.AssessmentOnly,
+            ProjectOnly = config.ProjectOnly,
+            Interactive = true
+        };
+    }
+
+    /// <summary>
+    /// Converts <see cref="CliOptions"/> to a <see cref="WizardConfiguration"/>.
+    /// </summary>
+    public static WizardConfiguration FromCliOptions(CliOptions options)
+    {
+        return new WizardConfiguration
+        {
+            Endpoint = options.AccountEndpoint,
+            AnalyzeAllDatabases = options.AnalyzeAllDatabases,
+            DatabaseName = options.DatabaseName,
+            WorkspaceId = options.WorkspaceId,
+            AutoDiscover = options.AutoDiscoverMonitoring,
+            OutputDirectory = options.OutputDirectory,
+            AssessmentOnly = options.AssessmentOnly,
+            ProjectOnly = options.ProjectOnly
+        };
+    }
+}

--- a/Interactive/ConsoleProgressReporter.cs
+++ b/Interactive/ConsoleProgressReporter.cs
@@ -1,0 +1,47 @@
+namespace CosmosToSqlAssessment.Interactive;
+
+/// <summary>
+/// Console-based progress reporter that displays step status with
+/// simple text indicators (✓, ✗, ⏳).
+/// </summary>
+internal sealed class ConsoleProgressReporter : IProgressReporter
+{
+    private readonly TextWriter _output;
+    private DateTime _stepStartTime;
+
+    public ConsoleProgressReporter(TextWriter? output = null)
+    {
+        _output = output ?? Console.Out;
+    }
+
+    public void StartStep(string stepName)
+    {
+        _stepStartTime = DateTime.UtcNow;
+        _output.WriteLine($"⏳ {stepName}...");
+    }
+
+    public void CompleteStep(string stepName)
+    {
+        var elapsed = DateTime.UtcNow - _stepStartTime;
+        _output.WriteLine($"✅ {stepName} (completed in {FormatElapsed(elapsed)})");
+    }
+
+    public void FailStep(string stepName, string errorMessage)
+    {
+        _output.WriteLine($"❌ {stepName} failed: {errorMessage}");
+    }
+
+    public void ReportProgress(string message)
+    {
+        _output.WriteLine($"   ℹ️ {message}");
+    }
+
+    private static string FormatElapsed(TimeSpan elapsed)
+    {
+        if (elapsed.TotalSeconds < 1)
+            return $"{elapsed.TotalMilliseconds:F0}ms";
+        if (elapsed.TotalMinutes < 1)
+            return $"{elapsed.TotalSeconds:F1}s";
+        return $"{elapsed.TotalMinutes:F1}min";
+    }
+}

--- a/Interactive/IProgressReporter.cs
+++ b/Interactive/IProgressReporter.cs
@@ -1,0 +1,20 @@
+namespace CosmosToSqlAssessment.Interactive;
+
+/// <summary>
+/// Abstraction for reporting progress during analysis operations.
+/// Enables unit testing without live console output.
+/// </summary>
+internal interface IProgressReporter
+{
+    /// <summary>Signals that a named step is starting.</summary>
+    void StartStep(string stepName);
+
+    /// <summary>Signals that the current step completed successfully.</summary>
+    void CompleteStep(string stepName);
+
+    /// <summary>Signals that the current step failed.</summary>
+    void FailStep(string stepName, string errorMessage);
+
+    /// <summary>Reports an intermediate progress message within a step.</summary>
+    void ReportProgress(string message);
+}

--- a/Interactive/IWizardConsole.cs
+++ b/Interactive/IWizardConsole.cs
@@ -1,0 +1,33 @@
+namespace CosmosToSqlAssessment.Interactive;
+
+/// <summary>
+/// Abstraction over console I/O for the interactive wizard.
+/// Enables unit testing without a live TTY.
+/// </summary>
+internal interface IWizardConsole
+{
+    /// <summary>
+    /// Prompts the user for a text value. Returns the user's input or
+    /// <paramref name="defaultValue"/> if the user enters nothing.
+    /// </summary>
+    string Prompt(string message, string? defaultValue = null);
+
+    /// <summary>
+    /// Presents a numbered list of choices and returns the selected item.
+    /// </summary>
+    T Select<T>(string title, IReadOnlyList<T> choices) where T : notnull;
+
+    /// <summary>
+    /// Asks a yes/no confirmation question.
+    /// </summary>
+    bool Confirm(string message, bool defaultValue = true);
+
+    /// <summary>Writes an informational message.</summary>
+    void WriteInfo(string message);
+
+    /// <summary>Writes an error message.</summary>
+    void WriteError(string message);
+
+    /// <summary>Writes a blank line.</summary>
+    void WriteLine();
+}

--- a/Interactive/IWizardConsole.cs
+++ b/Interactive/IWizardConsole.cs
@@ -30,4 +30,9 @@ internal interface IWizardConsole
 
     /// <summary>Writes a blank line.</summary>
     void WriteLine();
+
+    /// <summary>
+    /// Prompts repeatedly until the validator returns null (valid).
+    /// </summary>
+    string PromptWithValidation(string message, Func<string, string?> validator, string? defaultValue = null);
 }

--- a/Interactive/InputValidators.cs
+++ b/Interactive/InputValidators.cs
@@ -1,0 +1,69 @@
+namespace CosmosToSqlAssessment.Interactive;
+
+/// <summary>
+/// Pure static validation functions for wizard inputs.
+/// Each returns null if valid, or an error message string if invalid.
+/// </summary>
+internal static class InputValidators
+{
+    /// <summary>
+    /// Validates a Cosmos DB account endpoint URL.
+    /// Must be a valid absolute HTTPS URI.
+    /// </summary>
+    public static string? ValidateEndpoint(string input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+            return "Endpoint cannot be empty.";
+
+        if (!Uri.TryCreate(input, UriKind.Absolute, out var uri))
+            return "Invalid URL format. Please enter a valid absolute URL.";
+
+        if (uri.Scheme != "https" && uri.Scheme != "http")
+            return "Endpoint must use HTTPS (or HTTP for local emulator).";
+
+        return null;
+    }
+
+    /// <summary>
+    /// Validates a database name (must be non-empty).
+    /// </summary>
+    public static string? ValidateDatabaseName(string input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+            return "Database name cannot be empty.";
+
+        if (input.Length > 255)
+            return "Database name is too long (max 255 characters).";
+
+        return null;
+    }
+
+    /// <summary>
+    /// Validates a Log Analytics workspace ID (should be a GUID, or empty to skip).
+    /// </summary>
+    public static string? ValidateWorkspaceId(string input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+            return "Workspace ID cannot be empty.";
+
+        if (!Guid.TryParse(input, out _))
+            return "Workspace ID must be a valid GUID (e.g. 12345678-1234-1234-1234-123456789012).";
+
+        return null;
+    }
+
+    /// <summary>
+    /// Validates an output directory path.
+    /// </summary>
+    public static string? ValidateOutputDirectory(string input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+            return null; // Empty is okay — will use default
+
+        var invalidChars = Path.GetInvalidPathChars();
+        if (input.IndexOfAny(invalidChars) >= 0)
+            return "Path contains invalid characters.";
+
+        return null;
+    }
+}

--- a/Interactive/SessionStateManager.cs
+++ b/Interactive/SessionStateManager.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+
+namespace CosmosToSqlAssessment.Interactive;
+
+/// <summary>
+/// Manages wizard session state persistence for resume support.
+/// </summary>
+internal interface ISessionStateManager
+{
+    /// <summary>Saves the current state to disk.</summary>
+    void Save(WizardSessionState state);
+
+    /// <summary>Loads existing state, or null if none exists.</summary>
+    WizardSessionState? Load();
+
+    /// <summary>Removes the session state file (called on successful completion).</summary>
+    void Clear();
+
+    /// <summary>The path where session state is stored.</summary>
+    string StatePath { get; }
+}
+
+/// <summary>
+/// File-based session state manager.
+/// </summary>
+internal sealed class FileSessionStateManager : ISessionStateManager
+{
+    private static readonly JsonSerializerOptions _options = new() { WriteIndented = true };
+
+    public string StatePath { get; }
+
+    public FileSessionStateManager(string? statePath = null)
+    {
+        StatePath = statePath ?? Path.Combine(Directory.GetCurrentDirectory(), ".wizard-session.json");
+    }
+
+    public void Save(WizardSessionState state)
+    {
+        var json = JsonSerializer.Serialize(state, _options);
+        File.WriteAllText(StatePath, json);
+    }
+
+    public WizardSessionState? Load()
+    {
+        if (!File.Exists(StatePath))
+            return null;
+
+        var json = File.ReadAllText(StatePath);
+        return JsonSerializer.Deserialize<WizardSessionState>(json);
+    }
+
+    public void Clear()
+    {
+        if (File.Exists(StatePath))
+            File.Delete(StatePath);
+    }
+}

--- a/Interactive/SystemWizardConsole.cs
+++ b/Interactive/SystemWizardConsole.cs
@@ -1,0 +1,81 @@
+namespace CosmosToSqlAssessment.Interactive;
+
+/// <summary>
+/// Production implementation of <see cref="IWizardConsole"/> using
+/// <see cref="Console.ReadLine"/> and <see cref="Console.WriteLine"/>.
+/// </summary>
+internal sealed class SystemWizardConsole : IWizardConsole
+{
+    public string Prompt(string message, string? defaultValue = null)
+    {
+        if (defaultValue != null)
+        {
+            Console.Write($"{message} [{defaultValue}]: ");
+        }
+        else
+        {
+            Console.Write($"{message}: ");
+        }
+
+        var input = Console.ReadLine();
+
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return defaultValue ?? string.Empty;
+        }
+
+        return input.Trim();
+    }
+
+    public T Select<T>(string title, IReadOnlyList<T> choices) where T : notnull
+    {
+        Console.WriteLine(title);
+        for (int i = 0; i < choices.Count; i++)
+        {
+            Console.WriteLine($"  {i + 1}. {choices[i]}");
+        }
+
+        while (true)
+        {
+            Console.Write($"Enter choice (1-{choices.Count}): ");
+            var input = Console.ReadLine();
+
+            if (int.TryParse(input, out int selection) && selection >= 1 && selection <= choices.Count)
+            {
+                return choices[selection - 1];
+            }
+
+            Console.WriteLine($"  Invalid selection. Please enter a number between 1 and {choices.Count}.");
+        }
+    }
+
+    public bool Confirm(string message, bool defaultValue = true)
+    {
+        var hint = defaultValue ? "[Y/n]" : "[y/N]";
+        Console.Write($"{message} {hint}: ");
+
+        var input = Console.ReadLine()?.Trim().ToLowerInvariant();
+
+        if (string.IsNullOrEmpty(input))
+        {
+            return defaultValue;
+        }
+
+        return input == "y" || input == "yes";
+    }
+
+    public void WriteInfo(string message)
+    {
+        Console.WriteLine(message);
+    }
+
+    public void WriteError(string message)
+    {
+        Console.WriteLine($"❌ {message}");
+    }
+
+    public void WriteLine()
+    {
+        Console.WriteLine();
+    }
+}

--- a/Interactive/SystemWizardConsole.cs
+++ b/Interactive/SystemWizardConsole.cs
@@ -78,4 +78,16 @@ internal sealed class SystemWizardConsole : IWizardConsole
     {
         Console.WriteLine();
     }
+
+    public string PromptWithValidation(string message, Func<string, string?> validator, string? defaultValue = null)
+    {
+        while (true)
+        {
+            var input = Prompt(message, defaultValue);
+            var error = validator(input);
+            if (error == null)
+                return input;
+            WriteError(error);
+        }
+    }
 }

--- a/Interactive/WizardConfiguration.cs
+++ b/Interactive/WizardConfiguration.cs
@@ -1,0 +1,33 @@
+using System.Text.Json.Serialization;
+
+namespace CosmosToSqlAssessment.Interactive;
+
+/// <summary>
+/// Serializable wizard configuration that can be saved/loaded from JSON.
+/// </summary>
+internal sealed class WizardConfiguration
+{
+    [JsonPropertyName("endpoint")]
+    public string? Endpoint { get; set; }
+
+    [JsonPropertyName("analyzeAllDatabases")]
+    public bool AnalyzeAllDatabases { get; set; }
+
+    [JsonPropertyName("databaseName")]
+    public string? DatabaseName { get; set; }
+
+    [JsonPropertyName("workspaceId")]
+    public string? WorkspaceId { get; set; }
+
+    [JsonPropertyName("autoDiscover")]
+    public bool AutoDiscover { get; set; }
+
+    [JsonPropertyName("outputDirectory")]
+    public string? OutputDirectory { get; set; }
+
+    [JsonPropertyName("assessmentOnly")]
+    public bool AssessmentOnly { get; set; }
+
+    [JsonPropertyName("projectOnly")]
+    public bool ProjectOnly { get; set; }
+}

--- a/Interactive/WizardRunner.cs
+++ b/Interactive/WizardRunner.cs
@@ -10,19 +10,32 @@ internal sealed class WizardRunner
 {
     private readonly IWizardConsole _console;
     private readonly IConfigurationStore _configStore;
+    private readonly ISessionStateManager? _sessionManager;
 
-    public WizardRunner(IWizardConsole console, IConfigurationStore? configStore = null)
+    public WizardRunner(IWizardConsole console, IConfigurationStore? configStore = null, ISessionStateManager? sessionManager = null)
     {
         _console = console ?? throw new ArgumentNullException(nameof(console));
         _configStore = configStore ?? new JsonConfigurationStore();
+        _sessionManager = sessionManager;
     }
 
     /// <summary>
     /// Runs the interactive wizard and returns configured <see cref="CliOptions"/>.
+    /// If <paramref name="resumeState"/> is provided, skips already-completed steps.
     /// </summary>
-    public CliOptions Run(CancellationToken cancellationToken = default)
+    public CliOptions Run(CancellationToken cancellationToken = default, WizardSessionState? resumeState = null)
     {
         var options = new CliOptions { Interactive = true };
+        var state = resumeState ?? new WizardSessionState();
+        int startStep = state.CurrentStep;
+
+        // Restore previously-collected answers from session state
+        if (startStep > 0)
+        {
+            _console.WriteInfo("Resuming wizard from where you left off...");
+            _console.WriteLine();
+            RestoreFromState(options, state);
+        }
 
         // Step 1: Welcome
         _console.WriteLine();
@@ -37,72 +50,105 @@ internal sealed class WizardRunner
         cancellationToken.ThrowIfCancellationRequested();
 
         // Step 2: Cosmos DB endpoint
-        _console.WriteInfo("── Step 1: Cosmos DB Connection ──");
-        options.AccountEndpoint = _console.PromptWithValidation(
-            "Cosmos DB account endpoint (e.g. https://myaccount.documents.azure.com:443/)",
-            InputValidators.ValidateEndpoint);
+        if (startStep < 1)
+        {
+            _console.WriteInfo("── Step 1: Cosmos DB Connection ──");
+            options.AccountEndpoint = _console.PromptWithValidation(
+                "Cosmos DB account endpoint (e.g. https://myaccount.documents.azure.com:443/)",
+                InputValidators.ValidateEndpoint);
+            state.Endpoint = options.AccountEndpoint;
+            state.CurrentStep = 1;
+            _sessionManager?.Save(state);
+        }
 
         cancellationToken.ThrowIfCancellationRequested();
 
         // Step 3: Database selection
-        _console.WriteLine();
-        _console.WriteInfo("── Step 2: Database Selection ──");
-        var dbMode = _console.Select("How would you like to select databases?",
-            new[] { "Analyze all databases", "Specify a single database" });
+        if (startStep < 2)
+        {
+            _console.WriteLine();
+            _console.WriteInfo("── Step 2: Database Selection ──");
+            var dbMode = _console.Select("How would you like to select databases?",
+                new[] { "Analyze all databases", "Specify a single database" });
 
-        if (dbMode == "Analyze all databases")
-        {
-            options.AnalyzeAllDatabases = true;
-        }
-        else
-        {
-            options.DatabaseName = _console.PromptWithValidation(
-                "Database name",
-                InputValidators.ValidateDatabaseName);
+            if (dbMode == "Analyze all databases")
+            {
+                options.AnalyzeAllDatabases = true;
+                state.AnalyzeAllDatabases = true;
+            }
+            else
+            {
+                options.DatabaseName = _console.PromptWithValidation(
+                    "Database name",
+                    InputValidators.ValidateDatabaseName);
+                state.AnalyzeAllDatabases = false;
+                state.DatabaseName = options.DatabaseName;
+            }
+            state.CurrentStep = 2;
+            _sessionManager?.Save(state);
         }
 
         cancellationToken.ThrowIfCancellationRequested();
 
         // Step 4: Log Analytics workspace (optional)
-        _console.WriteLine();
-        _console.WriteInfo("── Step 3: Azure Monitor (Optional) ──");
-        var useMonitor = _console.Confirm("Include Azure Monitor performance metrics?", true);
-
-        if (useMonitor)
+        if (startStep < 3)
         {
-            options.WorkspaceId = _console.PromptWithValidation(
-                "Log Analytics workspace ID",
-                InputValidators.ValidateWorkspaceId);
-            options.AutoDiscoverMonitoring = _console.Confirm("Auto-discover monitoring settings?", false);
+            _console.WriteLine();
+            _console.WriteInfo("── Step 3: Azure Monitor (Optional) ──");
+            var useMonitor = _console.Confirm("Include Azure Monitor performance metrics?", true);
+            state.IncludeMonitor = useMonitor;
+
+            if (useMonitor)
+            {
+                options.WorkspaceId = _console.PromptWithValidation(
+                    "Log Analytics workspace ID",
+                    InputValidators.ValidateWorkspaceId);
+                options.AutoDiscoverMonitoring = _console.Confirm("Auto-discover monitoring settings?", false);
+                state.WorkspaceId = options.WorkspaceId;
+                state.AutoDiscover = options.AutoDiscoverMonitoring;
+            }
+            state.CurrentStep = 3;
+            _sessionManager?.Save(state);
         }
 
         cancellationToken.ThrowIfCancellationRequested();
 
         // Step 5: Output directory
-        _console.WriteLine();
-        _console.WriteInfo("── Step 4: Output Configuration ──");
-        options.OutputDirectory = _console.PromptWithValidation(
-            "Output directory for reports",
-            InputValidators.ValidateOutputDirectory,
-            "./output");
+        if (startStep < 4)
+        {
+            _console.WriteLine();
+            _console.WriteInfo("── Step 4: Output Configuration ──");
+            options.OutputDirectory = _console.PromptWithValidation(
+                "Output directory for reports",
+                InputValidators.ValidateOutputDirectory,
+                "./output");
+            state.OutputDirectory = options.OutputDirectory;
+            state.CurrentStep = 4;
+            _sessionManager?.Save(state);
+        }
 
         cancellationToken.ThrowIfCancellationRequested();
 
         // Step 6: Report type
-        _console.WriteLine();
-        _console.WriteInfo("── Step 5: Report Type ──");
-        var reportType = _console.Select("What would you like to generate?",
-            new[] { "Both assessment reports and SQL projects", "Assessment reports only", "SQL projects only" });
-
-        switch (reportType)
+        if (startStep < 5)
         {
-            case "Assessment reports only":
-                options.AssessmentOnly = true;
-                break;
-            case "SQL projects only":
-                options.ProjectOnly = true;
-                break;
-            // "Both" leaves both false (default behavior)
+            _console.WriteLine();
+            _console.WriteInfo("── Step 5: Report Type ──");
+            var reportType = _console.Select("What would you like to generate?",
+                new[] { "Both assessment reports and SQL projects", "Assessment reports only", "SQL projects only" });
+
+            switch (reportType)
+            {
+                case "Assessment reports only":
+                    options.AssessmentOnly = true;
+                    break;
+                case "SQL projects only":
+                    options.ProjectOnly = true;
+                    break;
+            }
+            state.ReportType = reportType;
+            state.CurrentStep = 5;
+            _sessionManager?.Save(state);
         }
 
         _console.WriteLine();
@@ -126,9 +172,32 @@ internal sealed class WizardRunner
             _console.WriteInfo($"Configuration saved to: {savePath}");
         }
 
+        // Clear session state on successful completion
+        _sessionManager?.Clear();
+
         _console.WriteLine();
 
         return options;
+    }
+
+    private static void RestoreFromState(CliOptions options, WizardSessionState state)
+    {
+        if (state.Endpoint != null)
+            options.AccountEndpoint = state.Endpoint;
+        if (state.AnalyzeAllDatabases == true)
+            options.AnalyzeAllDatabases = true;
+        if (state.DatabaseName != null)
+            options.DatabaseName = state.DatabaseName;
+        if (state.WorkspaceId != null)
+            options.WorkspaceId = state.WorkspaceId;
+        if (state.AutoDiscover == true)
+            options.AutoDiscoverMonitoring = true;
+        if (state.OutputDirectory != null)
+            options.OutputDirectory = state.OutputDirectory;
+        if (state.ReportType == "Assessment reports only")
+            options.AssessmentOnly = true;
+        else if (state.ReportType == "SQL projects only")
+            options.ProjectOnly = true;
     }
 
     private void DisplaySummary(CliOptions options)

--- a/Interactive/WizardRunner.cs
+++ b/Interactive/WizardRunner.cs
@@ -105,6 +105,37 @@ internal sealed class WizardRunner
 
         _console.WriteLine();
 
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Step 7: Summary confirmation
+        DisplaySummary(options);
+
+        if (!_console.Confirm("Proceed with this configuration?", true))
+        {
+            throw new OperationCanceledException("User declined to proceed after reviewing summary.");
+        }
+
+        _console.WriteLine();
+
         return options;
+    }
+
+    private void DisplaySummary(CliOptions options)
+    {
+        _console.WriteInfo("╔══════════════════════════════════════════════════════╗");
+        _console.WriteInfo("║              Configuration Summary                  ║");
+        _console.WriteInfo("╚══════════════════════════════════════════════════════╝");
+        _console.WriteLine();
+        _console.WriteInfo($"  Endpoint:       {options.AccountEndpoint ?? "(not set)"}");
+        _console.WriteInfo($"  Database:       {(options.AnalyzeAllDatabases ? "All databases" : options.DatabaseName ?? "(not set)")}");
+        _console.WriteInfo($"  Workspace ID:   {options.WorkspaceId ?? "(none)"}");
+        _console.WriteInfo($"  Auto-discover:  {(options.AutoDiscoverMonitoring ? "Yes" : "No")}");
+        _console.WriteInfo($"  Output dir:     {options.OutputDirectory ?? "(default)"}");
+
+        var reportType = options.AssessmentOnly ? "Assessment only"
+            : options.ProjectOnly ? "SQL projects only"
+            : "Both (assessment + SQL projects)";
+        _console.WriteInfo($"  Report type:    {reportType}");
+        _console.WriteLine();
     }
 }

--- a/Interactive/WizardRunner.cs
+++ b/Interactive/WizardRunner.cs
@@ -9,10 +9,12 @@ namespace CosmosToSqlAssessment.Interactive;
 internal sealed class WizardRunner
 {
     private readonly IWizardConsole _console;
+    private readonly IConfigurationStore _configStore;
 
-    public WizardRunner(IWizardConsole console)
+    public WizardRunner(IWizardConsole console, IConfigurationStore? configStore = null)
     {
         _console = console ?? throw new ArgumentNullException(nameof(console));
+        _configStore = configStore ?? new JsonConfigurationStore();
     }
 
     /// <summary>
@@ -113,6 +115,15 @@ internal sealed class WizardRunner
         if (!_console.Confirm("Proceed with this configuration?", true))
         {
             throw new OperationCanceledException("User declined to proceed after reviewing summary.");
+        }
+
+        // Offer to save configuration for reuse
+        if (_console.Confirm("Save this configuration for future use?", false))
+        {
+            var savePath = _console.Prompt("Save path", "./wizard-config.json");
+            var config = JsonConfigurationStore.FromCliOptions(options);
+            _configStore.Save(config, savePath);
+            _console.WriteInfo($"Configuration saved to: {savePath}");
         }
 
         _console.WriteLine();

--- a/Interactive/WizardRunner.cs
+++ b/Interactive/WizardRunner.cs
@@ -1,0 +1,102 @@
+using CosmosToSqlAssessment.Cli;
+
+namespace CosmosToSqlAssessment.Interactive;
+
+/// <summary>
+/// Orchestrates the interactive wizard flow, prompting the user step-by-step
+/// to configure the assessment and returning a populated <see cref="CliOptions"/>.
+/// </summary>
+internal sealed class WizardRunner
+{
+    private readonly IWizardConsole _console;
+
+    public WizardRunner(IWizardConsole console)
+    {
+        _console = console ?? throw new ArgumentNullException(nameof(console));
+    }
+
+    /// <summary>
+    /// Runs the interactive wizard and returns configured <see cref="CliOptions"/>.
+    /// </summary>
+    public CliOptions Run(CancellationToken cancellationToken = default)
+    {
+        var options = new CliOptions { Interactive = true };
+
+        // Step 1: Welcome
+        _console.WriteLine();
+        _console.WriteInfo("╔══════════════════════════════════════════════════════╗");
+        _console.WriteInfo("║   Cosmos DB to SQL Migration Assessment - Wizard    ║");
+        _console.WriteInfo("╚══════════════════════════════════════════════════════╝");
+        _console.WriteLine();
+        _console.WriteInfo("This wizard will guide you through configuring the assessment.");
+        _console.WriteInfo("Press Enter to accept default values shown in [brackets].");
+        _console.WriteLine();
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Step 2: Cosmos DB endpoint
+        _console.WriteInfo("── Step 1: Cosmos DB Connection ──");
+        options.AccountEndpoint = _console.Prompt(
+            "Cosmos DB account endpoint (e.g. https://myaccount.documents.azure.com:443/)");
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Step 3: Database selection
+        _console.WriteLine();
+        _console.WriteInfo("── Step 2: Database Selection ──");
+        var dbMode = _console.Select("How would you like to select databases?",
+            new[] { "Analyze all databases", "Specify a single database" });
+
+        if (dbMode == "Analyze all databases")
+        {
+            options.AnalyzeAllDatabases = true;
+        }
+        else
+        {
+            options.DatabaseName = _console.Prompt("Database name");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Step 4: Log Analytics workspace (optional)
+        _console.WriteLine();
+        _console.WriteInfo("── Step 3: Azure Monitor (Optional) ──");
+        var useMonitor = _console.Confirm("Include Azure Monitor performance metrics?", true);
+
+        if (useMonitor)
+        {
+            options.WorkspaceId = _console.Prompt("Log Analytics workspace ID");
+            options.AutoDiscoverMonitoring = _console.Confirm("Auto-discover monitoring settings?", false);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Step 5: Output directory
+        _console.WriteLine();
+        _console.WriteInfo("── Step 4: Output Configuration ──");
+        options.OutputDirectory = _console.Prompt("Output directory for reports", "./output");
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Step 6: Report type
+        _console.WriteLine();
+        _console.WriteInfo("── Step 5: Report Type ──");
+        var reportType = _console.Select("What would you like to generate?",
+            new[] { "Both assessment reports and SQL projects", "Assessment reports only", "SQL projects only" });
+
+        switch (reportType)
+        {
+            case "Assessment reports only":
+                options.AssessmentOnly = true;
+                break;
+            case "SQL projects only":
+                options.ProjectOnly = true;
+                break;
+            // "Both" leaves both false (default behavior)
+        }
+
+        _console.WriteLine();
+
+        return options;
+    }
+}

--- a/Interactive/WizardRunner.cs
+++ b/Interactive/WizardRunner.cs
@@ -36,8 +36,9 @@ internal sealed class WizardRunner
 
         // Step 2: Cosmos DB endpoint
         _console.WriteInfo("── Step 1: Cosmos DB Connection ──");
-        options.AccountEndpoint = _console.Prompt(
-            "Cosmos DB account endpoint (e.g. https://myaccount.documents.azure.com:443/)");
+        options.AccountEndpoint = _console.PromptWithValidation(
+            "Cosmos DB account endpoint (e.g. https://myaccount.documents.azure.com:443/)",
+            InputValidators.ValidateEndpoint);
 
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -53,7 +54,9 @@ internal sealed class WizardRunner
         }
         else
         {
-            options.DatabaseName = _console.Prompt("Database name");
+            options.DatabaseName = _console.PromptWithValidation(
+                "Database name",
+                InputValidators.ValidateDatabaseName);
         }
 
         cancellationToken.ThrowIfCancellationRequested();
@@ -65,7 +68,9 @@ internal sealed class WizardRunner
 
         if (useMonitor)
         {
-            options.WorkspaceId = _console.Prompt("Log Analytics workspace ID");
+            options.WorkspaceId = _console.PromptWithValidation(
+                "Log Analytics workspace ID",
+                InputValidators.ValidateWorkspaceId);
             options.AutoDiscoverMonitoring = _console.Confirm("Auto-discover monitoring settings?", false);
         }
 
@@ -74,7 +79,10 @@ internal sealed class WizardRunner
         // Step 5: Output directory
         _console.WriteLine();
         _console.WriteInfo("── Step 4: Output Configuration ──");
-        options.OutputDirectory = _console.Prompt("Output directory for reports", "./output");
+        options.OutputDirectory = _console.PromptWithValidation(
+            "Output directory for reports",
+            InputValidators.ValidateOutputDirectory,
+            "./output");
 
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/Interactive/WizardSessionState.cs
+++ b/Interactive/WizardSessionState.cs
@@ -1,0 +1,40 @@
+using System.Text.Json.Serialization;
+
+namespace CosmosToSqlAssessment.Interactive;
+
+/// <summary>
+/// Tracks the wizard's progress through its steps so an interrupted
+/// session can be resumed from where it left off.
+/// </summary>
+internal sealed class WizardSessionState
+{
+    [JsonPropertyName("currentStep")]
+    public int CurrentStep { get; set; }
+
+    [JsonPropertyName("endpoint")]
+    public string? Endpoint { get; set; }
+
+    [JsonPropertyName("analyzeAllDatabases")]
+    public bool? AnalyzeAllDatabases { get; set; }
+
+    [JsonPropertyName("databaseName")]
+    public string? DatabaseName { get; set; }
+
+    [JsonPropertyName("includeMonitor")]
+    public bool? IncludeMonitor { get; set; }
+
+    [JsonPropertyName("workspaceId")]
+    public string? WorkspaceId { get; set; }
+
+    [JsonPropertyName("autoDiscover")]
+    public bool? AutoDiscover { get; set; }
+
+    [JsonPropertyName("outputDirectory")]
+    public string? OutputDirectory { get; set; }
+
+    [JsonPropertyName("reportType")]
+    public string? ReportType { get; set; }
+
+    [JsonPropertyName("startedAt")]
+    public DateTime StartedAt { get; set; } = DateTime.UtcNow;
+}

--- a/Program.cs
+++ b/Program.cs
@@ -40,6 +40,13 @@ namespace CosmosToSqlAssessment
                     return 1;
                 }
 
+                // Interactive wizard mode placeholder (implemented in #149+)
+                if (options.Interactive)
+                {
+                    Console.WriteLine("Interactive wizard mode is not yet implemented. No assessment was run.");
+                    return 0;
+                }
+
                 // Build configuration
                 var configuration = BuildConfiguration(options);
 

--- a/Program.cs
+++ b/Program.cs
@@ -44,8 +44,25 @@ namespace CosmosToSqlAssessment
                 // Interactive wizard mode placeholder (implemented in #149+)
                 if (options.Interactive)
                 {
-                    var wizard = new WizardRunner(new SystemWizardConsole());
-                    options = wizard.Run(_cancellationTokenSource.Token);
+                    WizardSessionState? resumeState = null;
+                    ISessionStateManager? sessionManager = null;
+
+                    if (options.ResumeSession)
+                    {
+                        sessionManager = new FileSessionStateManager();
+                        resumeState = sessionManager.Load();
+                        if (resumeState == null)
+                        {
+                            Console.WriteLine("No interrupted wizard session found. Starting fresh.");
+                        }
+                    }
+                    else
+                    {
+                        sessionManager = new FileSessionStateManager();
+                    }
+
+                    var wizard = new WizardRunner(new SystemWizardConsole(), sessionManager: sessionManager);
+                    options = wizard.Run(_cancellationTokenSource.Token, resumeState);
 
                     // Re-validate wizard-produced options
                     if (!CliArgumentParser.Validate(options))

--- a/Program.cs
+++ b/Program.cs
@@ -53,6 +53,22 @@ namespace CosmosToSqlAssessment
                         return 1;
                     }
                 }
+                else if (!string.IsNullOrEmpty(options.ConfigFile))
+                {
+                    // Load saved configuration
+                    var store = new JsonConfigurationStore();
+                    var config = store.Load(options.ConfigFile);
+                    if (config == null)
+                    {
+                        Console.WriteLine($"❌ Configuration file not found: {options.ConfigFile}");
+                        return 1;
+                    }
+                    var loadedOptions = JsonConfigurationStore.ToCliOptions(config);
+                    // Preserve any CLI-specified save-config path
+                    loadedOptions.SaveConfigFile = options.SaveConfigFile;
+                    options = loadedOptions;
+                    Console.WriteLine($"✅ Configuration loaded from: {options.ConfigFile}");
+                }
 
                 // Build configuration
                 var configuration = BuildConfiguration(options);

--- a/Program.cs
+++ b/Program.cs
@@ -65,6 +65,27 @@ namespace CosmosToSqlAssessment
                 // services (including the orchestrator itself) get correct lifetimes.
                 using var scope = serviceProvider.CreateScope();
                 var orchestrator = scope.ServiceProvider.GetRequiredService<AssessmentOrchestrator>();
+
+                if (options.Interactive)
+                {
+                    var progress = new ConsoleProgressReporter();
+                    progress.StartStep("Running assessment");
+                    try
+                    {
+                        var result = await orchestrator.RunAsync(options, _cancellationTokenSource.Token);
+                        if (result == 0)
+                            progress.CompleteStep("Running assessment");
+                        else
+                            progress.FailStep("Running assessment", $"Exited with code {result}");
+                        return result;
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        progress.FailStep("Running assessment", ex.Message);
+                        throw;
+                    }
+                }
+
                 return await orchestrator.RunAsync(options, _cancellationTokenSource.Token);
             }
             catch (OperationCanceledException)

--- a/Program.cs
+++ b/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using CosmosToSqlAssessment.Cli;
 using CosmosToSqlAssessment.DependencyInjection;
+using CosmosToSqlAssessment.Interactive;
 using CosmosToSqlAssessment.Orchestration;
 
 namespace CosmosToSqlAssessment
@@ -43,8 +44,14 @@ namespace CosmosToSqlAssessment
                 // Interactive wizard mode placeholder (implemented in #149+)
                 if (options.Interactive)
                 {
-                    Console.WriteLine("Interactive wizard mode is not yet implemented. No assessment was run.");
-                    return 0;
+                    var wizard = new WizardRunner(new SystemWizardConsole());
+                    options = wizard.Run(_cancellationTokenSource.Token);
+
+                    // Re-validate wizard-produced options
+                    if (!CliArgumentParser.Validate(options))
+                    {
+                        return 1;
+                    }
                 }
 
                 // Build configuration

--- a/tests/CosmosToSqlAssessment.Tests/Cli/CliArgumentParserTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Cli/CliArgumentParserTests.cs
@@ -23,6 +23,7 @@ public class CliArgumentParserTests
         options.AssessmentOnly.Should().BeFalse();
         options.ProjectOnly.Should().BeFalse();
         options.TestConnection.Should().BeFalse();
+        options.Interactive.Should().BeFalse();
         output.ToString().Should().BeEmpty();
     }
 
@@ -86,6 +87,17 @@ public class CliArgumentParserTests
         var options = CliArgumentParser.Parse(new[] { "--test-connection" }, new StringWriter());
 
         options!.TestConnection.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("--interactive")]
+    [InlineData("-i")]
+    public void Parse_InteractiveFlag_SetsInteractive(string flag)
+    {
+        var options = CliArgumentParser.Parse(new[] { flag }, new StringWriter());
+
+        options.Should().NotBeNull();
+        options!.Interactive.Should().BeTrue();
     }
 
     // ---- Parse: value-taking flags -----------------------------------------
@@ -254,6 +266,31 @@ public class CliArgumentParserTests
         result.Should().BeTrue();
     }
 
+    [Fact]
+    public void Validate_InteractiveAndTestConnectionBothTrue_ReturnsFalseAndWritesError()
+    {
+        var output = new StringWriter();
+        var options = new CliOptions { Interactive = true, TestConnection = true };
+
+        var result = CliArgumentParser.Validate(options, output);
+
+        result.Should().BeFalse();
+        var text = output.ToString();
+        text.Should().Contain("Cannot specify both");
+        text.Should().Contain("--interactive");
+        text.Should().Contain("--test-connection");
+    }
+
+    [Fact]
+    public void Validate_InteractiveAlone_ReturnsTrue()
+    {
+        var result = CliArgumentParser.Validate(
+            new CliOptions { Interactive = true },
+            new StringWriter());
+
+        result.Should().BeTrue();
+    }
+
     // ---- DisplayHelp -------------------------------------------------------
 
     [Fact]
@@ -276,6 +313,7 @@ public class CliArgumentParserTests
         text.Should().Contain("--assessment-only");
         text.Should().Contain("--project-only");
         text.Should().Contain("--test-connection");
+        text.Should().Contain("--interactive");
         text.Should().Contain("Examples:");
     }
 }

--- a/tests/CosmosToSqlAssessment.Tests/Cli/CliArgumentParserTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Cli/CliArgumentParserTests.cs
@@ -24,6 +24,8 @@ public class CliArgumentParserTests
         options.ProjectOnly.Should().BeFalse();
         options.TestConnection.Should().BeFalse();
         options.Interactive.Should().BeFalse();
+        options.ConfigFile.Should().BeNull();
+        options.SaveConfigFile.Should().BeNull();
         output.ToString().Should().BeEmpty();
     }
 

--- a/tests/CosmosToSqlAssessment.Tests/Interactive/ConfigurationStoreTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Interactive/ConfigurationStoreTests.cs
@@ -1,0 +1,121 @@
+using CosmosToSqlAssessment.Cli;
+using CosmosToSqlAssessment.Interactive;
+
+namespace CosmosToSqlAssessment.Tests.Interactive;
+
+public class ConfigurationStoreTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public ConfigurationStoreTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"wizard-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    [Fact]
+    public void SaveAndLoad_RoundTrips()
+    {
+        var store = new JsonConfigurationStore();
+        var path = Path.Combine(_tempDir, "config.json");
+
+        var config = new WizardConfiguration
+        {
+            Endpoint = "https://myaccount.documents.azure.com:443/",
+            AnalyzeAllDatabases = true,
+            WorkspaceId = "12345678-1234-1234-1234-123456789012",
+            AutoDiscover = true,
+            OutputDirectory = "./output",
+            AssessmentOnly = false,
+            ProjectOnly = false
+        };
+
+        store.Save(config, path);
+        var loaded = store.Load(path);
+
+        loaded.Should().NotBeNull();
+        loaded!.Endpoint.Should().Be(config.Endpoint);
+        loaded.AnalyzeAllDatabases.Should().Be(config.AnalyzeAllDatabases);
+        loaded.WorkspaceId.Should().Be(config.WorkspaceId);
+        loaded.AutoDiscover.Should().Be(config.AutoDiscover);
+        loaded.OutputDirectory.Should().Be(config.OutputDirectory);
+    }
+
+    [Fact]
+    public void Load_NonexistentFile_ReturnsNull()
+    {
+        var store = new JsonConfigurationStore();
+        var result = store.Load(Path.Combine(_tempDir, "nonexistent.json"));
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void Save_CreatesDirectoryIfNeeded()
+    {
+        var store = new JsonConfigurationStore();
+        var path = Path.Combine(_tempDir, "sub", "deep", "config.json");
+
+        store.Save(new WizardConfiguration { Endpoint = "https://test.com/" }, path);
+
+        File.Exists(path).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ToCliOptions_MapsCorrectly()
+    {
+        var config = new WizardConfiguration
+        {
+            Endpoint = "https://test.documents.azure.com:443/",
+            AnalyzeAllDatabases = false,
+            DatabaseName = "MyDb",
+            WorkspaceId = "00000000-0000-0000-0000-000000000000",
+            AutoDiscover = true,
+            OutputDirectory = "C:\\out",
+            AssessmentOnly = true,
+            ProjectOnly = false
+        };
+
+        var options = JsonConfigurationStore.ToCliOptions(config);
+
+        options.AccountEndpoint.Should().Be(config.Endpoint);
+        options.AnalyzeAllDatabases.Should().BeFalse();
+        options.DatabaseName.Should().Be("MyDb");
+        options.WorkspaceId.Should().Be(config.WorkspaceId);
+        options.AutoDiscoverMonitoring.Should().BeTrue();
+        options.OutputDirectory.Should().Be("C:\\out");
+        options.AssessmentOnly.Should().BeTrue();
+        options.ProjectOnly.Should().BeFalse();
+        options.Interactive.Should().BeTrue();
+    }
+
+    [Fact]
+    public void FromCliOptions_MapsCorrectly()
+    {
+        var options = new CliOptions
+        {
+            AccountEndpoint = "https://test.documents.azure.com:443/",
+            AnalyzeAllDatabases = true,
+            WorkspaceId = "00000000-0000-0000-0000-000000000000",
+            AutoDiscoverMonitoring = false,
+            OutputDirectory = "./reports",
+            AssessmentOnly = false,
+            ProjectOnly = true
+        };
+
+        var config = JsonConfigurationStore.FromCliOptions(options);
+
+        config.Endpoint.Should().Be(options.AccountEndpoint);
+        config.AnalyzeAllDatabases.Should().BeTrue();
+        config.WorkspaceId.Should().Be(options.WorkspaceId);
+        config.AutoDiscover.Should().BeFalse();
+        config.OutputDirectory.Should().Be("./reports");
+        config.AssessmentOnly.Should().BeFalse();
+        config.ProjectOnly.Should().BeTrue();
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Interactive/ConsoleProgressReporterTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Interactive/ConsoleProgressReporterTests.cs
@@ -1,0 +1,68 @@
+using CosmosToSqlAssessment.Interactive;
+
+namespace CosmosToSqlAssessment.Tests.Interactive;
+
+public class ConsoleProgressReporterTests
+{
+    [Fact]
+    public void StartStep_WritesStepNameWithSpinner()
+    {
+        var output = new StringWriter();
+        var reporter = new ConsoleProgressReporter(output);
+
+        reporter.StartStep("Connecting");
+
+        output.ToString().Should().Contain("⏳ Connecting...");
+    }
+
+    [Fact]
+    public void CompleteStep_WritesCheckmarkAndElapsed()
+    {
+        var output = new StringWriter();
+        var reporter = new ConsoleProgressReporter(output);
+
+        reporter.StartStep("Analyzing");
+        reporter.CompleteStep("Analyzing");
+
+        var text = output.ToString();
+        text.Should().Contain("✅ Analyzing");
+        text.Should().Contain("completed in");
+    }
+
+    [Fact]
+    public void FailStep_WritesErrorWithMessage()
+    {
+        var output = new StringWriter();
+        var reporter = new ConsoleProgressReporter(output);
+
+        reporter.StartStep("Connecting");
+        reporter.FailStep("Connecting", "Connection refused");
+
+        var text = output.ToString();
+        text.Should().Contain("❌ Connecting failed: Connection refused");
+    }
+
+    [Fact]
+    public void ReportProgress_WritesIntermediateMessage()
+    {
+        var output = new StringWriter();
+        var reporter = new ConsoleProgressReporter(output);
+
+        reporter.ReportProgress("Found 3 databases");
+
+        output.ToString().Should().Contain("Found 3 databases");
+    }
+
+    [Fact]
+    public void CompleteStep_ShortDuration_ShowsMilliseconds()
+    {
+        var output = new StringWriter();
+        var reporter = new ConsoleProgressReporter(output);
+
+        reporter.StartStep("Quick");
+        reporter.CompleteStep("Quick");
+
+        // Should show ms for very fast operations
+        output.ToString().Should().Contain("ms");
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Interactive/FakeWizardConsole.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Interactive/FakeWizardConsole.cs
@@ -60,4 +60,19 @@ internal sealed class FakeWizardConsole : IWizardConsole
     public void WriteInfo(string message) => _output.Add($"INFO: {message}");
     public void WriteError(string message) => _output.Add($"ERROR: {message}");
     public void WriteLine() => _output.Add("");
+
+    public string PromptWithValidation(string message, Func<string, string?> validator, string? defaultValue = null)
+    {
+        // Simulate: try each queued response until one passes validation
+        // In tests, we queue valid responses directly
+        var input = Prompt(message, defaultValue);
+        var error = validator(input);
+        while (error != null)
+        {
+            _output.Add($"VALIDATION_ERROR: {error}");
+            input = Prompt(message, defaultValue);
+            error = validator(input);
+        }
+        return input;
+    }
 }

--- a/tests/CosmosToSqlAssessment.Tests/Interactive/FakeWizardConsole.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Interactive/FakeWizardConsole.cs
@@ -1,0 +1,63 @@
+using CosmosToSqlAssessment.Interactive;
+
+namespace CosmosToSqlAssessment.Tests.Interactive;
+
+/// <summary>
+/// Fake <see cref="IWizardConsole"/> that replays queued responses for unit testing.
+/// </summary>
+internal sealed class FakeWizardConsole : IWizardConsole
+{
+    private readonly Queue<string> _promptResponses = new();
+    private readonly Queue<int> _selectResponses = new();
+    private readonly Queue<bool> _confirmResponses = new();
+    private readonly List<string> _output = new();
+
+    public IReadOnlyList<string> Output => _output;
+
+    public FakeWizardConsole QueuePrompt(string response)
+    {
+        _promptResponses.Enqueue(response);
+        return this;
+    }
+
+    public FakeWizardConsole QueueSelect(int zeroBasedIndex)
+    {
+        _selectResponses.Enqueue(zeroBasedIndex);
+        return this;
+    }
+
+    public FakeWizardConsole QueueConfirm(bool response)
+    {
+        _confirmResponses.Enqueue(response);
+        return this;
+    }
+
+    public string Prompt(string message, string? defaultValue = null)
+    {
+        _output.Add($"PROMPT: {message}");
+        if (_promptResponses.Count == 0)
+            return defaultValue ?? string.Empty;
+        return _promptResponses.Dequeue();
+    }
+
+    public T Select<T>(string title, IReadOnlyList<T> choices) where T : notnull
+    {
+        _output.Add($"SELECT: {title}");
+        if (_selectResponses.Count == 0)
+            return choices[0];
+        var index = _selectResponses.Dequeue();
+        return choices[index];
+    }
+
+    public bool Confirm(string message, bool defaultValue = true)
+    {
+        _output.Add($"CONFIRM: {message}");
+        if (_confirmResponses.Count == 0)
+            return defaultValue;
+        return _confirmResponses.Dequeue();
+    }
+
+    public void WriteInfo(string message) => _output.Add($"INFO: {message}");
+    public void WriteError(string message) => _output.Add($"ERROR: {message}");
+    public void WriteLine() => _output.Add("");
+}

--- a/tests/CosmosToSqlAssessment.Tests/Interactive/InputValidatorsTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Interactive/InputValidatorsTests.cs
@@ -1,0 +1,101 @@
+using CosmosToSqlAssessment.Interactive;
+
+namespace CosmosToSqlAssessment.Tests.Interactive;
+
+public class InputValidatorsTests
+{
+    // ---- ValidateEndpoint ---------------------------------------------------
+
+    [Theory]
+    [InlineData("https://myaccount.documents.azure.com:443/")]
+    [InlineData("https://localhost:8081/")]
+    [InlineData("http://localhost:8081")]
+    [InlineData("https://myaccount.cosmos.azure.com:443/")]
+    public void ValidateEndpoint_ValidUrls_ReturnsNull(string input)
+    {
+        InputValidators.ValidateEndpoint(input).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("", "cannot be empty")]
+    [InlineData("   ", "cannot be empty")]
+    [InlineData("not-a-url", "Invalid URL format")]
+    [InlineData("ftp://myaccount.documents.azure.com", "must use HTTPS")]
+    public void ValidateEndpoint_InvalidUrls_ReturnsErrorMessage(string input, string expectedFragment)
+    {
+        var result = InputValidators.ValidateEndpoint(input);
+        result.Should().NotBeNull();
+        result.Should().Contain(expectedFragment);
+    }
+
+    // ---- ValidateDatabaseName -----------------------------------------------
+
+    [Theory]
+    [InlineData("MyDatabase")]
+    [InlineData("db-1")]
+    [InlineData("a")]
+    public void ValidateDatabaseName_ValidNames_ReturnsNull(string input)
+    {
+        InputValidators.ValidateDatabaseName(input).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("", "cannot be empty")]
+    [InlineData("   ", "cannot be empty")]
+    public void ValidateDatabaseName_InvalidNames_ReturnsError(string input, string expectedFragment)
+    {
+        var result = InputValidators.ValidateDatabaseName(input);
+        result.Should().NotBeNull();
+        result.Should().Contain(expectedFragment);
+    }
+
+    [Fact]
+    public void ValidateDatabaseName_TooLong_ReturnsError()
+    {
+        var longName = new string('x', 256);
+        var result = InputValidators.ValidateDatabaseName(longName);
+        result.Should().Contain("too long");
+    }
+
+    // ---- ValidateWorkspaceId ------------------------------------------------
+
+    [Theory]
+    [InlineData("12345678-1234-1234-1234-123456789012")]
+    [InlineData("00000000-0000-0000-0000-000000000000")]
+    public void ValidateWorkspaceId_ValidGuids_ReturnsNull(string input)
+    {
+        InputValidators.ValidateWorkspaceId(input).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("", "cannot be empty")]
+    [InlineData("not-a-guid", "must be a valid GUID")]
+    [InlineData("1234", "must be a valid GUID")]
+    public void ValidateWorkspaceId_InvalidGuids_ReturnsError(string input, string expectedFragment)
+    {
+        var result = InputValidators.ValidateWorkspaceId(input);
+        result.Should().NotBeNull();
+        result.Should().Contain(expectedFragment);
+    }
+
+    // ---- ValidateOutputDirectory --------------------------------------------
+
+    [Theory]
+    [InlineData("./output")]
+    [InlineData("C:\\Reports")]
+    [InlineData("relative/path")]
+    [InlineData("")] // empty is okay (uses default)
+    public void ValidateOutputDirectory_ValidPaths_ReturnsNull(string input)
+    {
+        InputValidators.ValidateOutputDirectory(input).Should().BeNull();
+    }
+
+    [Fact]
+    public void ValidateOutputDirectory_InvalidChars_ReturnsError()
+    {
+        // Use a character that's invalid in paths on all platforms
+        var invalidPath = "output\0path";
+        var result = InputValidators.ValidateOutputDirectory(invalidPath);
+        result.Should().Contain("invalid characters");
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Interactive/SessionStateManagerTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Interactive/SessionStateManagerTests.cs
@@ -1,0 +1,171 @@
+using CosmosToSqlAssessment.Interactive;
+
+namespace CosmosToSqlAssessment.Tests.Interactive;
+
+public class SessionStateManagerTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public SessionStateManagerTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"session-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    [Fact]
+    public void Save_And_Load_RoundTrips()
+    {
+        var path = Path.Combine(_tempDir, ".wizard-session.json");
+        var manager = new FileSessionStateManager(path);
+
+        var state = new WizardSessionState
+        {
+            CurrentStep = 3,
+            Endpoint = "https://test.documents.azure.com:443/",
+            AnalyzeAllDatabases = true,
+            WorkspaceId = "12345678-1234-1234-1234-123456789012",
+            OutputDirectory = "./out"
+        };
+
+        manager.Save(state);
+        var loaded = manager.Load();
+
+        loaded.Should().NotBeNull();
+        loaded!.CurrentStep.Should().Be(3);
+        loaded.Endpoint.Should().Be("https://test.documents.azure.com:443/");
+        loaded.AnalyzeAllDatabases.Should().BeTrue();
+        loaded.WorkspaceId.Should().Be("12345678-1234-1234-1234-123456789012");
+    }
+
+    [Fact]
+    public void Load_NoFile_ReturnsNull()
+    {
+        var path = Path.Combine(_tempDir, "nonexistent.json");
+        var manager = new FileSessionStateManager(path);
+
+        manager.Load().Should().BeNull();
+    }
+
+    [Fact]
+    public void Clear_RemovesFile()
+    {
+        var path = Path.Combine(_tempDir, ".wizard-session.json");
+        var manager = new FileSessionStateManager(path);
+
+        manager.Save(new WizardSessionState { CurrentStep = 1 });
+        File.Exists(path).Should().BeTrue();
+
+        manager.Clear();
+        File.Exists(path).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Clear_NoFile_DoesNotThrow()
+    {
+        var path = Path.Combine(_tempDir, "nonexistent.json");
+        var manager = new FileSessionStateManager(path);
+
+        var act = () => manager.Clear();
+        act.Should().NotThrow();
+    }
+}
+
+public class WizardRunnerResumeTests
+{
+    [Fact]
+    public void Run_ResumeFromStep3_SkipsEarlierSteps()
+    {
+        // State says we completed steps 0-2 (endpoint, db, monitor)
+        var state = new WizardSessionState
+        {
+            CurrentStep = 3,
+            Endpoint = "https://saved.documents.azure.com:443/",
+            AnalyzeAllDatabases = true,
+            IncludeMonitor = false
+        };
+
+        // Only need to provide answers for steps 3+ (output dir, report type, confirmations)
+        var console = new FakeWizardConsole()
+            .QueuePrompt("./resumed-output") // output dir
+            .QueueSelect(0) // both reports
+            .QueueConfirm(true) // confirm summary
+            .QueueConfirm(false); // don't save config
+
+        var runner = new WizardRunner(console);
+        var options = runner.Run(resumeState: state);
+
+        options.AccountEndpoint.Should().Be("https://saved.documents.azure.com:443/");
+        options.AnalyzeAllDatabases.Should().BeTrue();
+        options.OutputDirectory.Should().Be("./resumed-output");
+        console.Output.Should().Contain(s => s.Contains("Resuming"));
+    }
+
+    [Fact]
+    public void Run_WithSessionManager_SavesStateAfterEachStep()
+    {
+        var manager = new InMemorySessionStateManager();
+        var console = new FakeWizardConsole()
+            .QueuePrompt("https://acct.documents.azure.com:443/")
+            .QueueSelect(0) // all databases
+            .QueueConfirm(false) // no monitor
+            .QueuePrompt("./out")
+            .QueueSelect(0) // both
+            .QueueConfirm(true) // confirm
+            .QueueConfirm(false); // don't save config
+
+        var runner = new WizardRunner(console, sessionManager: manager);
+        runner.Run();
+
+        // State was saved multiple times (once per step) then cleared
+        manager.SaveCount.Should().BeGreaterThanOrEqualTo(5);
+        manager.WasCleared.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Run_NoResumeState_StartsFromBeginning()
+    {
+        var console = new FakeWizardConsole()
+            .QueuePrompt("https://acct.documents.azure.com:443/")
+            .QueueSelect(0)
+            .QueueConfirm(false)
+            .QueuePrompt("./out")
+            .QueueSelect(0)
+            .QueueConfirm(true)
+            .QueueConfirm(false);
+
+        var runner = new WizardRunner(console);
+        var options = runner.Run();
+
+        options.AccountEndpoint.Should().Be("https://acct.documents.azure.com:443/");
+        console.Output.Should().NotContain(s => s.Contains("Resuming"));
+    }
+}
+
+/// <summary>In-memory session state manager for testing.</summary>
+internal sealed class InMemorySessionStateManager : ISessionStateManager
+{
+    public int SaveCount { get; private set; }
+    public bool WasCleared { get; private set; }
+    public WizardSessionState? LastState { get; private set; }
+    public string StatePath => "<in-memory>";
+
+    public void Save(WizardSessionState state)
+    {
+        SaveCount++;
+        LastState = state;
+    }
+
+    public WizardSessionState? Load() => LastState;
+
+    public void Clear()
+    {
+        WasCleared = true;
+        LastState = null;
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Interactive/WizardRunnerTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Interactive/WizardRunnerTests.cs
@@ -14,7 +14,8 @@ public class WizardRunnerTests
             .QueuePrompt("12345678-1234-1234-1234-123456789012") // workspace ID
             .QueueConfirm(false) // no auto-discover
             .QueuePrompt("./reports") // output dir
-            .QueueSelect(0); // "Both assessment reports and SQL projects"
+            .QueueSelect(0) // "Both assessment reports and SQL projects"
+            .QueueConfirm(true); // confirm summary
 
         var runner = new WizardRunner(console);
         var options = runner.Run();
@@ -39,7 +40,8 @@ public class WizardRunnerTests
             .QueuePrompt("MyDatabase") // database name
             .QueueConfirm(false) // no monitor
             .QueuePrompt("C:\\output") // output dir
-            .QueueSelect(1); // "Assessment reports only"
+            .QueueSelect(1) // "Assessment reports only"
+            .QueueConfirm(true); // confirm summary
 
         var runner = new WizardRunner(console);
         var options = runner.Run();
@@ -62,7 +64,8 @@ public class WizardRunnerTests
             .QueueSelect(0) // all databases
             .QueueConfirm(false) // no monitor
             .QueuePrompt("") // output dir (will use default)
-            .QueueSelect(2); // "SQL projects only"
+            .QueueSelect(2) // "SQL projects only"
+            .QueueConfirm(true); // confirm summary
 
         var runner = new WizardRunner(console);
         var options = runner.Run();
@@ -79,7 +82,8 @@ public class WizardRunnerTests
             .QueueSelect(0) // all databases
             .QueueConfirm(false) // no monitor
             // no prompt response queued → returns defaultValue ("./output")
-            .QueueSelect(0); // both
+            .QueueSelect(0) // both
+            .QueueConfirm(true); // confirm summary
 
         var runner = new WizardRunner(console);
         var options = runner.Run();
@@ -97,7 +101,8 @@ public class WizardRunnerTests
             .QueuePrompt("12345678-1234-1234-1234-123456789012") // workspace ID
             .QueueConfirm(true) // auto-discover = yes
             .QueuePrompt("./out")
-            .QueueSelect(0); // both
+            .QueueSelect(0) // both
+            .QueueConfirm(true); // confirm summary
 
         var runner = new WizardRunner(console);
         var options = runner.Run();
@@ -129,7 +134,8 @@ public class WizardRunnerTests
             .QueueSelect(0)
             .QueueConfirm(false)
             .QueuePrompt("./out")
-            .QueueSelect(0);
+            .QueueSelect(0)
+            .QueueConfirm(true); // confirm summary
 
         var runner = new WizardRunner(console);
         runner.Run();
@@ -155,12 +161,52 @@ public class WizardRunnerTests
             .QueueSelect(0) // all databases
             .QueueConfirm(false) // no monitor
             .QueuePrompt("./out")
-            .QueueSelect(0);
+            .QueueSelect(0)
+            .QueueConfirm(true); // confirm summary
 
         var runner = new WizardRunner(console);
         var options = runner.Run();
 
         options.AccountEndpoint.Should().Be("https://acct.documents.azure.com:443/");
         console.Output.Should().Contain(s => s.Contains("VALIDATION_ERROR"));
+    }
+
+    [Fact]
+    public void Run_UserDeclinesSummary_ThrowsOperationCanceledException()
+    {
+        var console = new FakeWizardConsole()
+            .QueuePrompt("https://acct.documents.azure.com:443/")
+            .QueueSelect(0) // all databases
+            .QueueConfirm(false) // no monitor
+            .QueuePrompt("./out")
+            .QueueSelect(0)
+            .QueueConfirm(false); // decline summary
+
+        var runner = new WizardRunner(console);
+
+        var act = () => runner.Run();
+        act.Should().Throw<OperationCanceledException>();
+    }
+
+    [Fact]
+    public void Run_DisplaysSummaryWithConfiguration()
+    {
+        var console = new FakeWizardConsole()
+            .QueuePrompt("https://myaccount.documents.azure.com:443/")
+            .QueueSelect(0) // all databases
+            .QueueConfirm(true) // include monitor
+            .QueuePrompt("12345678-1234-1234-1234-123456789012")
+            .QueueConfirm(false) // no auto-discover
+            .QueuePrompt("./reports")
+            .QueueSelect(0)
+            .QueueConfirm(true); // confirm
+
+        var runner = new WizardRunner(console);
+        runner.Run();
+
+        console.Output.Should().Contain(s => s.Contains("Configuration Summary"));
+        console.Output.Should().Contain(s => s.Contains("myaccount"));
+        console.Output.Should().Contain(s => s.Contains("All databases"));
+        console.Output.Should().Contain(s => s.Contains("./reports"));
     }
 }

--- a/tests/CosmosToSqlAssessment.Tests/Interactive/WizardRunnerTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Interactive/WizardRunnerTests.cs
@@ -11,7 +11,7 @@ public class WizardRunnerTests
             .QueuePrompt("https://myaccount.documents.azure.com:443/") // endpoint
             .QueueSelect(0) // "Analyze all databases"
             .QueueConfirm(true) // include monitor
-            .QueuePrompt("workspace-123") // workspace ID
+            .QueuePrompt("12345678-1234-1234-1234-123456789012") // workspace ID
             .QueueConfirm(false) // no auto-discover
             .QueuePrompt("./reports") // output dir
             .QueueSelect(0); // "Both assessment reports and SQL projects"
@@ -23,7 +23,7 @@ public class WizardRunnerTests
         options.AccountEndpoint.Should().Be("https://myaccount.documents.azure.com:443/");
         options.AnalyzeAllDatabases.Should().BeTrue();
         options.DatabaseName.Should().BeNull();
-        options.WorkspaceId.Should().Be("workspace-123");
+        options.WorkspaceId.Should().Be("12345678-1234-1234-1234-123456789012");
         options.AutoDiscoverMonitoring.Should().BeFalse();
         options.OutputDirectory.Should().Be("./reports");
         options.AssessmentOnly.Should().BeFalse();
@@ -94,7 +94,7 @@ public class WizardRunnerTests
             .QueuePrompt("https://acct.documents.azure.com:443/")
             .QueueSelect(0) // all databases
             .QueueConfirm(true) // include monitor
-            .QueuePrompt("ws-id") // workspace ID
+            .QueuePrompt("12345678-1234-1234-1234-123456789012") // workspace ID
             .QueueConfirm(true) // auto-discover = yes
             .QueuePrompt("./out")
             .QueueSelect(0); // both
@@ -103,7 +103,7 @@ public class WizardRunnerTests
         var options = runner.Run();
 
         options.AutoDiscoverMonitoring.Should().BeTrue();
-        options.WorkspaceId.Should().Be("ws-id");
+        options.WorkspaceId.Should().Be("12345678-1234-1234-1234-123456789012");
     }
 
     [Fact]
@@ -144,5 +144,23 @@ public class WizardRunnerTests
     {
         var act = () => new WizardRunner(null!);
         act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Run_InvalidEndpointThenValid_RetriesAndSucceeds()
+    {
+        var console = new FakeWizardConsole()
+            .QueuePrompt("not-a-url") // first attempt - invalid
+            .QueuePrompt("https://acct.documents.azure.com:443/") // second attempt - valid
+            .QueueSelect(0) // all databases
+            .QueueConfirm(false) // no monitor
+            .QueuePrompt("./out")
+            .QueueSelect(0);
+
+        var runner = new WizardRunner(console);
+        var options = runner.Run();
+
+        options.AccountEndpoint.Should().Be("https://acct.documents.azure.com:443/");
+        console.Output.Should().Contain(s => s.Contains("VALIDATION_ERROR"));
     }
 }

--- a/tests/CosmosToSqlAssessment.Tests/Interactive/WizardRunnerTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Interactive/WizardRunnerTests.cs
@@ -1,0 +1,148 @@
+using CosmosToSqlAssessment.Interactive;
+
+namespace CosmosToSqlAssessment.Tests.Interactive;
+
+public class WizardRunnerTests
+{
+    [Fact]
+    public void Run_AllDatabases_WithMonitor_ReturnsCorrectOptions()
+    {
+        var console = new FakeWizardConsole()
+            .QueuePrompt("https://myaccount.documents.azure.com:443/") // endpoint
+            .QueueSelect(0) // "Analyze all databases"
+            .QueueConfirm(true) // include monitor
+            .QueuePrompt("workspace-123") // workspace ID
+            .QueueConfirm(false) // no auto-discover
+            .QueuePrompt("./reports") // output dir
+            .QueueSelect(0); // "Both assessment reports and SQL projects"
+
+        var runner = new WizardRunner(console);
+        var options = runner.Run();
+
+        options.Interactive.Should().BeTrue();
+        options.AccountEndpoint.Should().Be("https://myaccount.documents.azure.com:443/");
+        options.AnalyzeAllDatabases.Should().BeTrue();
+        options.DatabaseName.Should().BeNull();
+        options.WorkspaceId.Should().Be("workspace-123");
+        options.AutoDiscoverMonitoring.Should().BeFalse();
+        options.OutputDirectory.Should().Be("./reports");
+        options.AssessmentOnly.Should().BeFalse();
+        options.ProjectOnly.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Run_SpecificDatabase_NoMonitor_AssessmentOnly_ReturnsCorrectOptions()
+    {
+        var console = new FakeWizardConsole()
+            .QueuePrompt("https://other.documents.azure.com:443/") // endpoint
+            .QueueSelect(1) // "Specify a single database"
+            .QueuePrompt("MyDatabase") // database name
+            .QueueConfirm(false) // no monitor
+            .QueuePrompt("C:\\output") // output dir
+            .QueueSelect(1); // "Assessment reports only"
+
+        var runner = new WizardRunner(console);
+        var options = runner.Run();
+
+        options.AccountEndpoint.Should().Be("https://other.documents.azure.com:443/");
+        options.AnalyzeAllDatabases.Should().BeFalse();
+        options.DatabaseName.Should().Be("MyDatabase");
+        options.WorkspaceId.Should().BeNull();
+        options.AutoDiscoverMonitoring.Should().BeFalse();
+        options.OutputDirectory.Should().Be("C:\\output");
+        options.AssessmentOnly.Should().BeTrue();
+        options.ProjectOnly.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Run_ProjectOnly_ReturnsCorrectOptions()
+    {
+        var console = new FakeWizardConsole()
+            .QueuePrompt("https://acct.documents.azure.com:443/") // endpoint
+            .QueueSelect(0) // all databases
+            .QueueConfirm(false) // no monitor
+            .QueuePrompt("") // output dir (will use default)
+            .QueueSelect(2); // "SQL projects only"
+
+        var runner = new WizardRunner(console);
+        var options = runner.Run();
+
+        options.ProjectOnly.Should().BeTrue();
+        options.AssessmentOnly.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Run_DefaultOutputDirectory_UsesDefault()
+    {
+        var console = new FakeWizardConsole()
+            .QueuePrompt("https://acct.documents.azure.com:443/")
+            .QueueSelect(0) // all databases
+            .QueueConfirm(false) // no monitor
+            // no prompt response queued → returns defaultValue ("./output")
+            .QueueSelect(0); // both
+
+        var runner = new WizardRunner(console);
+        var options = runner.Run();
+
+        options.OutputDirectory.Should().Be("./output");
+    }
+
+    [Fact]
+    public void Run_WithAutoDiscover_SetsFlag()
+    {
+        var console = new FakeWizardConsole()
+            .QueuePrompt("https://acct.documents.azure.com:443/")
+            .QueueSelect(0) // all databases
+            .QueueConfirm(true) // include monitor
+            .QueuePrompt("ws-id") // workspace ID
+            .QueueConfirm(true) // auto-discover = yes
+            .QueuePrompt("./out")
+            .QueueSelect(0); // both
+
+        var runner = new WizardRunner(console);
+        var options = runner.Run();
+
+        options.AutoDiscoverMonitoring.Should().BeTrue();
+        options.WorkspaceId.Should().Be("ws-id");
+    }
+
+    [Fact]
+    public void Run_Cancellation_ThrowsOperationCanceledException()
+    {
+        var console = new FakeWizardConsole()
+            .QueuePrompt("https://acct.documents.azure.com:443/");
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var runner = new WizardRunner(console);
+
+        var act = () => runner.Run(cts.Token);
+        act.Should().Throw<OperationCanceledException>();
+    }
+
+    [Fact]
+    public void Run_DisplaysWelcomeMessage()
+    {
+        var console = new FakeWizardConsole()
+            .QueuePrompt("https://acct.documents.azure.com:443/")
+            .QueueSelect(0)
+            .QueueConfirm(false)
+            .QueuePrompt("./out")
+            .QueueSelect(0);
+
+        var runner = new WizardRunner(console);
+        runner.Run();
+
+        console.Output.Should().Contain(s => s.Contains("Wizard"));
+        console.Output.Should().Contain(s => s.Contains("Step 1"));
+        console.Output.Should().Contain(s => s.Contains("Step 2"));
+    }
+
+    [Fact]
+    public void Constructor_NullConsole_ThrowsArgumentNullException()
+    {
+        var act = () => new WizardRunner(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
Closes #71

## Sub-issues checklist
- [x] #148 — Add --interactive flag
- [x] #149 — Step-by-step prompts for configuration
- [x] #150 — Real-time input validation
- [x] #151 — Show progress during analysis
- [x] #152 — Summary confirmation before execution
- [x] #153 — Save configuration for reuse
- [x] #154 — Support for resuming interrupted sessions

## Implementation approach

This PR adds an interactive wizard mode to the CosmosDB-to-SQL migration assessment tool. When `--interactive` is passed, the tool launches a step-by-step guided experience that:
1. Prompts users for connection details and analysis options (with IWizardConsole abstraction for testability)
2. Validates inputs in real-time (InputValidators with retry loops)
3. Shows progress during analysis (IProgressReporter + ConsoleProgressReporter)
4. Displays a formatted summary for confirmation before execution
5. Supports saving/loading configuration (`--config`, `--save-config`) and resuming interrupted sessions (`--resume`)

Built on top of the refactored `AssessmentOrchestrator` from #126.

### New CLI flags
- `-i`, `--interactive` — Launch wizard mode
- `-c`, `--config <path>` — Load saved configuration
- `--save-config <path>` — Save configuration to file
- `--resume` — Resume interrupted wizard session

### Architecture
- `Interactive/IWizardConsole.cs` — Console I/O abstraction
- `Interactive/SystemWizardConsole.cs` — Production Console.ReadLine impl
- `Interactive/WizardRunner.cs` — Step orchestration with state persistence
- `Interactive/InputValidators.cs` — Pure validation functions
- `Interactive/IProgressReporter.cs` + `ConsoleProgressReporter.cs` — Progress display
- `Interactive/ConfigurationStore.cs` + `WizardConfiguration.cs` — JSON save/load
- `Interactive/SessionStateManager.cs` + `WizardSessionState.cs` — Resume support

## Testing

602 tests pass (52 new tests for interactive wizard components):
- CLI parser: --interactive, --config, --save-config, --resume flags + mutual exclusion
- WizardRunner: all flows, resume, cancellation, validation retry
- InputValidators: endpoint, database name, workspace ID, output dir
- ConsoleProgressReporter: start/complete/fail/progress output
- ConfigurationStore: save/load roundtrip, ToCliOptions/FromCliOptions mapping
- SessionStateManager: save/load/clear, resume from mid-step

## Branch-protection changes

None.
