### PR TITLE
Tighten benchmark regression tolerance from 2.00x to 1.10x (#234)

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,11 +392,11 @@ dotnet run -c Release \
 ### Indicative allocation envelopes
 
 > The CI-enforced regression budgets live in
-> [`baselines/baseline.json`](tests/Performance/CosmosToSqlAssessment.Benchmarks/baselines/baseline.json)
-> once a maintainer seeds them from a representative CI run (tracked by #234).
-> The table below is a **bootstrap sizing guide, not an SLO** — values are from
-> single-iteration dry runs during initial development, rounded to one
-> significant figure, and intended to give a sense of order of magnitude.
+> [`baselines/baseline.json`](tests/Performance/CosmosToSqlAssessment.Benchmarks/baselines/baseline.json),
+> seeded from representative CI runs (#234). The table below is a **bootstrap
+> sizing guide, not an SLO** — values are from single-iteration dry runs during
+> initial development, rounded to one significant figure, and intended to give a
+> sense of order of magnitude.
 
 **Why allocated bytes and not mean?** Cosmos analysis is allocation-bound
 (JsonDocument parsing); SQL assessment and report generation are I/O-bound.
@@ -422,37 +422,54 @@ regressions on both axes.
 
 ### Regression detection
 
-> ⚠️ **The shipped `baselines/baseline.json` is empty**, which makes the CI
-> regression check an intentional no-op until a maintainer seeds it. Run the
-> `Performance Regression` workflow with `update_baseline=true` from the Actions
-> tab, review the `refreshed-baseline` artifact, and commit it in a follow-up PR.
-> See the [benchmarks README's seeding/refreshing section](tests/Performance/CosmosToSqlAssessment.Benchmarks/README.md#seeding--refreshing-the-baseline)
-> for the full walkthrough. Tracked by #234.
+The `baselines/baseline.json` is seeded from real CI runs, so the regression
+check is **live**: every PR to `main` and every perf-relevant push to `main` is
+compared against it. To refresh it after an intentional perf change, run the
+`Performance Regression` workflow with `update_baseline=true` from the Actions
+tab, review the `refreshed-baseline` artifact, and commit it. See the
+[benchmarks README's seeding/refreshing section](tests/Performance/CosmosToSqlAssessment.Benchmarks/README.md#seeding--refreshing-the-baseline)
+for the full walkthrough.
 
 The `compare-baseline` CLI fails a benchmark when:
 
-- `actualMean > baselineMean × toleranceFactor`, **or**
-- `actualAllocated > max(baselineAllocated × toleranceFactor, baselineAllocated + allocationFloorBytes)`
+- `actualMean > baselineMean × meanToleranceFactor`, **or**
+- `actualAllocated > max(baselineAllocated × allocationToleranceFactor, baselineAllocated + allocationFloorBytes)`
 
 Shipped defaults:
 
 | Setting | Value | Purpose |
 |---|---|---|
-| `defaultToleranceFactor` | `2.00` | 100% headroom on mean and allocated. **Intentionally loose** for first-day false-positive safety; see #234 for the path to the parent target of 1.10. |
-| `defaultAllocationFloorBytes` | `1024` | Protects near-zero baselines from brittle alarms. |
+| `defaultToleranceFactor` | `1.10` | 10% headroom on both the mean and allocation axes for every benchmark, unless a per-axis override widens it. Satisfies the parent #79 ">10% degradation fails CI" criterion. |
+| `defaultAllocationFloorBytes` | `1024` | Protects near-zero baselines from brittle alarms — an absolute +1 KB is always allowed on top of the percentage. |
 
-Per-benchmark `toleranceFactor` overrides in `baselines/baseline.json` are
-preserved across `--update` runs, so micro-benchmarks (low variance) can be
-tightened toward `1.10` while I/O-bound macro-benchmarks (e.g.
-`ReportGenerationBenchmarks.GenerateAssessmentReportAsync_EndToEnd`) stay
-looser until a stable runner SKU is locked in. See #234 for the planned
-tightening rollout.
+Tolerances can be overridden per benchmark and, since #234, **independently per
+axis** in `baselines/baseline.json`:
+
+- `meanToleranceFactor` — widens only the wall-clock (mean) budget.
+- `allocationToleranceFactor` — widens only the allocation budget.
+- `toleranceFactor` — legacy shared override applied to both axes when an
+  axis-specific value is absent.
+
+Allocations are effectively deterministic on the runner (observed run-to-run
+drift < 0.01%), so allocation stays pinned at the strict `1.10` default for
+**every** benchmark — including the ones below. Only the noisier **mean** axis is
+widened, for the two I/O-bound macro-benchmarks:
+
+| Benchmark (all sizes) | `meanToleranceFactor` | Why |
+|---|---|---|
+| `ReportGenerationBenchmarks.GenerateAssessmentReportAsync_EndToEnd` | `1.50` | Writes 4.4 MB → 343 MB to disk; wall-clock swings with runner I/O contention. |
+| `SqlAssessmentBenchmarks.AssessMigrationAsync_EndToEnd` | `1.20` | 8-phase orchestration macro; moderate timing variance. |
+
+Per-benchmark overrides are preserved across `--update` runs. The baseline is
+seeded from the slower of two consecutive CI runs of the same commit
+(`meanNs`/`allocatedBytes` = `max(run1, run2)`) so the check is not anchored to a
+lucky-fast capture.
 
 `compare-baseline` exit codes:
 
 | Code | Meaning |
 | --- | --- |
-| `0` | All compared benchmarks within tolerance (also returned for an empty baseline). |
+| `0` | All compared benchmarks within tolerance (an empty `benchmarks` map is a no-op pass). |
 | `1` | At least one benchmark regressed. |
 | `2` | Bad invocation, missing/malformed files, or baseline-vs-report key drift. |
 
@@ -476,19 +493,18 @@ The badge at the top of this README reflects the latest default-branch run;
 immediately after the workflow first lands on `main` it may briefly show
 "no status" until the first push-to-`main` run completes.
 
-### Deferred parent acceptance criteria
+### Parent acceptance criteria status
 
-Two parent #79 acceptance criteria are intentionally deferred. Both have
-dedicated follow-up issues so the deferral is traceable:
+Both parent #79 acceptance criteria that were initially deferred are now
+satisfied. Each had a dedicated follow-up issue so the path stayed traceable:
 
-- **>10% degradation fails CI** — the shipped default is `2.00x` (100%
-  headroom). Tightening requires a seeded baseline and per-benchmark variance
-  characterisation on the CI runner. Tracked by **#234**.
-- **Benchmark results published to GitHub Pages** — the current design uploads
-  artifacts on every run (sufficient for inspection); a Pages dashboard
-  (`benchmark-action/github-action-benchmark` is the likely choice) is the
-  natural next step but requires `gh-pages` write permissions and a pinned
-  runner SKU. Tracked by **#233**.
+- ✅ **>10% degradation fails CI** — `defaultToleranceFactor` is `1.10`, seeded
+  against a stable CI baseline captured from consecutive runs of the same commit
+  (#234). Allocations stay strict at 10% for every benchmark; only the mean axis
+  of the two I/O-bound macro-benchmarks is widened. Resolved by **#234**.
+- ✅ **Benchmark results published to GitHub Pages** — the `publish-pages` job in
+  the workflow pushes each `main` run's results to the `gh-pages` branch via
+  `benchmark-action/github-action-benchmark`. Resolved by **#233**.
 
 ## 🛠️ Troubleshooting
 

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/README.md
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/README.md
@@ -66,13 +66,13 @@ local-only at present; CI integration arrives in #178.
   "capturedAt": "<ISO-8601 timestamp>",
   "capturedOn": "<machine / OS / runtime description>",
   "captureCommand": "<command used to produce the report>",
-  "defaultToleranceFactor": 2.00,
+  "defaultToleranceFactor": 1.10,
   "defaultAllocationFloorBytes": 1024,
   "benchmarks": {
     "Namespace.Class.Method(Size: Small)": {
       "meanNs": 12345.6,
       "allocatedBytes": 7890,
-      "toleranceFactor": 2.00
+      "meanToleranceFactor": 1.50
     }
   }
 }
@@ -80,15 +80,29 @@ local-only at present; CI integration arrives in #178.
 
 A benchmark fails the comparison if:
 
-- `actualMean > baselineMean × tolerance`, **or**
-- `actualAllocated > max(baselineAllocated × tolerance, baselineAllocated + defaultAllocationFloorBytes)`
+- `actualMean > baselineMean × meanToleranceFactor`, **or**
+- `actualAllocated > max(baselineAllocated × allocationToleranceFactor, baselineAllocated + defaultAllocationFloorBytes)`
 
-The allocation floor avoids brittle alarms when a baseline is near zero. Per-benchmark
-`toleranceFactor` overrides the file-level default and is preserved across `--update` runs.
+The allocation floor avoids brittle alarms when a baseline is near zero.
+Tolerances are resolved **independently per axis**, so the mean (wall-clock) and
+allocation budgets can be tuned separately:
+
+- `meanToleranceFactor` overrides only the mean axis.
+- `allocationToleranceFactor` overrides only the allocation axis.
+- `toleranceFactor` is a legacy shared override used for an axis only when its
+  axis-specific value is absent.
+- Anything still unset falls back to `defaultToleranceFactor`.
+
+All per-benchmark overrides are preserved across `--update` runs. The shipped
+baseline keeps allocation pinned at the strict `1.10` default everywhere
+(allocations are deterministic) and widens only the mean axis for the two
+I/O-bound macro-benchmarks (`GenerateAssessmentReportAsync_EndToEnd` → `1.50`,
+`AssessMigrationAsync_EndToEnd` → `1.20`).
 
 ### Seeding / refreshing the baseline
 
-The repo ships with an empty baseline. First-time seed:
+The baseline is seeded from real CI runs (see the [root README's CI section](../../../README.md#ci-integration)).
+To re-seed it locally — or to refresh it after an intentional perf change:
 
 ```bash
 # 1. Capture a real measurement run (short job — ~minutes, not seconds, but realistic).
@@ -125,10 +139,13 @@ Exit codes:
 | `2` | Bad invocation, missing/malformed files, or baseline-vs-report key drift. |
 
 > Cross-machine note: BenchmarkDotNet `Mean` numbers are noticeably hardware-dependent. The
-> shipped tolerance (`2.00` = 100% headroom) is intentionally loose. Tighten per-benchmark
-> values in the baseline once #178 pins a CI runner to one runner SKU.
+> CI baseline is therefore seeded from the GitHub-hosted `ubuntu-latest` runner (the same SKU
+> the workflow runs on) and captured as `max(run1, run2)` of two consecutive runs of the same
+> commit. The default tolerance is `1.10` (10% headroom); the mean axis is widened per benchmark
+> only where shared-runner timing variance demands it (see the table above). If you run locally,
+> expect absolute `Mean` numbers to differ — compare deltas, not absolutes.
 >
-> The CI workflow in #178 will invoke `compare-baseline` against the same `*-report-full.json`
+> The CI workflow invokes `compare-baseline` against the same `*-report-full.json`
 > artifacts; the contract here is intended to stay stable.
 
 ## CI

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/Tracking/BaselineComparer.cs
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/Tracking/BaselineComparer.cs
@@ -240,23 +240,29 @@ public static class BaselineComparer
                 continue;
             }
 
-            double tolerance = baselineRow.ToleranceFactor ?? baseline.DefaultToleranceFactor;
+            double meanTolerance = baselineRow.MeanToleranceFactor
+                ?? baselineRow.ToleranceFactor
+                ?? baseline.DefaultToleranceFactor;
+            double allocTolerance = baselineRow.AllocationToleranceFactor
+                ?? baselineRow.ToleranceFactor
+                ?? baseline.DefaultToleranceFactor;
             long floor = baseline.DefaultAllocationFloorBytes;
 
             double actualMean = actual.MeanNs.Value;
             long actualAlloc = actual.AllocatedBytes.Value;
 
-            double meanThreshold = baselineRow.MeanNs * tolerance;
+            double meanThreshold = baselineRow.MeanNs * meanTolerance;
             long allocThreshold = Math.Max(
-                (long)Math.Ceiling(baselineRow.AllocatedBytes * tolerance),
+                (long)Math.Ceiling(baselineRow.AllocatedBytes * allocTolerance),
                 baselineRow.AllocatedBytes + floor);
 
             bool meanRegression = actualMean > meanThreshold;
             bool allocRegression = actualAlloc > allocThreshold;
 
-            double improveDivisor = tolerance > 1.0 ? tolerance : 1.0;
-            bool meanImproved = baselineRow.MeanNs > 0 && actualMean < baselineRow.MeanNs / improveDivisor;
-            bool allocImproved = baselineRow.AllocatedBytes > 0 && actualAlloc < baselineRow.AllocatedBytes / improveDivisor;
+            double meanImproveDivisor = meanTolerance > 1.0 ? meanTolerance : 1.0;
+            double allocImproveDivisor = allocTolerance > 1.0 ? allocTolerance : 1.0;
+            bool meanImproved = baselineRow.MeanNs > 0 && actualMean < baselineRow.MeanNs / meanImproveDivisor;
+            bool allocImproved = baselineRow.AllocatedBytes > 0 && actualAlloc < baselineRow.AllocatedBytes / allocImproveDivisor;
 
             outcome.Rows.Add(new ComparisonRow(
                 FullName: name,
@@ -264,7 +270,8 @@ public static class BaselineComparer
                 ActualMeanNs: actualMean,
                 BaselineAllocatedBytes: baselineRow.AllocatedBytes,
                 ActualAllocatedBytes: actualAlloc,
-                ToleranceFactor: tolerance,
+                MeanToleranceFactor: meanTolerance,
+                AllocationToleranceFactor: allocTolerance,
                 AllocationFloorBytes: floor,
                 MeanRegression: meanRegression,
                 AllocationRegression: allocRegression,
@@ -348,13 +355,13 @@ public static class BaselineComparer
                 {
                     Console.WriteLine(
                         $"  ⚠ Mean above threshold: actual={row.ActualMeanNs:N1}ns > " +
-                        $"{row.BaselineMeanNs:N1}ns × {row.ToleranceFactor:N2} = {row.MeanThresholdNs:N1}ns");
+                        $"{row.BaselineMeanNs:N1}ns × {row.MeanToleranceFactor:N2} = {row.MeanThresholdNs:N1}ns");
                 }
                 if (row.AllocationRegression)
                 {
                     Console.WriteLine(
                         $"  ⚠ Allocations above threshold: actual={row.ActualAllocatedBytes:N0}B > " +
-                        $"max(baseline×{row.ToleranceFactor:N2}, baseline+{row.AllocationFloorBytes}) = {row.AllocationThresholdBytes:N0}B");
+                        $"max(baseline×{row.AllocationToleranceFactor:N2}, baseline+{row.AllocationFloorBytes}) = {row.AllocationThresholdBytes:N0}B");
                 }
                 if (!row.AnyRegression && row.AnyImprovement)
                 {

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/Tracking/BaselineRecord.cs
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/Tracking/BaselineRecord.cs
@@ -33,7 +33,27 @@ public sealed class BenchmarkBaseline
 
     public long AllocatedBytes { get; set; }
 
+    /// <summary>
+    /// Shared per-benchmark override applied to <em>both</em> the mean and allocation axes when the
+    /// axis-specific overrides below are absent. Kept for backwards compatibility with baselines
+    /// authored before the mean/allocation split.
+    /// </summary>
     public double? ToleranceFactor { get; set; }
+
+    /// <summary>
+    /// Per-benchmark override for the <em>mean (wall-clock)</em> axis only. Use this to widen the
+    /// tolerance for benchmarks whose timing is inherently noisy on shared runners (e.g. disk-I/O
+    /// macro-benchmarks) without loosening their allocation budget. Falls back to
+    /// <see cref="ToleranceFactor"/> then the file-level default.
+    /// </summary>
+    public double? MeanToleranceFactor { get; set; }
+
+    /// <summary>
+    /// Per-benchmark override for the <em>allocation</em> axis only. Allocations are deterministic,
+    /// so this is rarely needed; it exists for symmetry with <see cref="MeanToleranceFactor"/>.
+    /// Falls back to <see cref="ToleranceFactor"/> then the file-level default.
+    /// </summary>
+    public double? AllocationToleranceFactor { get; set; }
 }
 
 /// <summary>
@@ -45,7 +65,8 @@ public sealed record ComparisonRow(
     double ActualMeanNs,
     long BaselineAllocatedBytes,
     long ActualAllocatedBytes,
-    double ToleranceFactor,
+    double MeanToleranceFactor,
+    double AllocationToleranceFactor,
     long AllocationFloorBytes,
     bool MeanRegression,
     bool AllocationRegression,
@@ -55,10 +76,10 @@ public sealed record ComparisonRow(
     public bool AnyRegression => MeanRegression || AllocationRegression;
     public bool AnyImprovement => MeanImproved || AllocationImproved;
 
-    public double MeanThresholdNs => BaselineMeanNs * ToleranceFactor;
+    public double MeanThresholdNs => BaselineMeanNs * MeanToleranceFactor;
 
     public long AllocationThresholdBytes => Math.Max(
-        (long)Math.Ceiling(BaselineAllocatedBytes * ToleranceFactor),
+        (long)Math.Ceiling(BaselineAllocatedBytes * AllocationToleranceFactor),
         BaselineAllocatedBytes + AllocationFloorBytes);
 }
 

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/baselines/baseline.json
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/baselines/baseline.json
@@ -1,9 +1,248 @@
 {
   "schemaVersion": 1,
-  "capturedAt": null,
-  "capturedOn": "placeholder — seed via 'compare-baseline --update --report <full.json>'",
-  "captureCommand": "dotnet run -c Release --project tests/Performance/CosmosToSqlAssessment.Benchmarks/CosmosToSqlAssessment.Benchmarks.csproj -- --filter \"*\" --job short",
-  "defaultToleranceFactor": 2.00,
+  "capturedAt": "2026-06-18T23:50:57.8120696+00:00",
+  "capturedOn": "GitHub Actions ubuntu-latest (hosted) \u2014 seeded from the slower of two consecutive Performance Regression workflow_dispatch runs on post-#129 main (PR #244, issue #234)",
+  "captureCommand": "Performance Regression workflow_dispatch (update_baseline=true) x2; per-benchmark meanNs/allocatedBytes = max(run1, run2)",
+  "defaultToleranceFactor": 1.1,
   "defaultAllocationFloorBytes": 1024,
-  "benchmarks": {}
+  "benchmarks": {
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.CosmosAnalysisBenchmarks.MapJsonTypeToSqlTypeEnhanced_Primitives(Size: Small)": {
+      "meanNs": 134.02137163335627,
+      "allocatedBytes": 68
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.CosmosAnalysisBenchmarks.ExtractFieldsFlat_Document(Size: Small)": {
+      "meanNs": 2251.24538269043,
+      "allocatedBytes": 2528
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.CosmosAnalysisBenchmarks.AnalyzeArrayStructure_Tags(Size: Small)": {
+      "meanNs": 699.6669611930847,
+      "allocatedBytes": 984
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.CosmosAnalysisBenchmarks.AnalyzeArrayStructure_Objects(Size: Small)": {
+      "meanNs": 559.6241730372111,
+      "allocatedBytes": 1040
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.CosmosAnalysisBenchmarks.GetRecommendedSqlType_Mixed(Size: Small)": {
+      "meanNs": 845.9287075678508,
+      "allocatedBytes": 160
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.CosmosAnalysisBenchmarks.MapJsonTypeToSqlTypeEnhanced_Primitives(Size: Medium)": {
+      "meanNs": 134.34394064816564,
+      "allocatedBytes": 68
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.CosmosAnalysisBenchmarks.ExtractFieldsFlat_Document(Size: Medium)": {
+      "meanNs": 11828.099891662598,
+      "allocatedBytes": 9280
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.CosmosAnalysisBenchmarks.AnalyzeArrayStructure_Tags(Size: Medium)": {
+      "meanNs": 703.3250811258952,
+      "allocatedBytes": 984
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.CosmosAnalysisBenchmarks.AnalyzeArrayStructure_Objects(Size: Medium)": {
+      "meanNs": 562.9417924245198,
+      "allocatedBytes": 1040
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.CosmosAnalysisBenchmarks.GetRecommendedSqlType_Mixed(Size: Medium)": {
+      "meanNs": 840.2008336385092,
+      "allocatedBytes": 160
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.CosmosAnalysisBenchmarks.MapJsonTypeToSqlTypeEnhanced_Primitives(Size: Large)": {
+      "meanNs": 134.11707933847006,
+      "allocatedBytes": 68
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.CosmosAnalysisBenchmarks.ExtractFieldsFlat_Document(Size: Large)": {
+      "meanNs": 20197.383283342635,
+      "allocatedBytes": 16824
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.CosmosAnalysisBenchmarks.AnalyzeArrayStructure_Tags(Size: Large)": {
+      "meanNs": 702.5665452321371,
+      "allocatedBytes": 984
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.CosmosAnalysisBenchmarks.AnalyzeArrayStructure_Objects(Size: Large)": {
+      "meanNs": 603.8509126027425,
+      "allocatedBytes": 1040
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.CosmosAnalysisBenchmarks.GetRecommendedSqlType_Mixed(Size: Large)": {
+      "meanNs": 846.415423075358,
+      "allocatedBytes": 160
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.ReportGenerationBenchmarks.SanitizeFileName_Bank(Size: Small)": {
+      "meanNs": 48.543820991516114,
+      "allocatedBytes": 78
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.ReportGenerationBenchmarks.CreateValidWorksheetName_Bank(Size: Small)": {
+      "meanNs": 375.7633336639405,
+      "allocatedBytes": 630
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.ReportGenerationBenchmarks.GenerateAssessmentReportAsync_EndToEnd(Size: Small)": {
+      "meanNs": 23555623.83,
+      "allocatedBytes": 4376048,
+      "meanToleranceFactor": 1.5
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.ReportGenerationBenchmarks.SanitizeFileName_Bank(Size: Medium)": {
+      "meanNs": 48.556215356191,
+      "allocatedBytes": 78
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.ReportGenerationBenchmarks.CreateValidWorksheetName_Bank(Size: Medium)": {
+      "meanNs": 378.48888871256503,
+      "allocatedBytes": 630
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.ReportGenerationBenchmarks.GenerateAssessmentReportAsync_EndToEnd(Size: Medium)": {
+      "meanNs": 72155590.07142857,
+      "allocatedBytes": 33650192,
+      "meanToleranceFactor": 1.5
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.ReportGenerationBenchmarks.SanitizeFileName_Bank(Size: Large)": {
+      "meanNs": 48.73688116891043,
+      "allocatedBytes": 78
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.ReportGenerationBenchmarks.CreateValidWorksheetName_Bank(Size: Large)": {
+      "meanNs": 380.1769623209635,
+      "allocatedBytes": 630
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.ReportGenerationBenchmarks.GenerateAssessmentReportAsync_EndToEnd(Size: Large)": {
+      "meanNs": 707089416.5,
+      "allocatedBytes": 343472264,
+      "meanToleranceFactor": 1.5
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.SmokeBenchmarks.BuildAssessmentResult": {
+      "meanNs": 2977.030223083496,
+      "allocatedBytes": 3928
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.SqlAssessmentBenchmarks.AssessMigrationAsync_EndToEnd(Size: Small)": {
+      "meanNs": 37692.57879638672,
+      "allocatedBytes": 34760,
+      "meanToleranceFactor": 1.2
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.SqlAssessmentBenchmarks.GenerateIndexScript_Bank(Size: Small)": {
+      "meanNs": 438.98042433675135,
+      "allocatedBytes": 1071
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.SqlAssessmentBenchmarks.SanitizeName_Bank(Size: Small)": {
+      "meanNs": 149.7092420450846,
+      "allocatedBytes": 270
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.SqlAssessmentBenchmarks.AssessMigrationAsync_EndToEnd(Size: Medium)": {
+      "meanNs": 339773.4574544271,
+      "allocatedBytes": 256601,
+      "meanToleranceFactor": 1.2
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.SqlAssessmentBenchmarks.GenerateIndexScript_Bank(Size: Medium)": {
+      "meanNs": 435.7181802571614,
+      "allocatedBytes": 1071
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.SqlAssessmentBenchmarks.SanitizeName_Bank(Size: Medium)": {
+      "meanNs": 150.64176888529457,
+      "allocatedBytes": 270
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.SqlAssessmentBenchmarks.AssessMigrationAsync_EndToEnd(Size: Large)": {
+      "meanNs": 2066417.763671875,
+      "allocatedBytes": 1165253,
+      "meanToleranceFactor": 1.2
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.SqlAssessmentBenchmarks.GenerateIndexScript_Bank(Size: Large)": {
+      "meanNs": 436.659356994629,
+      "allocatedBytes": 1071
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.SqlAssessmentBenchmarks.SanitizeName_Bank(Size: Large)": {
+      "meanNs": 154.11902781895228,
+      "allocatedBytes": 270
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingMemoryProfileBenchmarks.StreamingClonePattern(DocumentCount: 1000)": {
+      "meanNs": 2737613.898995536,
+      "allocatedBytes": 2078381
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingMemoryProfileBenchmarks.BufferedRetainAllPattern(DocumentCount: 1000)": {
+      "meanNs": 2825968.7313802084,
+      "allocatedBytes": 2012693
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingMemoryProfileBenchmarks.StreamingWithSchemaExtraction(DocumentCount: 1000)": {
+      "meanNs": 14774228.611177884,
+      "allocatedBytes": 11963637
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingMemoryProfileBenchmarks.StreamingWithTypeMapping(DocumentCount: 1000)": {
+      "meanNs": 6180538.69453125,
+      "allocatedBytes": 3266723
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingMemoryProfileBenchmarks.StreamingClonePattern(DocumentCount: 10000)": {
+      "meanNs": 29255853.698958334,
+      "allocatedBytes": 20798418
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingMemoryProfileBenchmarks.BufferedRetainAllPattern(DocumentCount: 10000)": {
+      "meanNs": 35568583.25333332,
+      "allocatedBytes": 29036779
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingMemoryProfileBenchmarks.StreamingWithSchemaExtraction(DocumentCount: 10000)": {
+      "meanNs": 149238303.05,
+      "allocatedBytes": 119723956
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingMemoryProfileBenchmarks.StreamingWithTypeMapping(DocumentCount: 10000)": {
+      "meanNs": 63732628.325,
+      "allocatedBytes": 32690882
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingPipelineBenchmarks.StreamDocuments_PageSizeIteration(PageSize: 25)": {
+      "meanNs": 14206972.030729167,
+      "allocatedBytes": 10398077
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingPipelineBenchmarks.StreamDocuments_WithSchemaAnalysis(PageSize: 25)": {
+      "meanNs": 86811885.59523809,
+      "allocatedBytes": 73511971
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingPipelineBenchmarks.StreamDocuments_ContinuationTokenTracking(PageSize: 25)": {
+      "meanNs": 14126667.169791667,
+      "allocatedBytes": 10407629
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingPipelineBenchmarks.StreamContainers_Enumeration(PageSize: 25)": {
+      "meanNs": 2028.5500039320725,
+      "allocatedBytes": 1712
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingPipelineBenchmarks.StreamDocuments_PageSizeIteration(PageSize: 50)": {
+      "meanNs": 13716642.260044644,
+      "allocatedBytes": 10398077
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingPipelineBenchmarks.StreamDocuments_WithSchemaAnalysis(PageSize: 50)": {
+      "meanNs": 86119955.29761906,
+      "allocatedBytes": 73511971
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingPipelineBenchmarks.StreamDocuments_ContinuationTokenTracking(PageSize: 50)": {
+      "meanNs": 13773610.897916667,
+      "allocatedBytes": 10402829
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingPipelineBenchmarks.StreamContainers_Enumeration(PageSize: 50)": {
+      "meanNs": 3999.543505859375,
+      "allocatedBytes": 3312
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingPipelineBenchmarks.StreamDocuments_PageSizeIteration(PageSize: 100)": {
+      "meanNs": 13753779.553645832,
+      "allocatedBytes": 10398077
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingPipelineBenchmarks.StreamDocuments_WithSchemaAnalysis(PageSize: 100)": {
+      "meanNs": 85767824.31111112,
+      "allocatedBytes": 73511971
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingPipelineBenchmarks.StreamDocuments_ContinuationTokenTracking(PageSize: 100)": {
+      "meanNs": 13782550.202083332,
+      "allocatedBytes": 10400429
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingPipelineBenchmarks.StreamContainers_Enumeration(PageSize: 100)": {
+      "meanNs": 8060.806829325358,
+      "allocatedBytes": 6512
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingPipelineBenchmarks.StreamDocuments_PageSizeIteration(PageSize: 200)": {
+      "meanNs": 13729478.869419644,
+      "allocatedBytes": 10398077
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingPipelineBenchmarks.StreamDocuments_WithSchemaAnalysis(PageSize: 200)": {
+      "meanNs": 85821763.1,
+      "allocatedBytes": 73511971
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingPipelineBenchmarks.StreamDocuments_ContinuationTokenTracking(PageSize: 200)": {
+      "meanNs": 13907831.133854168,
+      "allocatedBytes": 10399229
+    },
+    "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingPipelineBenchmarks.StreamContainers_Enumeration(PageSize: 200)": {
+      "meanNs": 15817.066571916852,
+      "allocatedBytes": 12912
+    }
+  }
 }


### PR DESCRIPTION
Closes #234

Seeds a stable CI benchmark baseline against the final post-#129 streaming code and tightens the regression tolerance from `2.00x` (100% headroom) to the parent #79 target of `1.10x` (10%), with mean-only overrides for the inherently noisy I/O-bound macro-benchmarks.

## Implementation approach
1. **Seeded** the baseline from **two consecutive** `Performance Regression` `workflow_dispatch` runs (`update_baseline=true`) of the same commit. Allocations were byte-deterministic (run-to-run drift < 0.01%); means spanned 0.88x–1.13x, with only one sub-3µs micro-benchmark exceeding 1.10x. Each benchmark's committed `meanNs`/`allocatedBytes` = `max(run1, run2)` so the check isn't anchored to a lucky-fast capture.
2. **Per-axis tolerance split** (`BaselineComparer`/`BaselineRecord`): added `meanToleranceFactor` and `allocationToleranceFactor` so the noisy wall-clock axis can be widened **without** loosening the strict allocation budget (legacy `toleranceFactor` still works as a shared fallback). Verified end-to-end against the real CI report JSON: a +30% mean / +20% alloc report fails on **allocation only**, proving the mean override doesn't relax allocation.
3. **Tightened** `defaultToleranceFactor` → `1.10`. Mean-only overrides: `ReportGenerationBenchmarks.GenerateAssessmentReportAsync_EndToEnd` → `1.50` (4.4MB→343MB disk writes), `SqlAssessmentBenchmarks.AssessMigrationAsync_EndToEnd` → `1.20`. Allocation stays at `1.10` for every benchmark.
4. **Docs** — root `README.md` "Regression detection" + benchmarks `README.md` updated; "100% headroom intentionally" caveat removed; deferred-criteria section flipped to ✅.

## Checklist (acceptance criteria)
- [x] `baselines/baseline.json` populated from ≥2 consecutive CI runs (58 benchmarks)
- [x] `defaultToleranceFactor` = `1.10`
- [x] Per-benchmark (mean-only) overrides documented for the noisy macros
- [ ] 3 consecutive `Performance Regression` runs on `main` pass with zero false positives _(post-merge)_
- [x] Both READMEs updated; "100% headroom" caveat removed
- [x] Parent #79 criterion "Regression detection fails CI if perf degrades >10%" satisfied

## Testing
- `dotnet build` + `dotnet test` green (659 tests) on the rebased tree.
- `compare-baseline` run locally against all 6 real CI report files: 58 compared, 0 regressions.
- Per-axis behavior verified with crafted reports (mean override honored; allocation stays strict at 1.10).

## Branch-protection changes
None — the `Benchmark regression` check already runs on every PR to `main`.
