### PR TITLE
Parent #131: Multi-agent orchestration layer

### DIFF
--- a/Agents/AgentExecutionMode.cs
+++ b/Agents/AgentExecutionMode.cs
@@ -1,0 +1,27 @@
+namespace CosmosToSqlAssessment.Agents;
+
+/// <summary>
+/// Strategy the <c>AgentOrchestrator</c> uses to schedule a set of agents.
+/// </summary>
+/// <remarks>
+/// The mode selects a scheduling policy; actual ordering and gating are derived from each
+/// agent's <see cref="IAssessmentAgent.Dependencies"/> so the orchestrator never hardcodes
+/// per-agent rules.
+/// </remarks>
+public enum AgentExecutionMode
+{
+    /// <summary>Run agents one at a time in dependency order. Deterministic and easiest to debug.</summary>
+    Sequential,
+
+    /// <summary>
+    /// Run agents whose dependencies are already satisfied concurrently, scheduling more as
+    /// dependencies complete. Maximizes throughput for independent work.
+    /// </summary>
+    Parallel,
+
+    /// <summary>
+    /// Run agents in dependency order but skip any agent whose required upstream outputs are
+    /// missing (for example because an upstream agent failed), rather than failing the whole run.
+    /// </summary>
+    Conditional
+}

--- a/Agents/AgentMessage.cs
+++ b/Agents/AgentMessage.cs
@@ -1,0 +1,52 @@
+namespace CosmosToSqlAssessment.Agents;
+
+/// <summary>
+/// Severity of an <see cref="AgentMessage"/> recorded on a <see cref="SharedAssessmentContext"/>.
+/// </summary>
+public enum AgentMessageLevel
+{
+    /// <summary>Informational progress or diagnostic message.</summary>
+    Info,
+
+    /// <summary>A non-fatal concern that did not stop the agent.</summary>
+    Warning,
+
+    /// <summary>An error condition, typically paired with a failed <see cref="AgentResult"/>.</summary>
+    Error
+}
+
+/// <summary>
+/// An immutable, timestamped log entry produced by an agent and appended to the shared
+/// <see cref="SharedAssessmentContext.Messages"/> blackboard.
+/// </summary>
+/// <param name="AgentName">The <see cref="IAssessmentAgent.Name"/> of the producing agent.</param>
+/// <param name="Level">The severity of the message.</param>
+/// <param name="Text">The human-readable message text.</param>
+/// <param name="TimestampUtc">The UTC time the message was created.</param>
+public sealed record AgentMessage(
+    string AgentName,
+    AgentMessageLevel Level,
+    string Text,
+    DateTimeOffset TimestampUtc)
+{
+    /// <summary>Creates an <see cref="AgentMessageLevel.Info"/> message stamped with the current UTC time.</summary>
+    /// <param name="agentName">The producing agent's name.</param>
+    /// <param name="text">The message text.</param>
+    /// <returns>A new <see cref="AgentMessage"/>.</returns>
+    public static AgentMessage Info(string agentName, string text) =>
+        new(agentName, AgentMessageLevel.Info, text, DateTimeOffset.UtcNow);
+
+    /// <summary>Creates an <see cref="AgentMessageLevel.Warning"/> message stamped with the current UTC time.</summary>
+    /// <param name="agentName">The producing agent's name.</param>
+    /// <param name="text">The message text.</param>
+    /// <returns>A new <see cref="AgentMessage"/>.</returns>
+    public static AgentMessage Warning(string agentName, string text) =>
+        new(agentName, AgentMessageLevel.Warning, text, DateTimeOffset.UtcNow);
+
+    /// <summary>Creates an <see cref="AgentMessageLevel.Error"/> message stamped with the current UTC time.</summary>
+    /// <param name="agentName">The producing agent's name.</param>
+    /// <param name="text">The message text.</param>
+    /// <returns>A new <see cref="AgentMessage"/>.</returns>
+    public static AgentMessage Error(string agentName, string text) =>
+        new(agentName, AgentMessageLevel.Error, text, DateTimeOffset.UtcNow);
+}

--- a/Agents/AgentOrchestrationOptions.cs
+++ b/Agents/AgentOrchestrationOptions.cs
@@ -1,0 +1,23 @@
+namespace CosmosToSqlAssessment.Agents;
+
+/// <summary>
+/// Options that control how the <see cref="AgentOrchestrator"/> schedules and bounds an agentic run.
+/// </summary>
+public sealed record AgentOrchestrationOptions
+{
+    /// <summary>
+    /// How producer agents are scheduled. Defaults to <see cref="AgentExecutionMode.Sequential"/>, which
+    /// reproduces the single-pass order (Cosmos → SQL → data quality → Data Factory).
+    /// </summary>
+    public AgentExecutionMode Mode { get; init; } = AgentExecutionMode.Sequential;
+
+    /// <summary>
+    /// Optional per-agent timeout. <strong>Cooperative</strong>: it cancels the token passed to each agent,
+    /// so it only bounds agents (and the services they wrap) that observe cancellation. A timed-out agent is
+    /// recorded as a failed result and the run continues. <see langword="null"/> (default) means no timeout.
+    /// </summary>
+    public TimeSpan? PerAgentTimeout { get; init; }
+
+    /// <summary>A shared default instance using sequential scheduling and no timeout.</summary>
+    public static AgentOrchestrationOptions Default { get; } = new();
+}

--- a/Agents/AgentOrchestrationResult.cs
+++ b/Agents/AgentOrchestrationResult.cs
@@ -1,0 +1,42 @@
+using CosmosToSqlAssessment.Models;
+
+namespace CosmosToSqlAssessment.Agents;
+
+/// <summary>
+/// The immutable outcome of an <see cref="AgentOrchestrator"/> run. It exposes point-in-time snapshots only;
+/// the live, mutable <see cref="SharedAssessmentContext"/> is intentionally not surfaced so callers cannot
+/// retroactively change the projected result.
+/// </summary>
+/// <remarks>
+/// <strong>Consumption contract:</strong> <see cref="AssessmentResult"/> is a best-effort projection that is
+/// always non-null but is only safe to drive downstream report / SQL-project / Data Factory generation when
+/// <see cref="IsAcceptable"/> is <see langword="true"/>. When <see cref="IsAcceptable"/> is
+/// <see langword="false"/> (a required output is missing or outputs are inconsistent), the result may contain
+/// empty defaults and consumers should surface the failure instead of generating artifacts.
+/// </remarks>
+public sealed record AgentOrchestrationResult
+{
+    /// <summary>
+    /// The projected assessment, equivalent to single-pass output when the run is acceptable. Only safe for
+    /// downstream generation when <see cref="IsAcceptable"/> is <see langword="true"/>.
+    /// </summary>
+    public required AssessmentResult AssessmentResult { get; init; }
+
+    /// <summary>The validator's verdict, or <see langword="null"/> if validation did not produce a report.</summary>
+    public ValidationReport? Validation { get; init; }
+
+    /// <summary>A snapshot of every agent result recorded during the run, in execution order.</summary>
+    public IReadOnlyList<AgentResult> AgentResults { get; init; } = Array.Empty<AgentResult>();
+
+    /// <summary>A snapshot of every message logged during the run, in order.</summary>
+    public IReadOnlyList<AgentMessage> Messages { get; init; } = Array.Empty<AgentMessage>();
+
+    /// <summary>
+    /// Whether the run is acceptable (complete and consistent). Derived from
+    /// <see cref="ValidationReport.IsAcceptable"/>; <see langword="false"/> when no report was produced.
+    /// </summary>
+    public bool IsAcceptable { get; init; }
+
+    /// <summary>The execution mode the run was scheduled with.</summary>
+    public AgentExecutionMode Mode { get; init; }
+}

--- a/Agents/AgentOrchestrator.cs
+++ b/Agents/AgentOrchestrator.cs
@@ -1,0 +1,252 @@
+using Microsoft.Extensions.Logging;
+
+namespace CosmosToSqlAssessment.Agents;
+
+/// <summary>
+/// Coordinates the assessment agents over a single <see cref="SharedAssessmentContext"/>, scheduling them
+/// according to their declared <see cref="IAssessmentAgent.Dependencies"/> and the requested
+/// <see cref="AgentExecutionMode"/>, isolating per-agent failures, and finishing with the validation pass.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the stable public entry point that downstream agentic features build on. Producers (every agent
+/// except the validator) run first; the validator runs last so it observes every result. The Data Factory
+/// estimate is produced by an internal agent and therefore schedules uniformly through the dependency graph.
+/// </para>
+/// <para>
+/// The orchestrator validates the agent graph up front (see the constructor) and never throws for a
+/// recoverable agent failure — a failed or timed-out agent is recorded and the run continues, mirroring the
+/// single-pass pipeline's tolerance while still flagging missing required outputs through the validator.
+/// </para>
+/// </remarks>
+public sealed class AgentOrchestrator
+{
+    private readonly IReadOnlyList<IAssessmentAgent> _producers;
+    private readonly IReadOnlyList<IAssessmentAgent> _validators;
+    private readonly ILogger<AgentOrchestrator> _logger;
+
+    /// <summary>
+    /// Creates a new <see cref="AgentOrchestrator"/> over the supplied agents.
+    /// </summary>
+    /// <param name="agents">
+    /// The agents to coordinate. Exactly one agent must own each of the required roles
+    /// (<see cref="AgentRole.CosmosAnalysis"/>, <see cref="AgentRole.SqlPlanning"/>,
+    /// <see cref="AgentRole.DataFactoryEstimation"/>, <see cref="AgentRole.Validation"/>); data quality is
+    /// optional. No two agents may share a role or a name, and every dependency role must be produced by a
+    /// registered agent.
+    /// </param>
+    /// <param name="logger">Logger for diagnostic output.</param>
+    /// <exception cref="ArgumentNullException">If <paramref name="agents"/> or <paramref name="logger"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">If the agent graph violates the invariants above.</exception>
+    public AgentOrchestrator(IEnumerable<IAssessmentAgent> agents, ILogger<AgentOrchestrator> logger)
+    {
+        ArgumentNullException.ThrowIfNull(agents);
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        var all = agents.ToList();
+        ValidateGraph(all);
+
+        _validators = all.Where(a => a.Role == AgentRole.Validation).ToList();
+        _producers = all.Where(a => a.Role != AgentRole.Validation)
+            .OrderBy(a => RolePriority(a.Role))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Runs the agentic assessment for a single database and returns an immutable result.
+    /// </summary>
+    /// <param name="databaseName">The Cosmos DB database to assess.</param>
+    /// <param name="cosmosAccountName">Friendly name of the Cosmos DB account (used in the projected result).</param>
+    /// <param name="options">Scheduling options; defaults to sequential with no timeout.</param>
+    /// <param name="cancellationToken">Token used to cancel the whole run (propagates; does not become a failed result).</param>
+    /// <returns>The immutable <see cref="AgentOrchestrationResult"/> for the run.</returns>
+    public async Task<AgentOrchestrationResult> RunAsync(
+        string databaseName,
+        string cosmosAccountName,
+        AgentOrchestrationOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        options ??= AgentOrchestrationOptions.Default;
+        var context = new SharedAssessmentContext(databaseName, cosmosAccountName);
+
+        _logger.LogInformation(
+            "AgentOrchestrator starting for database {DatabaseName} in {Mode} mode with {ProducerCount} producer agent(s)",
+            databaseName, options.Mode, _producers.Count);
+
+        await RunProducersAsync(context, options, cancellationToken).ConfigureAwait(false);
+
+        // Validators always run last, sequentially, so they observe every producer result.
+        foreach (var validator in _validators)
+        {
+            await RunAgentAsync(validator, context, options, cancellationToken).ConfigureAwait(false);
+        }
+
+        var validation = context.ValidationReport;
+        var result = new AgentOrchestrationResult
+        {
+            AssessmentResult = context.ToAssessmentResult(),
+            Validation = validation,
+            AgentResults = context.Results,
+            Messages = context.Messages,
+            IsAcceptable = validation?.IsAcceptable ?? false,
+            Mode = options.Mode
+        };
+
+        _logger.LogInformation(
+            "AgentOrchestrator finished for database {DatabaseName}: acceptable={IsAcceptable}, {ResultCount} agent result(s)",
+            databaseName, result.IsAcceptable, result.AgentResults.Count);
+
+        return result;
+    }
+
+    private async Task RunProducersAsync(
+        SharedAssessmentContext context, AgentOrchestrationOptions options, CancellationToken cancellationToken)
+    {
+        var remaining = _producers.ToList();
+        var completedRoles = new HashSet<AgentRole>();
+
+        while (remaining.Count > 0)
+        {
+            var ready = remaining.Where(a => a.Dependencies.All(completedRoles.Contains)).ToList();
+            if (ready.Count == 0)
+            {
+                // Deadlock guard: dependencies can never be satisfied (e.g. an unmet/derived role). Run the
+                // rest in priority order; each agent self-skips when its required upstream output is missing.
+                ready = remaining;
+            }
+
+            if (options.Mode == AgentExecutionMode.Parallel)
+            {
+                // Run the whole ready wave concurrently.
+                await Task.WhenAll(ready.Select(a => RunAgentAsync(a, context, options, cancellationToken)))
+                    .ConfigureAwait(false);
+
+                foreach (var agent in ready)
+                {
+                    completedRoles.Add(agent.Role);
+                    remaining.Remove(agent);
+                }
+            }
+            else
+            {
+                // Sequential / Conditional: take the single highest-priority ready agent.
+                var agent = ready[0];
+
+                if (options.Mode == AgentExecutionMode.Conditional && !DependenciesSucceeded(agent, context))
+                {
+                    RecordConditionalSkip(agent, context);
+                }
+                else
+                {
+                    await RunAgentAsync(agent, context, options, cancellationToken).ConfigureAwait(false);
+                }
+
+                completedRoles.Add(agent.Role);
+                remaining.Remove(agent);
+            }
+        }
+    }
+
+    private bool DependenciesSucceeded(IAssessmentAgent agent, ISharedAssessmentContext context) =>
+        agent.Dependencies.All(context.HasSucceeded);
+
+    private void RecordConditionalSkip(IAssessmentAgent agent, ISharedAssessmentContext context)
+    {
+        var unmet = agent.Dependencies.Where(r => !context.HasSucceeded(r)).ToArray();
+        var reason = $"Conditional skip: dependency role(s) [{string.Join(", ", unmet)}] did not succeed.";
+        context.LogWarning(agent.Name, $"{agent.Name} skipped by orchestrator. {reason}");
+        context.RecordResult(AgentResult.Skipped(agent.Name, agent.Role, reason));
+    }
+
+    private async Task RunAgentAsync(
+        IAssessmentAgent agent, SharedAssessmentContext context, AgentOrchestrationOptions options, CancellationToken cancellationToken)
+    {
+        if (options.PerAgentTimeout is not TimeSpan timeout)
+        {
+            await agent.RunAsync(context, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        linked.CancelAfter(timeout);
+        try
+        {
+            await agent.RunAsync(context, linked.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // Per-agent timeout (not a global cancellation): record as failed and let the run continue.
+            var message = $"Timed out after {timeout.TotalSeconds:F0}s.";
+            context.LogError(agent.Name, $"{agent.Name} timed out: {message}");
+            context.RecordResult(AgentResult.Failed(agent.Name, agent.Role, message, timeout));
+        }
+    }
+
+    private static int RolePriority(AgentRole role) => role switch
+    {
+        AgentRole.CosmosAnalysis => 0,
+        AgentRole.SqlPlanning => 1,
+        AgentRole.DataQuality => 2,
+        AgentRole.DataFactoryEstimation => 3,
+        AgentRole.Validation => 4,
+        AgentRole.Orchestration => 5,
+        _ => 100
+    };
+
+    private static void ValidateGraph(IReadOnlyList<IAssessmentAgent> agents)
+    {
+        if (agents.Count == 0)
+        {
+            throw new InvalidOperationException("At least one agent must be supplied to the orchestrator.");
+        }
+
+        var duplicateNames = agents
+            .GroupBy(a => a.Name, StringComparer.Ordinal)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)
+            .ToArray();
+        if (duplicateNames.Length > 0)
+        {
+            throw new InvalidOperationException(
+                $"Duplicate agent name(s): {string.Join(", ", duplicateNames)}. Agent names must be unique.");
+        }
+
+        var duplicateRoles = agents
+            .GroupBy(a => a.Role)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)
+            .ToArray();
+        if (duplicateRoles.Length > 0)
+        {
+            throw new InvalidOperationException(
+                $"Multiple agents share role(s): {string.Join(", ", duplicateRoles)}. " +
+                "Each role's output is write-once, so at most one agent may own a role.");
+        }
+
+        var roles = agents.Select(a => a.Role).ToHashSet();
+        var requiredRoles = new[]
+        {
+            AgentRole.CosmosAnalysis,
+            AgentRole.SqlPlanning,
+            AgentRole.DataFactoryEstimation,
+            AgentRole.Validation
+        };
+        var missingRoles = requiredRoles.Where(r => !roles.Contains(r)).ToArray();
+        if (missingRoles.Length > 0)
+        {
+            throw new InvalidOperationException(
+                $"Missing required agent role(s): {string.Join(", ", missingRoles)}.");
+        }
+
+        foreach (var agent in agents)
+        {
+            var dangling = agent.Dependencies.Where(d => !roles.Contains(d)).ToArray();
+            if (dangling.Length > 0)
+            {
+                throw new InvalidOperationException(
+                    $"Agent '{agent.Name}' depends on role(s) [{string.Join(", ", dangling)}] " +
+                    "that no registered agent produces.");
+            }
+        }
+    }
+}

--- a/Agents/AgentResult.cs
+++ b/Agents/AgentResult.cs
@@ -1,0 +1,73 @@
+namespace CosmosToSqlAssessment.Agents;
+
+/// <summary>
+/// Terminal outcome of a single <see cref="IAssessmentAgent"/> run.
+/// </summary>
+public enum AgentRunStatus
+{
+    /// <summary>The agent completed and committed all of its required outputs to the context.</summary>
+    Succeeded,
+
+    /// <summary>The agent threw or otherwise failed; its outputs may be absent or partial.</summary>
+    Failed,
+
+    /// <summary>The agent did not run because a precondition (e.g. a dependency) was not met.</summary>
+    Skipped
+}
+
+/// <summary>
+/// Immutable record of how a single agent run finished. Recorded on the
+/// <see cref="SharedAssessmentContext"/> so the orchestrator can isolate failures and the
+/// <c>ValidatorAgent</c> can reason about completeness.
+/// </summary>
+/// <remarks>
+/// Contract: a <see cref="AgentRunStatus.Succeeded"/> result guarantees the agent's required
+/// outputs were committed to the context. <see cref="AgentRunStatus.Failed"/> and
+/// <see cref="AgentRunStatus.Skipped"/> make no such guarantee — consumers must treat the
+/// corresponding outputs as possibly absent.
+/// </remarks>
+public sealed record AgentResult
+{
+    /// <summary>The <see cref="IAssessmentAgent.Name"/> of the agent this result describes.</summary>
+    public required string AgentName { get; init; }
+
+    /// <summary>The domain role the agent owns.</summary>
+    public required AgentRole Role { get; init; }
+
+    /// <summary>The terminal status of the run.</summary>
+    public required AgentRunStatus Status { get; init; }
+
+    /// <summary>
+    /// The failure message when <see cref="Status"/> is <see cref="AgentRunStatus.Failed"/>, or the
+    /// skip reason when <see cref="AgentRunStatus.Skipped"/>. <see langword="null"/> on success.
+    /// </summary>
+    public string? Error { get; init; }
+
+    /// <summary>Wall-clock duration of the run. <see cref="TimeSpan.Zero"/> for skipped agents.</summary>
+    public TimeSpan Duration { get; init; }
+
+    /// <summary>Creates a successful result.</summary>
+    /// <param name="agentName">The agent's name.</param>
+    /// <param name="role">The agent's role.</param>
+    /// <param name="duration">Wall-clock duration of the run.</param>
+    /// <returns>A succeeded <see cref="AgentResult"/>.</returns>
+    public static AgentResult Succeeded(string agentName, AgentRole role, TimeSpan duration) =>
+        new() { AgentName = agentName, Role = role, Status = AgentRunStatus.Succeeded, Duration = duration };
+
+    /// <summary>Creates a failed result.</summary>
+    /// <param name="agentName">The agent's name.</param>
+    /// <param name="role">The agent's role.</param>
+    /// <param name="error">The failure message.</param>
+    /// <param name="duration">Wall-clock duration before failure.</param>
+    /// <returns>A failed <see cref="AgentResult"/>.</returns>
+    public static AgentResult Failed(string agentName, AgentRole role, string error, TimeSpan duration) =>
+        new() { AgentName = agentName, Role = role, Status = AgentRunStatus.Failed, Error = error, Duration = duration };
+
+    /// <summary>Creates a skipped result.</summary>
+    /// <param name="agentName">The agent's name.</param>
+    /// <param name="role">The agent's role.</param>
+    /// <param name="reason">Why the agent was skipped (e.g. an unmet dependency).</param>
+    /// <returns>A skipped <see cref="AgentResult"/>.</returns>
+    public static AgentResult Skipped(string agentName, AgentRole role, string reason) =>
+        new() { AgentName = agentName, Role = role, Status = AgentRunStatus.Skipped, Error = reason, Duration = TimeSpan.Zero };
+}

--- a/Agents/AgentRole.cs
+++ b/Agents/AgentRole.cs
@@ -1,0 +1,34 @@
+namespace CosmosToSqlAssessment.Agents;
+
+/// <summary>
+/// Identifies the assessment domain an <see cref="IAssessmentAgent"/> owns and the
+/// kind of output it contributes to a <see cref="SharedAssessmentContext"/>.
+/// </summary>
+/// <remarks>
+/// Roles let the orchestrator and the validator reason about which domain produced a
+/// given result without depending on concrete agent types. Adding new values is a
+/// source-compatible change, so the enum can grow as later epics introduce more agents.
+/// </remarks>
+public enum AgentRole
+{
+    /// <summary>Analysis of the source Cosmos DB account, databases, and containers.</summary>
+    CosmosAnalysis,
+
+    /// <summary>Azure SQL platform recommendation and migration planning.</summary>
+    SqlPlanning,
+
+    /// <summary>Pre-migration data-quality analysis of the source documents.</summary>
+    DataQuality,
+
+    /// <summary>
+    /// Azure Data Factory migration estimate derived from the Cosmos analysis and SQL plan.
+    /// Produced by the orchestrator as a derived step rather than by a domain agent.
+    /// </summary>
+    DataFactoryEstimation,
+
+    /// <summary>Cross-checking and completeness validation of other agents' outputs.</summary>
+    Validation,
+
+    /// <summary>Coordination of the agent run itself (used by the orchestrator).</summary>
+    Orchestration
+}

--- a/Agents/AssessmentAgentBase.cs
+++ b/Agents/AssessmentAgentBase.cs
@@ -1,0 +1,100 @@
+using System.Diagnostics;
+
+namespace CosmosToSqlAssessment.Agents;
+
+/// <summary>
+/// Base class for assessment agents that centralises run timing, structured logging, and the
+/// failure-isolation contract so concrete agents only implement their domain logic.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="RunAsync"/> never throws for a recoverable agent error: any exception (other than
+/// cancellation) is converted into an <see cref="AgentResult.Failed(string, AgentRole, string, TimeSpan)"/>
+/// result and recorded on the context, so one agent's failure cannot abort the rest of the run.
+/// </para>
+/// <para>
+/// <strong>Cancellation convention.</strong> <see cref="OperationCanceledException"/> is deliberately
+/// re-thrown rather than recorded, so a host-level cancellation (Ctrl+C) can propagate and map to the
+/// process's exit-code-130 handling. A <em>per-agent timeout</em> is therefore the orchestrator's
+/// responsibility: it should run each agent under a linked <see cref="CancellationTokenSource"/> and catch
+/// <c>OperationCanceledException when (!globalToken.IsCancellationRequested)</c> to record a failed/skipped
+/// timeout result while still letting global cancellation bubble up.
+/// </para>
+/// <para>
+/// Concrete agents should commit their domain output (via the context's <c>Set*</c> methods) as the last
+/// meaningful action in <see cref="ExecuteAsync"/>, so a later failure never leaves the context partially
+/// populated.
+/// </para>
+/// </remarks>
+public abstract class AssessmentAgentBase : IAssessmentAgent
+{
+    /// <inheritdoc />
+    public abstract string Name { get; }
+
+    /// <inheritdoc />
+    public abstract AgentRole Role { get; }
+
+    /// <inheritdoc />
+    public virtual IReadOnlyCollection<AgentRole> Dependencies => Array.Empty<AgentRole>();
+
+    /// <inheritdoc />
+    public async Task<AgentResult> RunAsync(ISharedAssessmentContext context, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var skipReason = GetSkipReason(context);
+        if (skipReason is not null)
+        {
+            context.LogWarning(Name, $"{Name} skipped: {skipReason}");
+            var skipped = AgentResult.Skipped(Name, Role, skipReason);
+            context.RecordResult(skipped);
+            return skipped;
+        }
+
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            context.LogInfo(Name, $"{Name} starting.");
+            await ExecuteAsync(context, cancellationToken).ConfigureAwait(false);
+            stopwatch.Stop();
+
+            var result = AgentResult.Succeeded(Name, Role, stopwatch.Elapsed);
+            context.RecordResult(result);
+            context.LogInfo(Name, $"{Name} completed in {stopwatch.Elapsed.TotalSeconds:F1}s.");
+            return result;
+        }
+        catch (OperationCanceledException)
+        {
+            stopwatch.Stop();
+            throw;
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            var message = $"{ex.GetType().Name}: {ex.Message}";
+            context.LogError(Name, $"{Name} failed: {message}");
+            var result = AgentResult.Failed(Name, Role, message, stopwatch.Elapsed);
+            context.RecordResult(result);
+            return result;
+        }
+    }
+
+    /// <summary>
+    /// Returns a non-<see langword="null"/> reason to skip this agent (e.g. a required upstream output is
+    /// missing), or <see langword="null"/> to run normally. Evaluated before <see cref="ExecuteAsync"/>.
+    /// The default never skips.
+    /// </summary>
+    /// <param name="context">The shared context, used to inspect upstream outputs.</param>
+    /// <returns>A skip reason, or <see langword="null"/> to proceed.</returns>
+    protected virtual string? GetSkipReason(ISharedAssessmentContext context) => null;
+
+    /// <summary>
+    /// Performs the agent's domain work. Implementations should compute locally and commit their single
+    /// domain output to <paramref name="context"/> as the final action. Throwing here is converted into a
+    /// failed result by <see cref="RunAsync"/>; <see cref="OperationCanceledException"/> propagates.
+    /// </summary>
+    /// <param name="context">The shared blackboard to read upstream outputs from and write this agent's output to.</param>
+    /// <param name="cancellationToken">Token used to cancel the run.</param>
+    /// <returns>A task that completes when the agent's work is done.</returns>
+    protected abstract Task ExecuteAsync(ISharedAssessmentContext context, CancellationToken cancellationToken);
+}

--- a/Agents/CosmosAnalyzerAgent.cs
+++ b/Agents/CosmosAnalyzerAgent.cs
@@ -1,0 +1,61 @@
+using CosmosToSqlAssessment.Services;
+using Microsoft.Extensions.Logging;
+
+namespace CosmosToSqlAssessment.Agents;
+
+/// <summary>
+/// Agent that owns the Cosmos DB analysis domain. It wraps the existing
+/// <see cref="CosmosDbAnalysisService"/> (whose signatures are intentionally unchanged) and commits the
+/// resulting <see cref="Models.CosmosDbAnalysis"/> to the shared context for downstream agents.
+/// </summary>
+/// <remarks>
+/// This is the root agent of an assessment run (no dependencies). It delegates to
+/// <see cref="CosmosDbAnalysisService.AnalyzeDatabaseAsync(string, CancellationToken)"/> — the same method
+/// the single-pass orchestrator uses — which streams documents per container internally and returns
+/// aggregated container metadata, so the agentic path stays equivalent to single-pass and introduces no
+/// whole-dataset buffering.
+/// </remarks>
+public sealed class CosmosAnalyzerAgent : AssessmentAgentBase
+{
+    /// <summary>The stable name of this agent.</summary>
+    public const string AgentName = "CosmosAnalyzer";
+
+    private readonly CosmosDbAnalysisService _analysisService;
+    private readonly ILogger<CosmosAnalyzerAgent> _logger;
+
+    /// <summary>
+    /// Creates a new <see cref="CosmosAnalyzerAgent"/>.
+    /// </summary>
+    /// <param name="analysisService">The existing Cosmos DB analysis service to wrap.</param>
+    /// <param name="logger">Logger for diagnostic output.</param>
+    public CosmosAnalyzerAgent(CosmosDbAnalysisService analysisService, ILogger<CosmosAnalyzerAgent> logger)
+    {
+        _analysisService = analysisService ?? throw new ArgumentNullException(nameof(analysisService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public override string Name => AgentName;
+
+    /// <inheritdoc />
+    public override AgentRole Role => AgentRole.CosmosAnalysis;
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(ISharedAssessmentContext context, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("CosmosAnalyzerAgent analyzing database {DatabaseName}", context.DatabaseName);
+
+        var analysis = await _analysisService
+            .AnalyzeDatabaseAsync(context.DatabaseName, cancellationToken)
+            .ConfigureAwait(false);
+
+        context.LogInfo(Name, $"Analyzed {analysis.Containers.Count} container(s).");
+        if (analysis.MonitoringLimitations.Count > 0)
+        {
+            context.LogWarning(Name, $"{analysis.MonitoringLimitations.Count} monitoring limitation(s) detected.");
+        }
+
+        // Commit is the final action so a later failure never leaves a half-populated context.
+        context.SetCosmosAnalysis(Name, analysis);
+    }
+}

--- a/Agents/DataFactoryEstimatorAgent.cs
+++ b/Agents/DataFactoryEstimatorAgent.cs
@@ -1,0 +1,80 @@
+using CosmosToSqlAssessment.Services;
+using Microsoft.Extensions.Logging;
+
+namespace CosmosToSqlAssessment.Agents;
+
+/// <summary>
+/// Internal agent that produces the Data Factory migration estimate. The estimate is a step derived from the
+/// Cosmos analysis and SQL assessment rather than a standalone public agent, so this type is
+/// <see langword="internal"/> — but it participates in the dependency graph like any other agent so the
+/// orchestrator can schedule it uniformly.
+/// </summary>
+/// <remarks>
+/// Wraps the unchanged <see cref="DataFactoryEstimateService"/>. Depends on
+/// <see cref="AgentRole.CosmosAnalysis"/> and <see cref="AgentRole.SqlPlanning"/> and skips if either is
+/// absent. Its output is required for a complete assessment.
+/// </remarks>
+internal sealed class DataFactoryEstimatorAgent : AssessmentAgentBase
+{
+    /// <summary>The stable name of this agent.</summary>
+    public const string AgentName = "DataFactoryEstimator";
+
+    private static readonly IReadOnlyCollection<AgentRole> _dependencies =
+        new[] { AgentRole.CosmosAnalysis, AgentRole.SqlPlanning };
+
+    private readonly DataFactoryEstimateService _dataFactoryService;
+    private readonly ILogger<DataFactoryEstimatorAgent> _logger;
+
+    /// <summary>
+    /// Creates a new <see cref="DataFactoryEstimatorAgent"/>.
+    /// </summary>
+    /// <param name="dataFactoryService">The existing Data Factory estimate service to wrap.</param>
+    /// <param name="logger">Logger for diagnostic output.</param>
+    public DataFactoryEstimatorAgent(DataFactoryEstimateService dataFactoryService, ILogger<DataFactoryEstimatorAgent> logger)
+    {
+        _dataFactoryService = dataFactoryService ?? throw new ArgumentNullException(nameof(dataFactoryService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public override string Name => AgentName;
+
+    /// <inheritdoc />
+    public override AgentRole Role => AgentRole.DataFactoryEstimation;
+
+    /// <inheritdoc />
+    public override IReadOnlyCollection<AgentRole> Dependencies => _dependencies;
+
+    /// <inheritdoc />
+    protected override string? GetSkipReason(ISharedAssessmentContext context)
+    {
+        if (!context.HasCosmosAnalysis)
+        {
+            return "Cosmos analysis is not available; cannot estimate the Data Factory migration.";
+        }
+
+        if (!context.HasSqlAssessment)
+        {
+            return "SQL assessment is not available; cannot estimate the Data Factory migration.";
+        }
+
+        return null;
+    }
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(ISharedAssessmentContext context, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("DataFactoryEstimatorAgent estimating migration for database {DatabaseName}", context.DatabaseName);
+
+        var estimate = await _dataFactoryService
+            .EstimateMigrationAsync(context.CosmosAnalysis!, context.SqlAssessment!, cancellationToken)
+            .ConfigureAwait(false);
+
+        context.LogInfo(Name,
+            $"Estimated duration {estimate.EstimatedDuration:hh\\:mm\\:ss}, " +
+            $"{estimate.RecommendedDIUs} DIU(s), ~${estimate.EstimatedCostUSD:F2}.");
+
+        // Commit is the final action so a later failure never leaves a half-populated context.
+        context.SetDataFactoryEstimate(Name, estimate);
+    }
+}

--- a/Agents/DataQualityAgent.cs
+++ b/Agents/DataQualityAgent.cs
@@ -1,0 +1,71 @@
+using CosmosToSqlAssessment.Services;
+using Microsoft.Extensions.Logging;
+
+namespace CosmosToSqlAssessment.Agents;
+
+/// <summary>
+/// Agent that owns the pre-migration data-quality domain. It wraps the existing
+/// <see cref="DataQualityAnalysisService"/> (unchanged) and commits the resulting
+/// <see cref="Models.DataQualityAnalysis"/> to the shared context.
+/// </summary>
+/// <remarks>
+/// Depends on <see cref="AgentRole.CosmosAnalysis"/> and skips when it is absent. Its output is
+/// <strong>optional</strong>: a skipped or failed data-quality run leaves
+/// <see cref="ISharedAssessmentContext.DataQualityAnalysis"/> null and does <em>not</em> make the overall
+/// run incomplete, mirroring the single-pass pipeline where data quality is non-fatal.
+/// </remarks>
+public sealed class DataQualityAgent : AssessmentAgentBase
+{
+    /// <summary>The stable name of this agent.</summary>
+    public const string AgentName = "DataQuality";
+
+    private static readonly IReadOnlyCollection<AgentRole> _dependencies = new[] { AgentRole.CosmosAnalysis };
+
+    private readonly DataQualityAnalysisService _dataQualityService;
+    private readonly ILogger<DataQualityAgent> _logger;
+
+    /// <summary>
+    /// Creates a new <see cref="DataQualityAgent"/>.
+    /// </summary>
+    /// <param name="dataQualityService">The existing data-quality analysis service to wrap.</param>
+    /// <param name="logger">Logger for diagnostic output.</param>
+    public DataQualityAgent(DataQualityAnalysisService dataQualityService, ILogger<DataQualityAgent> logger)
+    {
+        _dataQualityService = dataQualityService ?? throw new ArgumentNullException(nameof(dataQualityService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public override string Name => AgentName;
+
+    /// <inheritdoc />
+    public override AgentRole Role => AgentRole.DataQuality;
+
+    /// <inheritdoc />
+    public override IReadOnlyCollection<AgentRole> Dependencies => _dependencies;
+
+    /// <inheritdoc />
+    protected override string? GetSkipReason(ISharedAssessmentContext context) =>
+        context.HasCosmosAnalysis
+            ? null
+            : "Cosmos analysis is not available; cannot analyze data quality.";
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(ISharedAssessmentContext context, CancellationToken cancellationToken)
+    {
+        var cosmosAnalysis = context.CosmosAnalysis!; // guaranteed present past the skip gate
+        _logger.LogInformation("DataQualityAgent analyzing data quality for database {DatabaseName}", context.DatabaseName);
+
+        var analysis = await _dataQualityService
+            .AnalyzeDataQualityAsync(cosmosAnalysis, context.DatabaseName, cancellationToken)
+            .ConfigureAwait(false);
+
+        context.LogInfo(Name,
+            $"Analyzed {analysis.TotalDocumentsAnalyzed} document(s); " +
+            $"{analysis.CriticalIssuesCount} critical, {analysis.WarningIssuesCount} warning(s); " +
+            $"quality score {analysis.Summary.OverallQualityScore:F1}/100 ({analysis.Summary.QualityRating}).");
+
+        // Commit is the final action so a later failure never leaves a half-populated context.
+        context.SetDataQualityAnalysis(Name, analysis);
+    }
+}

--- a/Agents/IAssessmentAgent.cs
+++ b/Agents/IAssessmentAgent.cs
@@ -1,0 +1,43 @@
+namespace CosmosToSqlAssessment.Agents;
+
+/// <summary>
+/// A single-responsibility participant in an agentic assessment run. Each agent owns one
+/// <see cref="AgentRole"/>, reads any upstream outputs it needs from the shared context, performs its
+/// work, and commits its own output back to the context.
+/// </summary>
+/// <remarks>
+/// This is the stable abstraction the orchestrator (#215) and later epics (#132/#133/#69) compose
+/// against. Implementations must:
+/// <list type="bullet">
+///   <item>be safe to construct via dependency injection and to run independently in isolation;</item>
+///   <item>never throw for a recoverable condition — return a <see cref="AgentResult.Failed"/> or
+///   <see cref="AgentResult.Skipped"/> result and log a message instead, so a single agent's problem
+///   does not abort the whole run;</item>
+///   <item>commit their domain output exactly once via the context's <c>Set*</c> methods on success.</item>
+/// </list>
+/// </remarks>
+public interface IAssessmentAgent
+{
+    /// <summary>A stable, unique, human-readable identifier for this agent (e.g. <c>CosmosAnalyzer</c>).</summary>
+    string Name { get; }
+
+    /// <summary>The assessment domain this agent owns and contributes output for.</summary>
+    AgentRole Role { get; }
+
+    /// <summary>
+    /// The roles whose outputs this agent requires before it can run. The orchestrator uses this to
+    /// order sequential runs, gate conditional runs, and schedule parallel runs. An empty collection
+    /// means the agent has no upstream dependencies.
+    /// </summary>
+    IReadOnlyCollection<AgentRole> Dependencies { get; }
+
+    /// <summary>
+    /// Executes the agent against the shared context and returns its terminal result. Implementations
+    /// should catch their own recoverable errors and report them through the returned
+    /// <see cref="AgentResult"/> rather than throwing.
+    /// </summary>
+    /// <param name="context">The shared blackboard to read upstream outputs from and write this agent's output to.</param>
+    /// <param name="cancellationToken">Token used to cancel the run.</param>
+    /// <returns>The terminal <see cref="AgentResult"/> describing how the run finished.</returns>
+    Task<AgentResult> RunAsync(ISharedAssessmentContext context, CancellationToken cancellationToken = default);
+}

--- a/Agents/ISharedAssessmentContext.cs
+++ b/Agents/ISharedAssessmentContext.cs
@@ -32,6 +32,13 @@ public interface ISharedAssessmentContext
     /// <summary>The Data Factory migration estimate, or <see langword="null"/> if not yet produced.</summary>
     DataFactoryEstimate? DataFactoryEstimate { get; }
 
+    /// <summary>
+    /// The validator's verdict, or <see langword="null"/> if validation has not run. This is run metadata,
+    /// not a domain output: it is not part of <see cref="GetMissingRequiredOutputs"/> and does not feed
+    /// <see cref="ToAssessmentResult"/>.
+    /// </summary>
+    ValidationReport? ValidationReport { get; }
+
     /// <summary>Whether <see cref="CosmosAnalysis"/> has been set.</summary>
     bool HasCosmosAnalysis { get; }
 
@@ -43,6 +50,13 @@ public interface ISharedAssessmentContext
 
     /// <summary>Whether <see cref="DataFactoryEstimate"/> has been set.</summary>
     bool HasDataFactoryEstimate { get; }
+
+    /// <summary>
+    /// Whether <see cref="ValidationReport"/> has been set. <see langword="false"/> means validation did not
+    /// run or crashed before producing a report (treat as an infrastructure failure, distinct from an
+    /// unacceptable-but-reported run).
+    /// </summary>
+    bool HasValidationReport { get; }
 
     /// <summary>A snapshot of all messages appended so far, in insertion order.</summary>
     IReadOnlyList<AgentMessage> Messages { get; }
@@ -81,6 +95,14 @@ public interface ISharedAssessmentContext
     /// <param name="producerName">Name of the producer (an agent or the orchestrator's derived step).</param>
     /// <param name="estimate">The estimate to commit.</param>
     void SetDataFactoryEstimate(string producerName, DataFactoryEstimate estimate);
+
+    /// <summary>
+    /// Commits the validator's verdict. Throws <see cref="InvalidOperationException"/> if it has already been
+    /// set (validation is single-run per context).
+    /// </summary>
+    /// <param name="producerName">Name of the validating agent.</param>
+    /// <param name="report">The validation report to commit.</param>
+    void SetValidationReport(string producerName, ValidationReport report);
 
     /// <summary>Appends a pre-built message to the blackboard.</summary>
     /// <param name="message">The message to append.</param>

--- a/Agents/ISharedAssessmentContext.cs
+++ b/Agents/ISharedAssessmentContext.cs
@@ -1,0 +1,138 @@
+using CosmosToSqlAssessment.Models;
+
+namespace CosmosToSqlAssessment.Agents;
+
+/// <summary>
+/// Thread-safe shared blackboard through which assessment agents communicate. Agents read the
+/// outputs produced by upstream agents, contribute their own domain output exactly once, append
+/// log messages, and record their run results. Implemented by <see cref="SharedAssessmentContext"/>.
+/// </summary>
+/// <remarks>
+/// The contract is the stable surface later agents and orchestration layers depend on. All members
+/// are safe to call concurrently. Collection-returning members return point-in-time snapshots, never
+/// live views.
+/// </remarks>
+public interface ISharedAssessmentContext
+{
+    /// <summary>Name of the Cosmos DB database under assessment.</summary>
+    string DatabaseName { get; }
+
+    /// <summary>Friendly name of the Cosmos DB account under assessment.</summary>
+    string CosmosAccountName { get; }
+
+    /// <summary>The Cosmos DB analysis output, or <see langword="null"/> if not yet produced.</summary>
+    CosmosDbAnalysis? CosmosAnalysis { get; }
+
+    /// <summary>The SQL migration assessment output, or <see langword="null"/> if not yet produced.</summary>
+    SqlMigrationAssessment? SqlAssessment { get; }
+
+    /// <summary>The data-quality analysis output, or <see langword="null"/> if not produced (it is optional).</summary>
+    DataQualityAnalysis? DataQualityAnalysis { get; }
+
+    /// <summary>The Data Factory migration estimate, or <see langword="null"/> if not yet produced.</summary>
+    DataFactoryEstimate? DataFactoryEstimate { get; }
+
+    /// <summary>Whether <see cref="CosmosAnalysis"/> has been set.</summary>
+    bool HasCosmosAnalysis { get; }
+
+    /// <summary>Whether <see cref="SqlAssessment"/> has been set.</summary>
+    bool HasSqlAssessment { get; }
+
+    /// <summary>Whether <see cref="DataQualityAnalysis"/> has been set.</summary>
+    bool HasDataQualityAnalysis { get; }
+
+    /// <summary>Whether <see cref="DataFactoryEstimate"/> has been set.</summary>
+    bool HasDataFactoryEstimate { get; }
+
+    /// <summary>A snapshot of all messages appended so far, in insertion order.</summary>
+    IReadOnlyList<AgentMessage> Messages { get; }
+
+    /// <summary>A snapshot of all agent results recorded so far, in insertion order.</summary>
+    IReadOnlyList<AgentResult> Results { get; }
+
+    /// <summary>
+    /// Commits the Cosmos DB analysis output. Throws <see cref="InvalidOperationException"/> if it has
+    /// already been set (single-assignment guard against concurrent double-writes).
+    /// </summary>
+    /// <param name="producerName">Name of the agent producing the output.</param>
+    /// <param name="analysis">The analysis to commit.</param>
+    void SetCosmosAnalysis(string producerName, CosmosDbAnalysis analysis);
+
+    /// <summary>
+    /// Commits the SQL migration assessment output. Throws <see cref="InvalidOperationException"/> if it
+    /// has already been set.
+    /// </summary>
+    /// <param name="producerName">Name of the agent producing the output.</param>
+    /// <param name="assessment">The assessment to commit.</param>
+    void SetSqlAssessment(string producerName, SqlMigrationAssessment assessment);
+
+    /// <summary>
+    /// Commits the data-quality analysis output. Throws <see cref="InvalidOperationException"/> if it has
+    /// already been set.
+    /// </summary>
+    /// <param name="producerName">Name of the agent producing the output.</param>
+    /// <param name="analysis">The analysis to commit.</param>
+    void SetDataQualityAnalysis(string producerName, DataQualityAnalysis analysis);
+
+    /// <summary>
+    /// Commits the Data Factory migration estimate. Throws <see cref="InvalidOperationException"/> if it
+    /// has already been set.
+    /// </summary>
+    /// <param name="producerName">Name of the producer (an agent or the orchestrator's derived step).</param>
+    /// <param name="estimate">The estimate to commit.</param>
+    void SetDataFactoryEstimate(string producerName, DataFactoryEstimate estimate);
+
+    /// <summary>Appends a pre-built message to the blackboard.</summary>
+    /// <param name="message">The message to append.</param>
+    void AddMessage(AgentMessage message);
+
+    /// <summary>Appends an <see cref="AgentMessageLevel.Info"/> message.</summary>
+    /// <param name="agentName">The producing agent's name.</param>
+    /// <param name="text">The message text.</param>
+    void LogInfo(string agentName, string text);
+
+    /// <summary>Appends an <see cref="AgentMessageLevel.Warning"/> message.</summary>
+    /// <param name="agentName">The producing agent's name.</param>
+    /// <param name="text">The message text.</param>
+    void LogWarning(string agentName, string text);
+
+    /// <summary>Appends an <see cref="AgentMessageLevel.Error"/> message.</summary>
+    /// <param name="agentName">The producing agent's name.</param>
+    /// <param name="text">The message text.</param>
+    void LogError(string agentName, string text);
+
+    /// <summary>Records the terminal result of an agent run.</summary>
+    /// <param name="result">The result to record.</param>
+    void RecordResult(AgentResult result);
+
+    /// <summary>Returns the most recently recorded result for the named agent, or <see langword="null"/>.</summary>
+    /// <param name="agentName">The agent name to look up.</param>
+    /// <returns>The matching <see cref="AgentResult"/> or <see langword="null"/>.</returns>
+    AgentResult? GetResult(string agentName);
+
+    /// <summary>Whether any recorded result for the given role succeeded.</summary>
+    /// <param name="role">The role to test.</param>
+    /// <returns><see langword="true"/> if at least one agent with that role succeeded.</returns>
+    bool HasSucceeded(AgentRole role);
+
+    /// <summary>
+    /// Lists the required outputs (<see cref="CosmosAnalysis"/>, <see cref="SqlAssessment"/>,
+    /// <see cref="DataFactoryEstimate"/>) that are still missing. Data-quality analysis is optional and
+    /// never reported here. Used by the validator to flag incomplete runs.
+    /// </summary>
+    /// <returns>Human-readable names of missing required outputs; empty when complete.</returns>
+    IReadOnlyList<string> GetMissingRequiredOutputs();
+
+    /// <summary>Whether all required outputs are present (i.e. <see cref="GetMissingRequiredOutputs"/> is empty).</summary>
+    /// <returns><see langword="true"/> if the context can produce a complete assessment result.</returns>
+    bool IsCompleteForAssessmentResult();
+
+    /// <summary>
+    /// Projects the accumulated outputs into the existing <see cref="AssessmentResult"/> model so the
+    /// unchanged downstream report / SQL-project / Data Factory generation can consume them. Best-effort:
+    /// missing required outputs are filled with empty defaults rather than throwing, mirroring the
+    /// single-pass pipeline's tolerance of a skipped data-quality phase.
+    /// </summary>
+    /// <returns>A populated <see cref="AssessmentResult"/>.</returns>
+    AssessmentResult ToAssessmentResult();
+}

--- a/Agents/SharedAssessmentContext.cs
+++ b/Agents/SharedAssessmentContext.cs
@@ -24,6 +24,7 @@ public sealed class SharedAssessmentContext : ISharedAssessmentContext
     private SqlMigrationAssessment? _sqlAssessment;
     private DataQualityAnalysis? _dataQualityAnalysis;
     private DataFactoryEstimate? _dataFactoryEstimate;
+    private ValidationReport? _validationReport;
 
     /// <summary>
     /// Creates a new context for a single database assessment.
@@ -61,6 +62,9 @@ public sealed class SharedAssessmentContext : ISharedAssessmentContext
     public DataFactoryEstimate? DataFactoryEstimate { get { lock (_gate) { return _dataFactoryEstimate; } } }
 
     /// <inheritdoc />
+    public ValidationReport? ValidationReport { get { lock (_gate) { return _validationReport; } } }
+
+    /// <inheritdoc />
     public bool HasCosmosAnalysis { get { lock (_gate) { return _cosmosAnalysis is not null; } } }
 
     /// <inheritdoc />
@@ -71,6 +75,9 @@ public sealed class SharedAssessmentContext : ISharedAssessmentContext
 
     /// <inheritdoc />
     public bool HasDataFactoryEstimate { get { lock (_gate) { return _dataFactoryEstimate is not null; } } }
+
+    /// <inheritdoc />
+    public bool HasValidationReport { get { lock (_gate) { return _validationReport is not null; } } }
 
     /// <inheritdoc />
     public IReadOnlyList<AgentMessage> Messages { get { lock (_gate) { return _messages.ToArray(); } } }
@@ -119,6 +126,17 @@ public sealed class SharedAssessmentContext : ISharedAssessmentContext
         {
             ThrowIfAlreadySet(_dataFactoryEstimate, nameof(DataFactoryEstimate), producerName);
             _dataFactoryEstimate = estimate;
+        }
+    }
+
+    /// <inheritdoc />
+    public void SetValidationReport(string producerName, ValidationReport report)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+        lock (_gate)
+        {
+            ThrowIfAlreadySet(_validationReport, nameof(ValidationReport), producerName);
+            _validationReport = report;
         }
     }
 

--- a/Agents/SharedAssessmentContext.cs
+++ b/Agents/SharedAssessmentContext.cs
@@ -1,0 +1,230 @@
+using CosmosToSqlAssessment.Models;
+
+namespace CosmosToSqlAssessment.Agents;
+
+/// <summary>
+/// Thread-safe blackboard implementation of <see cref="ISharedAssessmentContext"/>. A single private
+/// lock guards every piece of mutable state (the four domain outputs, the message log, and the result
+/// log) so concurrently scheduled agents observe a consistent view.
+/// </summary>
+/// <remarks>
+/// Domain outputs are write-once: each <c>Set*</c> method throws <see cref="InvalidOperationException"/>
+/// on a second write, which surfaces accidental concurrent double-production as a clear failure rather
+/// than silent corruption. Reads of the domain outputs return the committed reference (the underlying
+/// model objects are not mutated after being committed); reads of <see cref="Messages"/> and
+/// <see cref="Results"/> return immutable snapshots taken under the lock.
+/// </remarks>
+public sealed class SharedAssessmentContext : ISharedAssessmentContext
+{
+    private readonly object _gate = new();
+    private readonly List<AgentMessage> _messages = new();
+    private readonly List<AgentResult> _results = new();
+
+    private CosmosDbAnalysis? _cosmosAnalysis;
+    private SqlMigrationAssessment? _sqlAssessment;
+    private DataQualityAnalysis? _dataQualityAnalysis;
+    private DataFactoryEstimate? _dataFactoryEstimate;
+
+    /// <summary>
+    /// Creates a new context for a single database assessment.
+    /// </summary>
+    /// <param name="databaseName">Name of the Cosmos DB database under assessment.</param>
+    /// <param name="cosmosAccountName">Friendly name of the Cosmos DB account under assessment.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="databaseName"/> is null or empty.</exception>
+    public SharedAssessmentContext(string databaseName, string cosmosAccountName)
+    {
+        if (string.IsNullOrEmpty(databaseName))
+        {
+            throw new ArgumentException("Database name cannot be null or empty.", nameof(databaseName));
+        }
+
+        DatabaseName = databaseName;
+        CosmosAccountName = cosmosAccountName ?? string.Empty;
+    }
+
+    /// <inheritdoc />
+    public string DatabaseName { get; }
+
+    /// <inheritdoc />
+    public string CosmosAccountName { get; }
+
+    /// <inheritdoc />
+    public CosmosDbAnalysis? CosmosAnalysis { get { lock (_gate) { return _cosmosAnalysis; } } }
+
+    /// <inheritdoc />
+    public SqlMigrationAssessment? SqlAssessment { get { lock (_gate) { return _sqlAssessment; } } }
+
+    /// <inheritdoc />
+    public DataQualityAnalysis? DataQualityAnalysis { get { lock (_gate) { return _dataQualityAnalysis; } } }
+
+    /// <inheritdoc />
+    public DataFactoryEstimate? DataFactoryEstimate { get { lock (_gate) { return _dataFactoryEstimate; } } }
+
+    /// <inheritdoc />
+    public bool HasCosmosAnalysis { get { lock (_gate) { return _cosmosAnalysis is not null; } } }
+
+    /// <inheritdoc />
+    public bool HasSqlAssessment { get { lock (_gate) { return _sqlAssessment is not null; } } }
+
+    /// <inheritdoc />
+    public bool HasDataQualityAnalysis { get { lock (_gate) { return _dataQualityAnalysis is not null; } } }
+
+    /// <inheritdoc />
+    public bool HasDataFactoryEstimate { get { lock (_gate) { return _dataFactoryEstimate is not null; } } }
+
+    /// <inheritdoc />
+    public IReadOnlyList<AgentMessage> Messages { get { lock (_gate) { return _messages.ToArray(); } } }
+
+    /// <inheritdoc />
+    public IReadOnlyList<AgentResult> Results { get { lock (_gate) { return _results.ToArray(); } } }
+
+    /// <inheritdoc />
+    public void SetCosmosAnalysis(string producerName, CosmosDbAnalysis analysis)
+    {
+        ArgumentNullException.ThrowIfNull(analysis);
+        lock (_gate)
+        {
+            ThrowIfAlreadySet(_cosmosAnalysis, nameof(CosmosAnalysis), producerName);
+            _cosmosAnalysis = analysis;
+        }
+    }
+
+    /// <inheritdoc />
+    public void SetSqlAssessment(string producerName, SqlMigrationAssessment assessment)
+    {
+        ArgumentNullException.ThrowIfNull(assessment);
+        lock (_gate)
+        {
+            ThrowIfAlreadySet(_sqlAssessment, nameof(SqlAssessment), producerName);
+            _sqlAssessment = assessment;
+        }
+    }
+
+    /// <inheritdoc />
+    public void SetDataQualityAnalysis(string producerName, DataQualityAnalysis analysis)
+    {
+        ArgumentNullException.ThrowIfNull(analysis);
+        lock (_gate)
+        {
+            ThrowIfAlreadySet(_dataQualityAnalysis, nameof(DataQualityAnalysis), producerName);
+            _dataQualityAnalysis = analysis;
+        }
+    }
+
+    /// <inheritdoc />
+    public void SetDataFactoryEstimate(string producerName, DataFactoryEstimate estimate)
+    {
+        ArgumentNullException.ThrowIfNull(estimate);
+        lock (_gate)
+        {
+            ThrowIfAlreadySet(_dataFactoryEstimate, nameof(DataFactoryEstimate), producerName);
+            _dataFactoryEstimate = estimate;
+        }
+    }
+
+    /// <inheritdoc />
+    public void AddMessage(AgentMessage message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        lock (_gate)
+        {
+            _messages.Add(message);
+        }
+    }
+
+    /// <inheritdoc />
+    public void LogInfo(string agentName, string text) => AddMessage(AgentMessage.Info(agentName, text));
+
+    /// <inheritdoc />
+    public void LogWarning(string agentName, string text) => AddMessage(AgentMessage.Warning(agentName, text));
+
+    /// <inheritdoc />
+    public void LogError(string agentName, string text) => AddMessage(AgentMessage.Error(agentName, text));
+
+    /// <inheritdoc />
+    public void RecordResult(AgentResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        lock (_gate)
+        {
+            _results.Add(result);
+        }
+    }
+
+    /// <inheritdoc />
+    public AgentResult? GetResult(string agentName)
+    {
+        lock (_gate)
+        {
+            for (var i = _results.Count - 1; i >= 0; i--)
+            {
+                if (string.Equals(_results[i].AgentName, agentName, StringComparison.Ordinal))
+                {
+                    return _results[i];
+                }
+            }
+
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
+    public bool HasSucceeded(AgentRole role)
+    {
+        lock (_gate)
+        {
+            foreach (var result in _results)
+            {
+                if (result.Role == role && result.Status == AgentRunStatus.Succeeded)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> GetMissingRequiredOutputs()
+    {
+        lock (_gate)
+        {
+            var missing = new List<string>();
+            if (_cosmosAnalysis is null) missing.Add(nameof(CosmosAnalysis));
+            if (_sqlAssessment is null) missing.Add(nameof(SqlAssessment));
+            if (_dataFactoryEstimate is null) missing.Add(nameof(DataFactoryEstimate));
+            return missing;
+        }
+    }
+
+    /// <inheritdoc />
+    public bool IsCompleteForAssessmentResult() => GetMissingRequiredOutputs().Count == 0;
+
+    /// <inheritdoc />
+    public AssessmentResult ToAssessmentResult()
+    {
+        lock (_gate)
+        {
+            return new AssessmentResult
+            {
+                CosmosAccountName = CosmosAccountName,
+                DatabaseName = DatabaseName,
+                CosmosAnalysis = _cosmosAnalysis ?? new CosmosDbAnalysis(),
+                SqlAssessment = _sqlAssessment ?? new SqlMigrationAssessment(),
+                DataFactoryEstimate = _dataFactoryEstimate ?? new DataFactoryEstimate(),
+                DataQualityAnalysis = _dataQualityAnalysis
+            };
+        }
+    }
+
+    private static void ThrowIfAlreadySet(object? current, string outputName, string producerName)
+    {
+        if (current is not null)
+        {
+            throw new InvalidOperationException(
+                $"{outputName} has already been set and cannot be overwritten by '{producerName}'. " +
+                "Each domain output is write-once on the shared assessment context.");
+        }
+    }
+}

--- a/Agents/SqlPlannerAgent.cs
+++ b/Agents/SqlPlannerAgent.cs
@@ -1,0 +1,72 @@
+using CosmosToSqlAssessment.Services;
+using Microsoft.Extensions.Logging;
+
+namespace CosmosToSqlAssessment.Agents;
+
+/// <summary>
+/// Agent that owns the Azure SQL migration-planning domain. It wraps the existing
+/// <see cref="SqlMigrationAssessmentService"/> (unchanged) and commits the resulting
+/// <see cref="Models.SqlMigrationAssessment"/> to the shared context.
+/// </summary>
+/// <remarks>
+/// Depends on <see cref="AgentRole.CosmosAnalysis"/>: it skips cleanly (recording an
+/// <see cref="AgentRunStatus.Skipped"/> result) when no Cosmos analysis is present, which is how an
+/// upstream Cosmos failure degrades to a missing SQL plan instead of aborting the whole run. Because
+/// <c>SqlAssessment</c> is a required output, the orchestrator/validator treat its absence as an
+/// incomplete run.
+/// </remarks>
+public sealed class SqlPlannerAgent : AssessmentAgentBase
+{
+    /// <summary>The stable name of this agent.</summary>
+    public const string AgentName = "SqlPlanner";
+
+    private static readonly IReadOnlyCollection<AgentRole> _dependencies = new[] { AgentRole.CosmosAnalysis };
+
+    private readonly SqlMigrationAssessmentService _assessmentService;
+    private readonly ILogger<SqlPlannerAgent> _logger;
+
+    /// <summary>
+    /// Creates a new <see cref="SqlPlannerAgent"/>.
+    /// </summary>
+    /// <param name="assessmentService">The existing SQL migration assessment service to wrap.</param>
+    /// <param name="logger">Logger for diagnostic output.</param>
+    public SqlPlannerAgent(SqlMigrationAssessmentService assessmentService, ILogger<SqlPlannerAgent> logger)
+    {
+        _assessmentService = assessmentService ?? throw new ArgumentNullException(nameof(assessmentService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public override string Name => AgentName;
+
+    /// <inheritdoc />
+    public override AgentRole Role => AgentRole.SqlPlanning;
+
+    /// <inheritdoc />
+    public override IReadOnlyCollection<AgentRole> Dependencies => _dependencies;
+
+    /// <inheritdoc />
+    protected override string? GetSkipReason(ISharedAssessmentContext context) =>
+        context.HasCosmosAnalysis
+            ? null
+            : "Cosmos analysis is not available; cannot plan the SQL migration.";
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(ISharedAssessmentContext context, CancellationToken cancellationToken)
+    {
+        var cosmosAnalysis = context.CosmosAnalysis!; // guaranteed present past the skip gate
+        _logger.LogInformation("SqlPlannerAgent assessing SQL migration for database {DatabaseName}", context.DatabaseName);
+
+        var assessment = await _assessmentService
+            .AssessMigrationAsync(cosmosAnalysis, context.DatabaseName, cancellationToken)
+            .ConfigureAwait(false);
+
+        context.LogInfo(Name,
+            $"Recommended platform {assessment.RecommendedPlatform}; " +
+            $"{assessment.IndexRecommendations.Count} index recommendation(s); " +
+            $"complexity {assessment.Complexity.OverallComplexity}.");
+
+        // Commit is the final action so a later failure never leaves a half-populated context.
+        context.SetSqlAssessment(Name, assessment);
+    }
+}

--- a/Agents/ValidationFinding.cs
+++ b/Agents/ValidationFinding.cs
@@ -1,0 +1,60 @@
+namespace CosmosToSqlAssessment.Agents;
+
+/// <summary>
+/// Classifies a <see cref="ValidationFinding"/> by the kind of problem it represents, so consumers can
+/// reason about which findings affect run completeness versus cross-output consistency versus pure diagnostics.
+/// </summary>
+public enum ValidationFindingCategory
+{
+    /// <summary>
+    /// A required domain output is missing. Completeness findings drive
+    /// <see cref="ValidationReport.IsComplete"/>.
+    /// </summary>
+    Completeness,
+
+    /// <summary>
+    /// Two or more agent outputs disagree (e.g. a Cosmos container has no SQL mapping). An
+    /// <see cref="AgentMessageLevel.Error"/> consistency finding makes
+    /// <see cref="ValidationReport.IsConsistent"/> false.
+    /// </summary>
+    Consistency,
+
+    /// <summary>
+    /// Informational or non-fatal observation (e.g. an optional agent was skipped or failed). Diagnostic
+    /// findings never affect the report's <see cref="ValidationReport.IsAcceptable"/> verdict.
+    /// </summary>
+    Diagnostic
+}
+
+/// <summary>
+/// A single observation produced by the <see cref="ValidatorAgent"/> while cross-checking agent outputs.
+/// </summary>
+/// <remarks>
+/// <see cref="Check"/> is a stable, machine-readable identifier (see the <c>Check*</c> constants on
+/// <see cref="ValidatorAgent"/>) intended for filtering and display by downstream consumers;
+/// <see cref="Detail"/> carries the human-readable explanation.
+/// </remarks>
+public sealed record ValidationFinding
+{
+    /// <summary>The category of problem this finding represents.</summary>
+    public required ValidationFindingCategory Category { get; init; }
+
+    /// <summary>The severity of the finding.</summary>
+    public required AgentMessageLevel Level { get; init; }
+
+    /// <summary>A stable, machine-readable identifier for the check that produced this finding.</summary>
+    public required string Check { get; init; }
+
+    /// <summary>A human-readable description of the finding.</summary>
+    public required string Detail { get; init; }
+
+    /// <summary>Creates a finding.</summary>
+    /// <param name="category">The category of the finding.</param>
+    /// <param name="level">The severity of the finding.</param>
+    /// <param name="check">The stable check identifier.</param>
+    /// <param name="detail">The human-readable detail.</param>
+    /// <returns>A new <see cref="ValidationFinding"/>.</returns>
+    public static ValidationFinding Create(
+        ValidationFindingCategory category, AgentMessageLevel level, string check, string detail) =>
+        new() { Category = category, Level = level, Check = check, Detail = detail };
+}

--- a/Agents/ValidationReport.cs
+++ b/Agents/ValidationReport.cs
@@ -1,0 +1,53 @@
+namespace CosmosToSqlAssessment.Agents;
+
+/// <summary>
+/// The typed verdict produced by the <see cref="ValidatorAgent"/> after cross-checking the outputs of the
+/// other agents. It is the stable, structured surface downstream consumers (and the orchestrator/CLI) use
+/// to decide whether an agentic run succeeded.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is <strong>run metadata, not a domain assessment output</strong>: it is not listed by
+/// <see cref="ISharedAssessmentContext.GetMissingRequiredOutputs"/> and it does not feed
+/// <see cref="ISharedAssessmentContext.ToAssessmentResult"/>. A missing report
+/// (<see cref="ISharedAssessmentContext.HasValidationReport"/> is <see langword="false"/>) means validation
+/// never ran or crashed before it could emit a report — consumers should treat that as an infrastructure
+/// failure distinct from an unacceptable-but-reported run.
+/// </para>
+/// <para>
+/// Consumers should prefer the typed <see cref="IsAcceptable"/>/<see cref="IsComplete"/> verdict over parsing
+/// <see cref="ISharedAssessmentContext.Messages"/>.
+/// </para>
+/// </remarks>
+public sealed record ValidationReport
+{
+    /// <summary>
+    /// Whether every required output (Cosmos analysis, SQL assessment, Data Factory estimate) is present.
+    /// Driven by <see cref="MissingRequiredOutputs"/>; data quality is optional and never affects this.
+    /// </summary>
+    public required bool IsComplete { get; init; }
+
+    /// <summary>
+    /// Whether the agent outputs are mutually consistent — i.e. there are no
+    /// <see cref="AgentMessageLevel.Error"/>-level <see cref="ValidationFindingCategory.Consistency"/> findings.
+    /// </summary>
+    public required bool IsConsistent { get; init; }
+
+    /// <summary>
+    /// The overall verdict: the run is acceptable when it is both complete and consistent. The orchestrator
+    /// and CLI derive the process exit code from this.
+    /// </summary>
+    public bool IsAcceptable => IsComplete && IsConsistent;
+
+    /// <summary>The names of required outputs that were missing at validation time; empty when complete.</summary>
+    public IReadOnlyList<string> MissingRequiredOutputs { get; init; } = Array.Empty<string>();
+
+    /// <summary>The names of agents that recorded a failed result; diagnostic only, never affects the verdict.</summary>
+    public IReadOnlyList<string> FailedAgents { get; init; } = Array.Empty<string>();
+
+    /// <summary>All findings produced during validation, in the order they were discovered.</summary>
+    public IReadOnlyList<ValidationFinding> Findings { get; init; } = Array.Empty<ValidationFinding>();
+
+    /// <summary>Whether optional data-quality analysis was available at validation time.</summary>
+    public bool DataQualityAvailable { get; init; }
+}

--- a/Agents/ValidatorAgent.cs
+++ b/Agents/ValidatorAgent.cs
@@ -1,0 +1,228 @@
+using CosmosToSqlAssessment.Models;
+using Microsoft.Extensions.Logging;
+
+namespace CosmosToSqlAssessment.Agents;
+
+/// <summary>
+/// Agent that cross-checks the outputs produced by the other agents and emits a typed
+/// <see cref="Agents.ValidationReport"/> describing whether the run is complete and internally consistent.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The validator <strong>never skips</strong>: it always runs so it can flag whatever is missing, and is
+/// scheduled <em>last</em> by the orchestrator (after the optional data-quality agent and the derived Data
+/// Factory step). Its <see cref="Dependencies"/> list only the agent-backed required producers so a
+/// dependency-ordering scheduler places it after them; it does not depend on the optional data-quality
+/// output (which may legitimately never be produced).
+/// </para>
+/// <para>
+/// Finding a problem is a successful validation, not a failure: the agent records
+/// <see cref="AgentRunStatus.Succeeded"/> as long as it produced a report, even when that report is not
+/// acceptable. Only a genuine execution fault makes the agent fail — and even then the validator hardens
+/// its cross-checks so a malformed upstream output becomes a finding rather than a crash, ensuring a report
+/// is (almost) always emitted. The orchestrator/CLI derive the process exit code from
+/// <see cref="Agents.ValidationReport.IsAcceptable"/>.
+/// </para>
+/// </remarks>
+public sealed class ValidatorAgent : AssessmentAgentBase
+{
+    /// <summary>The stable name of this agent.</summary>
+    public const string AgentName = "Validator";
+
+    /// <summary>Check code: a required domain output is missing.</summary>
+    public const string CheckMissingRequiredOutput = "MissingRequiredOutput";
+
+    /// <summary>Check code: an agent recorded a failed result.</summary>
+    public const string CheckAgentFailed = "AgentFailed";
+
+    /// <summary>Check code: optional data-quality analysis was not available.</summary>
+    public const string CheckDataQualityUnavailable = "DataQualityUnavailable";
+
+    /// <summary>Check code: optional data-quality analysis was available.</summary>
+    public const string CheckDataQualityAvailable = "DataQualityAvailable";
+
+    /// <summary>Check code: a Cosmos container has no corresponding SQL mapping.</summary>
+    public const string CheckUnmappedCosmosContainer = "UnmappedCosmosContainer";
+
+    /// <summary>Check code: a SQL container mapping has a null/empty source container name.</summary>
+    public const string CheckMalformedSqlMapping = "MalformedSqlMapping";
+
+    /// <summary>Check code: the database metrics container count disagrees with the analyzed container list.</summary>
+    public const string CheckContainerCountMismatch = "ContainerCountMismatch";
+
+    /// <summary>Check code: an unexpected error occurred inside the validator's cross-checks.</summary>
+    public const string CheckValidatorInternalError = "ValidatorInternalError";
+
+    private static readonly IReadOnlyCollection<AgentRole> _dependencies =
+        new[] { AgentRole.CosmosAnalysis, AgentRole.SqlPlanning };
+
+    private readonly ILogger<ValidatorAgent> _logger;
+
+    /// <summary>
+    /// Creates a new <see cref="ValidatorAgent"/>.
+    /// </summary>
+    /// <param name="logger">Logger for diagnostic output.</param>
+    public ValidatorAgent(ILogger<ValidatorAgent> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public override string Name => AgentName;
+
+    /// <inheritdoc />
+    public override AgentRole Role => AgentRole.Validation;
+
+    /// <inheritdoc />
+    public override IReadOnlyCollection<AgentRole> Dependencies => _dependencies;
+
+    /// <inheritdoc />
+    protected override Task ExecuteAsync(ISharedAssessmentContext context, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("ValidatorAgent cross-checking outputs for database {DatabaseName}", context.DatabaseName);
+
+        var findings = new List<ValidationFinding>();
+
+        // --- Completeness: required outputs that were never produced. ---
+        var missing = context.GetMissingRequiredOutputs();
+        foreach (var output in missing)
+        {
+            var detail = $"Required output '{output}' was not produced.";
+            findings.Add(ValidationFinding.Create(
+                ValidationFindingCategory.Completeness, AgentMessageLevel.Error, CheckMissingRequiredOutput, detail));
+            context.LogError(Name, detail);
+        }
+
+        // --- Diagnostic: agents that failed (informational; completeness stays output-based). ---
+        var failedAgents = context.Results
+            .Where(r => r.Status == AgentRunStatus.Failed)
+            .Select(r => r.AgentName)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        foreach (var agentName in failedAgents)
+        {
+            var detail = $"Agent '{agentName}' reported a failure; downstream outputs it owns may be absent.";
+            findings.Add(ValidationFinding.Create(
+                ValidationFindingCategory.Diagnostic, AgentMessageLevel.Warning, CheckAgentFailed, detail));
+            context.LogWarning(Name, detail);
+        }
+
+        // --- Diagnostic: optional data quality. Never affects the verdict. ---
+        var dataQualityAvailable = context.HasDataQualityAnalysis;
+        if (dataQualityAvailable)
+        {
+            findings.Add(ValidationFinding.Create(
+                ValidationFindingCategory.Diagnostic, AgentMessageLevel.Info, CheckDataQualityAvailable,
+                "Optional data-quality analysis is available."));
+        }
+        else
+        {
+            var detail = "Optional data-quality analysis was not produced; this does not affect run acceptability.";
+            findings.Add(ValidationFinding.Create(
+                ValidationFindingCategory.Diagnostic, AgentMessageLevel.Info, CheckDataQualityUnavailable, detail));
+            context.LogInfo(Name, detail);
+        }
+
+        // --- Consistency: cross-check Cosmos <-> SQL coverage. Hardened against malformed shapes. ---
+        try
+        {
+            CrossCheckCosmosToSql(context, findings);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // A malformed upstream output must not turn the validator into a crashed agent: record it as a
+            // finding and still emit a report so the incompleteness/inconsistency is surfaced cleanly.
+            var detail = $"Validator cross-check raised {ex.GetType().Name}: {ex.Message}";
+            findings.Add(ValidationFinding.Create(
+                ValidationFindingCategory.Consistency, AgentMessageLevel.Error, CheckValidatorInternalError, detail));
+            context.LogError(Name, detail);
+        }
+
+        var isComplete = missing.Count == 0;
+        var isConsistent = !findings.Any(f =>
+            f.Category == ValidationFindingCategory.Consistency && f.Level == AgentMessageLevel.Error);
+
+        var report = new ValidationReport
+        {
+            IsComplete = isComplete,
+            IsConsistent = isConsistent,
+            MissingRequiredOutputs = missing,
+            FailedAgents = failedAgents,
+            Findings = findings,
+            DataQualityAvailable = dataQualityAvailable
+        };
+
+        context.LogInfo(Name,
+            $"Validation complete: acceptable={report.IsAcceptable} (complete={isComplete}, consistent={isConsistent}); " +
+            $"{findings.Count} finding(s), {missing.Count} missing required output(s), {failedAgents.Length} failed agent(s).");
+
+        // Commit is the final action so a later failure never leaves the context with a partial report.
+        context.SetValidationReport(Name, report);
+        return Task.CompletedTask;
+    }
+
+    private void CrossCheckCosmosToSql(ISharedAssessmentContext context, List<ValidationFinding> findings)
+    {
+        var cosmos = context.CosmosAnalysis;
+        var sql = context.SqlAssessment;
+        if (cosmos is null || sql is null)
+        {
+            // Absence is already captured as a completeness finding; there is nothing to cross-check.
+            return;
+        }
+
+        var containers = cosmos.Containers ?? new List<ContainerAnalysis>();
+
+        // Build the set of source containers covered by the SQL plan (null-safe at every level).
+        var mappedSources = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var databaseMapping in sql.DatabaseMappings ?? new List<DatabaseMapping>())
+        {
+            foreach (var containerMapping in databaseMapping.ContainerMappings ?? new List<ContainerMapping>())
+            {
+                var source = containerMapping.SourceContainer;
+                if (string.IsNullOrWhiteSpace(source))
+                {
+                    var detail = "A SQL container mapping has a null or empty source container name.";
+                    findings.Add(ValidationFinding.Create(
+                        ValidationFindingCategory.Consistency, AgentMessageLevel.Error, CheckMalformedSqlMapping, detail));
+                    context.LogError(Name, detail);
+                    continue;
+                }
+
+                mappedSources.Add(source);
+            }
+        }
+
+        foreach (var container in containers)
+        {
+            var name = container?.ContainerName;
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                continue;
+            }
+
+            if (!mappedSources.Contains(name))
+            {
+                var detail = $"Cosmos container '{name}' has no corresponding SQL table mapping.";
+                findings.Add(ValidationFinding.Create(
+                    ValidationFindingCategory.Consistency, AgentMessageLevel.Error, CheckUnmappedCosmosContainer, detail));
+                context.LogError(Name, detail);
+            }
+        }
+
+        // Soft consistency signal: the reported container count vs. the analyzed list. Warning-only because
+        // the metric may be an approximation in some sources, so it must not flip IsConsistent on its own.
+        var reportedCount = cosmos.DatabaseMetrics?.ContainerCount ?? containers.Count;
+        if (reportedCount != containers.Count)
+        {
+            var detail = $"DatabaseMetrics.ContainerCount ({reportedCount}) differs from the number of analyzed containers ({containers.Count}).";
+            findings.Add(ValidationFinding.Create(
+                ValidationFindingCategory.Consistency, AgentMessageLevel.Warning, CheckContainerCountMismatch, detail));
+            context.LogWarning(Name, detail);
+        }
+    }
+}

--- a/Cli/CliArgumentParser.cs
+++ b/Cli/CliArgumentParser.cs
@@ -88,6 +88,9 @@ internal static class CliArgumentParser
                 case "-i":
                     options.Interactive = true;
                     break;
+                case "--agentic":
+                    options.Agentic = true;
+                    break;
                 case "--config":
                 case "-c":
                     if (i + 1 < args.Length)
@@ -165,6 +168,7 @@ internal static class CliArgumentParser
         output.WriteLine("  --project-only            Generate SQL projects only (skip assessment reports)");
         output.WriteLine("  --test-connection         Test connectivity to Cosmos DB and Azure Monitor");
         output.WriteLine("  -i, --interactive         Launch interactive wizard mode for guided configuration");
+        output.WriteLine("  --agentic                 Run the assessment via the multi-agent orchestration layer (equivalent output)");
         output.WriteLine("  -c, --config <path>       Load configuration from a saved JSON file");
         output.WriteLine("  --save-config <path>      Save wizard configuration to a JSON file for reuse");
         output.WriteLine("  --resume                  Resume an interrupted interactive wizard session");

--- a/Cli/CliOptions.cs
+++ b/Cli/CliOptions.cs
@@ -17,6 +17,7 @@ internal sealed class CliOptions
     public bool ProjectOnly { get; set; }
     public bool TestConnection { get; set; }
     public bool Interactive { get; set; }
+    public bool Agentic { get; set; }
     public string? ConfigFile { get; set; }
     public string? SaveConfigFile { get; set; }
     public bool ResumeSession { get; set; }

--- a/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/DependencyInjection/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Azure.Identity;
 using Azure.ResourceManager;
+using CosmosToSqlAssessment.Agents;
 using CosmosToSqlAssessment.Orchestration;
 using CosmosToSqlAssessment.Reporting;
 using CosmosToSqlAssessment.Services;
@@ -68,6 +69,15 @@ namespace CosmosToSqlAssessment.DependencyInjection
 
             // Orchestration
             services.AddScoped<AssessmentOrchestrator>();
+
+            // Multi-agent orchestration layer (parent #131). Each agent wraps an existing service and
+            // communicates through the shared assessment context; the orchestrator coordinates them.
+            services.AddScoped<IAssessmentAgent, CosmosAnalyzerAgent>();
+            services.AddScoped<IAssessmentAgent, SqlPlannerAgent>();
+            services.AddScoped<IAssessmentAgent, DataQualityAgent>();
+            services.AddScoped<IAssessmentAgent, DataFactoryEstimatorAgent>();
+            services.AddScoped<IAssessmentAgent, ValidatorAgent>();
+            services.AddScoped<AgentOrchestrator>();
 
             return services;
         }

--- a/Models/UserInputs.cs
+++ b/Models/UserInputs.cs
@@ -11,6 +11,13 @@ public class UserInputs
     public string OutputDirectory { get; set; } = string.Empty;
     public string AccountEndpoint { get; set; } = string.Empty;
     public MonitoringConfiguration? MonitoringConfig { get; set; }
+
+    /// <summary>
+    /// When <see langword="true"/>, the per-database assessment is computed through the multi-agent
+    /// orchestration layer (<c>--agentic</c>) instead of the inline single-pass sequence. The produced
+    /// assessment is equivalent; only the execution path differs.
+    /// </summary>
+    public bool UseAgentic { get; set; }
 }
 
 /// <summary>

--- a/Orchestration/AssessmentOrchestrator.cs
+++ b/Orchestration/AssessmentOrchestrator.cs
@@ -2,6 +2,7 @@ using Azure;
 using Azure.Identity;
 using Azure.Monitor.Query;
 using Azure.Monitor.Query.Models;
+using CosmosToSqlAssessment.Agents;
 using CosmosToSqlAssessment.Cli;
 using CosmosToSqlAssessment.DependencyInjection;
 using CosmosToSqlAssessment.Models;
@@ -254,6 +255,12 @@ internal sealed class AssessmentOrchestrator
             DatabaseName = databaseName
         };
 
+        if (userInputs.UseAgentic)
+        {
+            return await RunDatabaseAssessmentAgenticAsync(
+                activeServiceProvider, assessmentResult, databaseName, cancellationToken);
+        }
+
         // Step 1: Cosmos DB Analysis
         Console.WriteLine("📊 Phase 1: Analyzing Cosmos DB database...");
         var cosmosService = activeServiceProvider.GetRequiredService<CosmosDbAnalysisService>();
@@ -334,6 +341,76 @@ internal sealed class AssessmentOrchestrator
             _logger.LogError(ex, "Failed to calculate Data Factory estimates");
             throw new InvalidOperationException($"Data Factory estimation failed for database {databaseName}: {ex.Message}", ex);
         }
+
+        return assessmentResult;
+    }
+
+    /// <summary>
+    /// Computes the per-database assessment through the multi-agent orchestration layer
+    /// (<c>--agentic</c>). Produces output equivalent to the single-pass
+    /// <see cref="RunDatabaseAssessmentAsync"/> path, then feeds the same unchanged report /
+    /// SQL-project generation.
+    /// </summary>
+    /// <remarks>
+    /// A child DI scope is created per database so scoped agents do not leak state across a
+    /// multi-database run and are disposed deterministically. Failure parity with single-pass is
+    /// preserved by gating the fatal path on <em>completeness</em> (the required Cosmos analysis, SQL
+    /// assessment, and Data Factory estimate are all present) rather than full acceptability — a
+    /// consistency-only finding (e.g. an unmapped container) stays non-fatal, and an absent/failed
+    /// optional data-quality analysis is likewise non-fatal, exactly as in the single-pass flow.
+    /// </remarks>
+    private async Task<AssessmentResult> RunDatabaseAssessmentAgenticAsync(
+        IServiceProvider activeServiceProvider,
+        AssessmentResult assessmentResult,
+        string databaseName,
+        CancellationToken cancellationToken)
+    {
+        Console.WriteLine("🤖 Agentic mode: coordinating specialist agents (Cosmos → SQL → data quality → Data Factory → validation)...");
+
+        using var scope = activeServiceProvider.CreateScope();
+        var orchestrator = scope.ServiceProvider.GetRequiredService<AgentOrchestrator>();
+
+        var run = await orchestrator.RunAsync(
+            databaseName,
+            assessmentResult.CosmosAccountName,
+            new AgentOrchestrationOptions { Mode = AgentExecutionMode.Sequential },
+            cancellationToken);
+
+        var projected = run.AssessmentResult;
+
+        // Fatal only when a REQUIRED output is missing (parity with the single-pass flow, which throws
+        // on Cosmos / SQL / Data Factory failure but not on data-quality failure or a consistency-only
+        // validator finding). ToAssessmentResult() default-constructs missing required outputs, so
+        // completeness is read from the validator's report (IsComplete), not from null checks. A missing
+        // report (validator never emitted one) is treated as fatal since the result can't be trusted.
+        var report = run.Validation;
+        if (report is not { IsComplete: true })
+        {
+            var missing = report is { MissingRequiredOutputs.Count: > 0 }
+                ? string.Join(", ", report.MissingRequiredOutputs)
+                : "Cosmos analysis, SQL assessment, or Data Factory estimate";
+            _logger.LogError("Agentic assessment incomplete for database {DatabaseName}: missing {Missing}", databaseName, missing);
+            throw new InvalidOperationException(
+                $"Agentic assessment failed for database {databaseName}: missing required output(s): {missing}.");
+        }
+
+        assessmentResult.CosmosAnalysis = projected.CosmosAnalysis;
+        assessmentResult.SqlAssessment = projected.SqlAssessment;
+        assessmentResult.DataQualityAnalysis = projected.DataQualityAnalysis;
+        assessmentResult.DataFactoryEstimate = projected.DataFactoryEstimate;
+
+        Console.WriteLine($"   ✅ Analyzed {assessmentResult.CosmosAnalysis.Containers.Count} containers");
+        Console.WriteLine($"   ✅ Recommended platform: {assessmentResult.SqlAssessment.RecommendedPlatform}");
+        if (assessmentResult.DataQualityAnalysis is not null)
+        {
+            Console.WriteLine($"   ✅ Quality score: {assessmentResult.DataQualityAnalysis.Summary.OverallQualityScore:F1}/100 ({assessmentResult.DataQualityAnalysis.Summary.QualityRating})");
+        }
+        else
+        {
+            Console.WriteLine("   ⚠️  Data quality analysis unavailable (optional) - continuing");
+        }
+        Console.WriteLine($"   ✅ Estimated migration time: {assessmentResult.DataFactoryEstimate.EstimatedDuration:hh\\:mm\\:ss}");
+        Console.WriteLine($"   {(run.IsAcceptable ? "✅ Validation: acceptable" : "⚠️  Validation: complete but with consistency warnings")}");
 
         return assessmentResult;
     }
@@ -544,6 +621,8 @@ internal sealed class AssessmentOrchestrator
 
         try
         {
+            inputs.UseAgentic = options.Agentic;
+
             inputs.AccountEndpoint = !string.IsNullOrEmpty(options.AccountEndpoint)
                 ? options.AccountEndpoint
                 : _configuration["CosmosDb:AccountEndpoint"] ?? string.Empty;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -356,6 +356,267 @@ Application → Azure Identity → Azure AD → Resource Access
 - Template-based formatting
 - Compressed output files
 
+---
+
+## Multi-Agent Orchestration Layer (Agentic Mode)
+
+> Foundation of the M4 agentic-intelligence epic (#130, parent #131). This layer is **opt-in** via the
+> `--agentic` CLI flag and produces output **equivalent** to the default single-pass flow described above —
+> it changes *how* the per-database assessment is computed, not *what* is produced.
+
+### Motivation
+
+The single-pass flow runs a fixed sequence (Cosmos → SQL → data quality → Data Factory) inline in
+`AssessmentOrchestrator`. The agentic layer re-expresses that same work as a set of **autonomous agents**
+that each own one domain, declare their dependencies, and communicate only through a shared, thread-safe
+**blackboard** (`SharedAssessmentContext`). A coordinator (`AgentOrchestrator`) schedules them with
+failure isolation, optional parallelism, and an always-on validation pass. This makes the pipeline
+composable and independently testable, and gives downstream issues (#132/#133/#69) a stable surface to
+build richer agentic behaviour on.
+
+The agents **wrap the existing services without changing their signatures**, so the analysis logic — and
+the streaming behaviour from #129 — is reused verbatim.
+
+### Stable public surface
+
+Everything below lives in namespace `CosmosToSqlAssessment.Agents`. The **public interfaces, records, and
+result types — together with the documented invariants** — form the stable surface that #132/#133/#69 build
+on. Internal wiring (DI registration) and the `internal` `DataFactoryEstimatorAgent` are implementation
+details and are **not** extension points.
+
+| Type | Kind | Responsibility |
+|---|---|---|
+| `IAssessmentAgent` | interface | An agent: `Name`, `Role` (`AgentRole`), `Dependencies` (`IReadOnlyCollection<AgentRole>`), `RunAsync(ISharedAssessmentContext, CancellationToken)` → `AgentResult`. |
+| `AssessmentAgentBase` | abstract base | Shared lifecycle: times the run, records an `AgentResult`, converts exceptions to **`Failed`** results (isolation), **rethrows `OperationCanceledException`**, and exposes a `GetSkipReason` hook that yields a **`Skipped`** result. |
+| `ISharedAssessmentContext` / `SharedAssessmentContext` | blackboard | Thread-safe (single lock) shared state: **write-once** domain outputs + **write-once** `ValidationReport`, a message log, a per-agent result log, `GetMissingRequiredOutputs()`, and `ToAssessmentResult()`. |
+| `AgentOrchestrator` | coordinator | Validates the agent graph in its constructor, then `RunAsync(databaseName, cosmosAccountName, options?, ct)` → `AgentOrchestrationResult`. |
+| `AgentOrchestrationOptions` | record | `Mode` (`AgentExecutionMode`, default `Sequential`) and an optional cooperative `PerAgentTimeout`. |
+| `AgentOrchestrationResult` | record | **Immutable snapshots only** (see below). |
+| `AgentMessage` / `AgentResult` | records | A logged message (`AgentName`, `Level`, `Text`, `TimestampUtc`) and a terminal agent outcome (`AgentName`, `Role`, `Status`, `Error?`, `Duration`). |
+| `ValidationReport` / `ValidationFinding` | records | The validator's typed verdict and individual cross-check findings. |
+| `AgentRole` / `AgentMessageLevel` / `AgentRunStatus` / `AgentExecutionMode` / `ValidationFindingCategory` | enums | Domain role, severity, terminal status, scheduling mode, and finding category. |
+
+> **Snapshot contract.** `AgentOrchestrationResult` exposes only **immutable point-in-time snapshots**
+> (the projected `AssessmentResult`, the `ValidationReport`, the `AgentResults` and `Messages` lists,
+> `IsAcceptable`, and `Mode`). The live mutable `SharedAssessmentContext` is intentionally **not** surfaced —
+> consumers must not expect to observe or mutate the context after a run. The stable downstream artifact is
+> the projected legacy `AssessmentResult`.
+
+### Agent roster & dependency graph
+
+```mermaid
+flowchart TD
+    C["CosmosAnalyzerAgent<br/>role: CosmosAnalysis<br/>(root, no deps)"]
+    S["SqlPlannerAgent<br/>role: SqlPlanning"]
+    Q["DataQualityAgent<br/>role: DataQuality<br/>(optional)"]
+    F["DataFactoryEstimatorAgent<br/>role: DataFactoryEstimation<br/>(internal)"]
+    V["ValidatorAgent<br/>role: Validation<br/>(never skips)"]
+
+    C --> S
+    C --> Q
+    C --> F
+    S --> F
+    C -.-> V
+    S -.-> V
+```
+
+Each agent wraps an unchanged service: `CosmosAnalyzerAgent` → `CosmosDbAnalysisService`,
+`SqlPlannerAgent` → `SqlMigrationAssessmentService`, `DataQualityAgent` → `DataQualityAnalysisService`,
+`DataFactoryEstimatorAgent` → `DataFactoryEstimateService`. The `ValidatorAgent` produces no domain output;
+it cross-checks the others.
+
+#### Required vs optional outputs
+
+Completeness and the CLI's fatal semantics are driven entirely by the **required** outputs:
+
+| Output | Required for completeness? | Produced by |
+|---|:--:|---|
+| `CosmosAnalysis` | ✅ Yes | `CosmosAnalyzerAgent` |
+| `SqlAssessment` | ✅ Yes | `SqlPlannerAgent` |
+| `DataFactoryEstimate` | ✅ Yes | `DataFactoryEstimatorAgent` |
+| `DataQualityAnalysis` | ❌ No (optional) | `DataQualityAgent` |
+| `ValidationReport` | n/a — always emitted | `ValidatorAgent` |
+
+An absent or failed `DataQualityAgent` is **non-fatal** and is reported diagnostically; it never affects
+completeness unless deliberately promoted to a required output.
+
+### Shared context & data flow
+
+```mermaid
+flowchart LR
+    A1[Agents] -- "Set*() write-once" --> CTX[(SharedAssessmentContext)]
+    A1 -- "LogInfo / LogWarning" --> CTX
+    CTX -- "ToAssessmentResult()" --> AR[AssessmentResult]
+    AR --> RPT[Report generation]
+    AR --> SQLPROJ[SQL project generation]
+```
+
+Agents commit their domain output to the context as their **last action**, so a later failure never leaves a
+half-populated context. The context projects to the legacy `AssessmentResult` via `ToAssessmentResult()`,
+which is fed to the **unchanged** report and SQL-project generation — this reuse is what guarantees
+equivalence with single-pass output. Agents that wrap data-heavy services **preserve the services' internal
+streaming / `IAsyncEnumerable` semantics** (#129); the orchestration layer introduces no whole-dataset
+buffering.
+
+### Execution modes
+
+The orchestrator separates **producers** (Cosmos, SQL, data quality, Data Factory) from the **validator**.
+Producers are scheduled by mode; the validator always runs **last** (see invariants below). A producer's
+role is *completed* once its agent records any terminal result, and a producer becomes *ready* when every
+role in its `Dependencies` is completed.
+
+#### Sequential (default, and what `--agentic` uses)
+
+Runs the highest-priority **ready** producer one at a time, reproducing the exact single-pass order.
+
+```mermaid
+sequenceDiagram
+    participant O as AgentOrchestrator
+    participant C as CosmosAnalyzerAgent
+    participant S as SqlPlannerAgent
+    participant Q as DataQualityAgent
+    participant F as DataFactoryEstimatorAgent
+    participant V as ValidatorAgent
+    participant X as SharedAssessmentContext
+
+    Note over O: ValidateGraph() runs in the constructor
+    O->>C: RunAsync(ctx)
+    C->>X: SetCosmosAnalysis(...)
+    O->>S: RunAsync(ctx)
+    S->>X: SetSqlAssessment(...)
+    O->>Q: RunAsync(ctx)
+    Q->>X: SetDataQualityAnalysis(...) [optional]
+    O->>F: RunAsync(ctx)
+    F->>X: SetDataFactoryEstimate(...)
+    O->>V: RunAsync(ctx)
+    V->>X: SetValidationReport(...)
+    O->>X: ToAssessmentResult() + snapshot Results/Messages
+    O-->>O: AgentOrchestrationResult (immutable snapshots)
+```
+
+#### Parallel (delta from Sequential)
+
+The whole **ready wave** runs concurrently via `Task.WhenAll`; the validator is still held until all
+producers complete. With the standard roster the waves are: **wave 0** = `Cosmos`; **wave 1** =
+`{Sql, DataQuality}` concurrently (both depend only on Cosmos); **wave 2** = `DataFactory` (needs Sql);
+then the **validator**.
+
+```mermaid
+sequenceDiagram
+    participant O as AgentOrchestrator
+    participant C as CosmosAnalyzerAgent
+    participant S as SqlPlannerAgent
+    participant Q as DataQualityAgent
+    participant F as DataFactoryEstimatorAgent
+    participant V as ValidatorAgent
+
+    O->>C: wave 0
+    par wave 1 (Task.WhenAll)
+        O->>S: RunAsync(ctx)
+    and
+        O->>Q: RunAsync(ctx)
+    end
+    O->>F: wave 2
+    O->>V: validator last
+```
+
+#### Conditional (delta from Sequential)
+
+Sequential ordering, but a producer whose dependencies did **not succeed** is recorded **`Skipped`
+without being invoked**. The validator still runs and reports the resulting incompleteness.
+
+```mermaid
+sequenceDiagram
+    participant O as AgentOrchestrator
+    participant C as CosmosAnalyzerAgent
+    participant S as SqlPlannerAgent
+    participant V as ValidatorAgent
+
+    O->>C: RunAsync(ctx)
+    C-->>O: Failed (e.g. analysis error)
+    Note over O,S: Sql/DataQuality/DataFactory deps did not succeed
+    O-->>O: record Sql = Skipped (not invoked)
+    O-->>O: record DataQuality / DataFactory = Skipped
+    O->>V: RunAsync(ctx)
+    Note over O,V: ValidatorAgent never skips
+    V-->>O: ValidationReport(IsComplete = false)
+```
+
+#### Scheduling determinism
+
+Sequential and Conditional schedule in **dependency-priority order** and are fully deterministic. In
+**Parallel** mode, agents within a ready wave execute concurrently, so the relative order of their messages
+and results is **not** semantically meaningful. Consumers should key off **role / result identity**, not
+incidental log order. (The orchestrator snapshots the result and message lists so a returned
+`AgentOrchestrationResult` is itself stable.)
+
+### Failure isolation, validation & recoverability
+
+- **Isolation.** An agent that throws is recorded as a `Failed` result; the run continues so other agents
+  can still produce their outputs. `OperationCanceledException` is the exception — it is rethrown so global
+  Ctrl+C cancellation propagates (and `Program` maps it to exit code 130).
+- **Cooperative timeout.** `PerAgentTimeout` cancels a **linked** `CancellationToken`; it only bounds agents
+  (and the services they wrap) that *observe* cancellation. A timed-out agent becomes a `Failed` result and
+  the run continues. Long-running or streaming agents must propagate and honour the token and must not
+  swallow cancellation.
+- **The validator is an invariant, not a step.** `ValidatorAgent` **never skips** and runs **last in every
+  mode**, even when producers failed or required outputs are missing. Its job is to convert partial
+  orchestration state into a complete `ValidationReport`:
+  - **Completeness** — `IsComplete` is true when no *required* output is missing (`MissingRequiredOutputs`
+    empty). A missing required output yields a `Completeness`/`Error` finding.
+  - **Consistency** — `IsConsistent` is true when there are no `Error`-level `Consistency` findings. An
+    unmapped Cosmos container is a `Consistency`/`Error`; a container-count mismatch is a softer
+    `Consistency`/`Warning`. Failed or absent optional agents produce `Diagnostic` findings only.
+  - **Acceptability** — `IsAcceptable = IsComplete && IsConsistent`.
+
+### Equivalence guarantee
+
+Agentic mode is held to **output equivalence** with single-pass mode by regression tests
+(`tests/CosmosToSqlAssessment.Tests/EndToEnd/AgentEquivalenceTests.cs`): driving the real services (against
+the mock Azure SDKs) through the `AgentOrchestrator` produces an `AssessmentResult` that is field-for-field
+equivalent to the legacy `E2EFixture.RunAssessmentAsync` baseline — in **both Sequential and Parallel**
+modes — excluding only non-deterministic members (generated IDs and timestamps). Additional fake-agent
+scheduling tests (`Agents/AgentOrchestratorTests.cs`) cover ordering, parallel waves, failure isolation,
+conditional skip, timeout, and graph validation.
+
+### CLI usage
+
+```bash
+# Run the assessment through the multi-agent orchestration layer (equivalent output)
+CosmosToSqlAssessment --agentic --database MyDatabase
+
+# Works with the usual flags
+CosmosToSqlAssessment --agentic --all-databases --output C:\Reports
+```
+
+When `--agentic` is set, `AssessmentOrchestrator` computes each database's assessment through the
+`AgentOrchestrator` (a **child DI scope per database**, explicit **Sequential** mode) and then feeds the same
+unchanged report / SQL-project generation. **Fatal semantics match single-pass** and are expressed as an
+invariant: the run fails only when it is **incomplete** (`ValidationReport.IsComplete == false`), i.e. a
+*required* output is missing. A consistency-only finding (e.g. an unmapped container) and an absent/failed
+optional data-quality analysis are **non-fatal**, exactly as in single-pass.
+
+### Extensibility — adding an agent (for #132/#133/#69)
+
+There is **exactly one agent per `AgentRole`**, and the orchestrator validates this at construction.
+
+1. **Adding an agent for an existing role is not the model.** A new agent almost always introduces (or
+   re-uses) a *distinct* role. Implement `IAssessmentAgent` (or derive from `AssessmentAgentBase` for the
+   shared timing / isolation / skip lifecycle), set `Name`, `Role`, and `Dependencies`, and commit any
+   domain output to the context **last** via a `Set*` method.
+2. **Register it** in DI (`AddCosmosAssessment`) as `IAssessmentAgent`; the orchestrator discovers it via
+   `IEnumerable<IAssessmentAgent>` and schedules it by its dependencies — no scheduler changes needed.
+3. **Adding a new *role*** may additionally require updating: the graph-validation rules (which roles are
+   required), the scheduling priority order, the validator's completeness/consistency expectations, and —
+   if the agent produces a new domain output — `SharedAssessmentContext` and the `ToAssessmentResult()`
+   projection.
+4. **Model optional agents** so their absence or failure stays diagnostic and does **not** affect
+   completeness, unless the new output is intentionally promoted to *required*.
+
+Graph-validation rules the constructor enforces (violations throw `InvalidOperationException`): unique agent
+names, exactly one agent per role, all required roles present, and no dependency on a role that no
+registered agent provides.
+
 ## Deployment Architecture
 
 ### 1. Development Environment

--- a/tests/CosmosToSqlAssessment.Tests/Agents/AgentMessageAndResultTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Agents/AgentMessageAndResultTests.cs
@@ -1,0 +1,71 @@
+using CosmosToSqlAssessment.Agents;
+
+namespace CosmosToSqlAssessment.Tests.Agents;
+
+/// <summary>
+/// Unit tests for the <see cref="AgentMessage"/> and <see cref="AgentResult"/> value records
+/// and their static factory helpers (#210).
+/// </summary>
+public class AgentMessageAndResultTests
+{
+    [Fact]
+    public void AgentMessage_factories_set_level_and_recent_timestamp()
+    {
+        var before = DateTimeOffset.UtcNow;
+
+        var info = AgentMessage.Info("CosmosAnalyzer", "hello");
+        var warn = AgentMessage.Warning("DataQuality", "careful");
+        var error = AgentMessage.Error("Validator", "broken");
+
+        var after = DateTimeOffset.UtcNow;
+
+        info.Level.Should().Be(AgentMessageLevel.Info);
+        info.AgentName.Should().Be("CosmosAnalyzer");
+        info.Text.Should().Be("hello");
+        info.TimestampUtc.Should().BeOnOrAfter(before).And.BeOnOrBefore(after);
+
+        warn.Level.Should().Be(AgentMessageLevel.Warning);
+        error.Level.Should().Be(AgentMessageLevel.Error);
+    }
+
+    [Fact]
+    public void AgentResult_succeeded_has_no_error()
+    {
+        var result = AgentResult.Succeeded("SqlPlanner", AgentRole.SqlPlanning, TimeSpan.FromSeconds(3));
+
+        result.Status.Should().Be(AgentRunStatus.Succeeded);
+        result.AgentName.Should().Be("SqlPlanner");
+        result.Role.Should().Be(AgentRole.SqlPlanning);
+        result.Error.Should().BeNull();
+        result.Duration.Should().Be(TimeSpan.FromSeconds(3));
+    }
+
+    [Fact]
+    public void AgentResult_failed_carries_error_and_duration()
+    {
+        var result = AgentResult.Failed("CosmosAnalyzer", AgentRole.CosmosAnalysis, "timeout", TimeSpan.FromSeconds(9));
+
+        result.Status.Should().Be(AgentRunStatus.Failed);
+        result.Error.Should().Be("timeout");
+        result.Duration.Should().Be(TimeSpan.FromSeconds(9));
+    }
+
+    [Fact]
+    public void AgentResult_skipped_carries_reason_and_zero_duration()
+    {
+        var result = AgentResult.Skipped("DataQuality", AgentRole.DataQuality, "no cosmos analysis");
+
+        result.Status.Should().Be(AgentRunStatus.Skipped);
+        result.Error.Should().Be("no cosmos analysis");
+        result.Duration.Should().Be(TimeSpan.Zero);
+    }
+
+    [Fact]
+    public void AgentResult_records_are_value_equal()
+    {
+        var a = AgentResult.Succeeded("A", AgentRole.Validation, TimeSpan.FromSeconds(1));
+        var b = AgentResult.Succeeded("A", AgentRole.Validation, TimeSpan.FromSeconds(1));
+
+        a.Should().Be(b);
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Agents/AgentOrchestratorTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Agents/AgentOrchestratorTests.cs
@@ -1,0 +1,224 @@
+using CosmosToSqlAssessment.Agents;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CosmosToSqlAssessment.Tests.Agents;
+
+/// <summary>
+/// Scheduling/coordination tests for <see cref="AgentOrchestrator"/> (#215) using lightweight fake agents,
+/// so the engine (ordering, waves, failure isolation, conditional skip, timeout, graph validation) is tested
+/// independently of the real services. Equivalence and real-service behaviour live in the end-to-end tests.
+/// </summary>
+public class AgentOrchestratorTests
+{
+    private sealed class FakeAgent : AssessmentAgentBase
+    {
+        private readonly List<string> _log;
+        private readonly Func<CancellationToken, Task>? _body;
+        private readonly string? _skipReason;
+
+        public FakeAgent(
+            string name,
+            AgentRole role,
+            IReadOnlyCollection<AgentRole> dependencies,
+            List<string> log,
+            Func<CancellationToken, Task>? body = null,
+            string? skipReason = null)
+        {
+            Name = name;
+            Role = role;
+            Dependencies = dependencies;
+            _log = log;
+            _body = body;
+            _skipReason = skipReason;
+        }
+
+        public override string Name { get; }
+        public override AgentRole Role { get; }
+        public override IReadOnlyCollection<AgentRole> Dependencies { get; }
+
+        protected override string? GetSkipReason(ISharedAssessmentContext context) => _skipReason;
+
+        protected override async Task ExecuteAsync(ISharedAssessmentContext context, CancellationToken cancellationToken)
+        {
+            lock (_log)
+            {
+                _log.Add(Name);
+            }
+
+            if (_body is not null)
+            {
+                await _body(cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static AgentOrchestrator NewOrchestrator(IEnumerable<IAssessmentAgent> agents) =>
+        new(agents, NullLogger<AgentOrchestrator>.Instance);
+
+    private static List<IAssessmentAgent> StandardAgents(
+        List<string> log,
+        Func<CancellationToken, Task>? cosmosBody = null)
+    {
+        return new List<IAssessmentAgent>
+        {
+            new FakeAgent("Cosmos", AgentRole.CosmosAnalysis, Array.Empty<AgentRole>(), log, cosmosBody),
+            new FakeAgent("Sql", AgentRole.SqlPlanning, new[] { AgentRole.CosmosAnalysis }, log),
+            new FakeAgent("DataQuality", AgentRole.DataQuality, new[] { AgentRole.CosmosAnalysis }, log),
+            new FakeAgent("DataFactory", AgentRole.DataFactoryEstimation, new[] { AgentRole.CosmosAnalysis, AgentRole.SqlPlanning }, log),
+            new FakeAgent("Validator", AgentRole.Validation, new[] { AgentRole.CosmosAnalysis, AgentRole.SqlPlanning }, log)
+        };
+    }
+
+    [Fact]
+    public async Task Sequential_runs_in_dependency_priority_order()
+    {
+        var log = new List<string>();
+        var orchestrator = NewOrchestrator(StandardAgents(log));
+
+        await orchestrator.RunAsync("AppDb", "acct",
+            new AgentOrchestrationOptions { Mode = AgentExecutionMode.Sequential });
+
+        log.Should().Equal("Cosmos", "Sql", "DataQuality", "DataFactory", "Validator");
+    }
+
+    [Fact]
+    public async Task Parallel_runs_waves_with_cosmos_first_and_validator_last()
+    {
+        var log = new List<string>();
+        var orchestrator = NewOrchestrator(StandardAgents(log));
+
+        await orchestrator.RunAsync("AppDb", "acct",
+            new AgentOrchestrationOptions { Mode = AgentExecutionMode.Parallel });
+
+        log.Should().HaveCount(5);
+        log[0].Should().Be("Cosmos");                       // wave 0
+        log.IndexOf("Sql").Should().BeLessThan(log.IndexOf("DataFactory")); // DataFactory waits for Sql
+        log.IndexOf("Cosmos").Should().BeLessThan(log.IndexOf("Sql"));
+        log[^1].Should().Be("Validator");                   // validator strictly last
+    }
+
+    [Fact]
+    public async Task Failure_isolation_lets_other_agents_continue()
+    {
+        var log = new List<string>();
+        var agents = StandardAgents(log);
+        agents[1] = new FakeAgent("Sql", AgentRole.SqlPlanning, new[] { AgentRole.CosmosAnalysis }, log,
+            _ => throw new InvalidOperationException("sql boom"));
+        var orchestrator = NewOrchestrator(agents);
+
+        var result = await orchestrator.RunAsync("AppDb", "acct");
+
+        result.AgentResults.Single(r => r.AgentName == "Sql").Status.Should().Be(AgentRunStatus.Failed);
+        result.AgentResults.Single(r => r.AgentName == "Cosmos").Status.Should().Be(AgentRunStatus.Succeeded);
+        // Other agents still ran despite the SQL failure.
+        log.Should().Contain("DataFactory").And.Contain("DataQuality").And.Contain("Validator");
+    }
+
+    [Fact]
+    public async Task Conditional_skips_dependents_when_a_dependency_fails()
+    {
+        var log = new List<string>();
+        var agents = StandardAgents(log, cosmosBody: _ => throw new InvalidOperationException("cosmos boom"));
+        var orchestrator = NewOrchestrator(agents);
+
+        var result = await orchestrator.RunAsync("AppDb", "acct",
+            new AgentOrchestrationOptions { Mode = AgentExecutionMode.Conditional });
+
+        result.AgentResults.Single(r => r.AgentName == "Cosmos").Status.Should().Be(AgentRunStatus.Failed);
+        foreach (var dependent in new[] { "Sql", "DataQuality", "DataFactory" })
+        {
+            var r = result.AgentResults.Single(x => x.AgentName == dependent);
+            r.Status.Should().Be(AgentRunStatus.Skipped);
+            r.Error.Should().Contain("Conditional skip");
+        }
+        // Conditionally-skipped producers never executed; the Validator never skips so it still runs last.
+        log.Should().Equal("Cosmos", "Validator");
+    }
+
+    [Fact]
+    public async Task Per_agent_timeout_records_a_failed_result_and_continues()
+    {
+        var log = new List<string>();
+        var agents = StandardAgents(log,
+            cosmosBody: ct => Task.Delay(TimeSpan.FromSeconds(30), ct));
+        var orchestrator = NewOrchestrator(agents);
+
+        var result = await orchestrator.RunAsync("AppDb", "acct",
+            new AgentOrchestrationOptions
+            {
+                Mode = AgentExecutionMode.Sequential,
+                PerAgentTimeout = TimeSpan.FromMilliseconds(150)
+            });
+
+        var cosmos = result.AgentResults.Single(r => r.AgentName == "Cosmos");
+        cosmos.Status.Should().Be(AgentRunStatus.Failed);
+        cosmos.Error.Should().Contain("Timed out");
+        // Run continued past the timed-out agent.
+        result.AgentResults.Should().Contain(r => r.AgentName == "Validator");
+    }
+
+    [Fact]
+    public async Task Global_cancellation_propagates()
+    {
+        var log = new List<string>();
+        var agents = StandardAgents(log,
+            cosmosBody: ct => { ct.ThrowIfCancellationRequested(); return Task.CompletedTask; });
+        var orchestrator = NewOrchestrator(agents);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var act = async () => await orchestrator.RunAsync("AppDb", "acct", null, cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public void Constructor_rejects_duplicate_role()
+    {
+        var log = new List<string>();
+        var agents = StandardAgents(log);
+        agents.Add(new FakeAgent("Cosmos2", AgentRole.CosmosAnalysis, Array.Empty<AgentRole>(), log));
+
+        var act = () => NewOrchestrator(agents);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*share role*");
+    }
+
+    [Fact]
+    public void Constructor_rejects_duplicate_name()
+    {
+        var log = new List<string>();
+        var agents = StandardAgents(log);
+        // Same name, different (also duplicate-free? no) — use a fresh role to isolate the name check.
+        agents[2] = new FakeAgent("Cosmos", AgentRole.DataQuality, new[] { AgentRole.CosmosAnalysis }, log);
+
+        var act = () => NewOrchestrator(agents);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*unique*");
+    }
+
+    [Fact]
+    public void Constructor_rejects_missing_required_role()
+    {
+        var log = new List<string>();
+        var agents = StandardAgents(log);
+        agents.RemoveAll(a => a.Role == AgentRole.DataFactoryEstimation);
+
+        var act = () => NewOrchestrator(agents);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*required agent role*");
+    }
+
+    [Fact]
+    public void Constructor_rejects_dangling_dependency()
+    {
+        var log = new List<string>();
+        var agents = StandardAgents(log);
+        // Validator depends on a role nobody produces.
+        agents[4] = new FakeAgent("Validator", AgentRole.Validation, new[] { AgentRole.Orchestration }, log);
+
+        var act = () => NewOrchestrator(agents);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*no registered agent produces*");
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Agents/CosmosAnalyzerAgentTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Agents/CosmosAnalyzerAgentTests.cs
@@ -1,0 +1,95 @@
+using CosmosToSqlAssessment.Agents;
+using CosmosToSqlAssessment.Tests.EndToEnd;
+using CosmosToSqlAssessment.Tests.Mocks;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CosmosToSqlAssessment.Tests.Agents;
+
+/// <summary>
+/// Unit tests for <see cref="CosmosAnalyzerAgent"/> and the shared <see cref="AssessmentAgentBase"/>
+/// failure-isolation behaviour (#211). Each agent is exercised in isolation.
+/// </summary>
+public class CosmosAnalyzerAgentTests
+{
+    private static CosmosAnalyzerAgent NewAgent(CosmosDbAnalysisService service) =>
+        new(service, NullLogger<CosmosAnalyzerAgent>.Instance);
+
+    [Fact]
+    public void Metadata_is_stable()
+    {
+        using var fixture = new E2EFixture().WithDatabase("AppDb").Build();
+        var agent = NewAgent(fixture.CosmosService);
+
+        agent.Name.Should().Be("CosmosAnalyzer");
+        agent.Role.Should().Be(AgentRole.CosmosAnalysis);
+        agent.Dependencies.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Run_analyzes_database_and_commits_to_context()
+    {
+        using var fixture = new E2EFixture()
+            .WithDatabase("AppDb", db => db
+                .WithContainer("users", c => c
+                    .WithPartitionKey("/userId").WithThroughput(400)
+                    .WithDocuments(E2ESampleData.TwoUsers.ToArray()))
+                .WithContainer("orders", c => c
+                    .WithPartitionKey("/orderId").WithThroughput(800)
+                    .WithDocuments(E2ESampleData.ThreeOrders.ToArray())))
+            .Build();
+
+        var context = new SharedAssessmentContext("AppDb", "test-account");
+        var agent = NewAgent(fixture.CosmosService);
+
+        var result = await agent.RunAsync(context);
+
+        result.Status.Should().Be(AgentRunStatus.Succeeded);
+        result.Role.Should().Be(AgentRole.CosmosAnalysis);
+        context.HasCosmosAnalysis.Should().BeTrue();
+        context.CosmosAnalysis!.Containers.Should().HaveCount(2);
+        context.GetResult("CosmosAnalyzer")!.Status.Should().Be(AgentRunStatus.Succeeded);
+        context.Messages.Should().Contain(m => m.Text.Contains("Analyzed 2 container"));
+    }
+
+    private static CosmosDbAnalysisService ThrowingService(Exception toThrow)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+        var clientMock = new Mock<CosmosClient>();
+        clientMock.Setup(c => c.GetDatabase(It.IsAny<string>())).Throws(toThrow);
+        return new CosmosDbAnalysisService(config, NullLogger<CosmosDbAnalysisService>.Instance, clientMock.Object);
+    }
+
+    [Fact]
+    public async Task Run_isolates_failure_without_throwing()
+    {
+        var service = ThrowingService(new InvalidOperationException("simulated cosmos outage"));
+        var context = new SharedAssessmentContext("AppDb", "test-account");
+        var agent = NewAgent(service);
+
+        // Must NOT throw — failure isolation.
+        var result = await agent.RunAsync(context);
+
+        result.Status.Should().Be(AgentRunStatus.Failed);
+        result.Error.Should().Contain("simulated cosmos outage");
+        result.Error.Should().Contain("InvalidOperationException");
+        context.HasCosmosAnalysis.Should().BeFalse();
+        context.Messages.Should().Contain(m => m.Level == AgentMessageLevel.Error);
+    }
+
+    [Fact]
+    public async Task Run_propagates_cancellation_and_records_no_failure()
+    {
+        var service = ThrowingService(new OperationCanceledException());
+        var context = new SharedAssessmentContext("AppDb", "test-account");
+        var agent = NewAgent(service);
+
+        var act = async () => await agent.RunAsync(context, CancellationToken.None);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        // Cancellation is not an agent failure: no Failed result recorded.
+        context.GetResult("CosmosAnalyzer").Should().BeNull();
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Agents/DataQualityAgentTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Agents/DataQualityAgentTests.cs
@@ -1,0 +1,86 @@
+using CosmosToSqlAssessment.Agents;
+using CosmosToSqlAssessment.Tests.EndToEnd;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CosmosToSqlAssessment.Tests.Agents;
+
+/// <summary>
+/// Unit tests for <see cref="DataQualityAgent"/> (#213), exercised in isolation against the mock harness.
+/// </summary>
+public class DataQualityAgentTests
+{
+    private static DataQualityAgent NewAgent(DataQualityAnalysisService service) =>
+        new(service, NullLogger<DataQualityAgent>.Instance);
+
+    private static async Task<(E2EFixture Fixture, SharedAssessmentContext Context)> SeededAsync()
+    {
+        var fixture = new E2EFixture()
+            .WithDatabase("AppDb", db => db
+                .WithContainer("users", c => c
+                    .WithPartitionKey("/userId").WithThroughput(400)
+                    .WithDocuments(E2ESampleData.TwoUsers.ToArray())))
+            .Build();
+
+        var context = new SharedAssessmentContext("AppDb", "test-account");
+        var cosmos = await fixture.CosmosService.AnalyzeDatabaseAsync("AppDb");
+        context.SetCosmosAnalysis("CosmosAnalyzer", cosmos);
+        return (fixture, context);
+    }
+
+    [Fact]
+    public void Metadata_is_stable()
+    {
+        using var fixture = new E2EFixture().WithDatabase("AppDb").Build();
+        var agent = NewAgent(fixture.DataQualityService);
+
+        agent.Name.Should().Be("DataQuality");
+        agent.Role.Should().Be(AgentRole.DataQuality);
+        agent.Dependencies.Should().BeEquivalentTo(new[] { AgentRole.CosmosAnalysis });
+    }
+
+    [Fact]
+    public async Task Run_analyzes_quality_when_cosmos_analysis_present()
+    {
+        var (fixture, context) = await SeededAsync();
+        using var _ = fixture;
+        var agent = NewAgent(fixture.DataQualityService);
+
+        var result = await agent.RunAsync(context);
+
+        result.Status.Should().Be(AgentRunStatus.Succeeded);
+        context.HasDataQualityAnalysis.Should().BeTrue();
+        context.DataQualityAnalysis.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Run_skips_when_cosmos_analysis_missing_and_stays_optional()
+    {
+        using var fixture = new E2EFixture().WithDatabase("AppDb").Build();
+        var context = new SharedAssessmentContext("AppDb", "test-account");
+        var agent = NewAgent(fixture.DataQualityService);
+
+        var result = await agent.RunAsync(context);
+
+        result.Status.Should().Be(AgentRunStatus.Skipped);
+        result.Error.Should().Contain("Cosmos analysis is not available");
+        context.HasDataQualityAnalysis.Should().BeFalse();
+        // Optional output: a skipped data-quality run must NOT make the run incomplete.
+        context.GetMissingRequiredOutputs().Should().NotContain("DataQualityAnalysis");
+    }
+
+    [Fact]
+    public async Task Run_isolates_failure_without_throwing()
+    {
+        var (fixture, context) = await SeededAsync();
+        using var _ = fixture;
+        // Pre-set the data-quality output so the agent's final write-once commit throws,
+        // deterministically exercising the base failure-isolation path through the real agent.
+        context.SetDataQualityAnalysis("Intruder", new DataQualityAnalysis());
+        var agent = NewAgent(fixture.DataQualityService);
+
+        var result = await agent.RunAsync(context);
+
+        result.Status.Should().Be(AgentRunStatus.Failed);
+        result.Error.Should().Contain("InvalidOperationException");
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Agents/SharedAssessmentContextTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Agents/SharedAssessmentContextTests.cs
@@ -1,0 +1,210 @@
+using CosmosToSqlAssessment.Agents;
+
+namespace CosmosToSqlAssessment.Tests.Agents;
+
+/// <summary>
+/// Unit tests for the foundational agent communication contract introduced in #210:
+/// <see cref="SharedAssessmentContext"/>, <see cref="AgentMessage"/>, and <see cref="AgentResult"/>.
+/// </summary>
+public class SharedAssessmentContextTests
+{
+    private static SharedAssessmentContext NewContext() => new("AppDb", "test-account");
+
+    [Fact]
+    public void Constructor_rejects_empty_database_name()
+    {
+        var act = () => new SharedAssessmentContext("", "acct");
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Constructor_tolerates_null_account_name()
+    {
+        var context = new SharedAssessmentContext("AppDb", null!);
+        context.CosmosAccountName.Should().BeEmpty();
+        context.DatabaseName.Should().Be("AppDb");
+    }
+
+    [Fact]
+    public void Domain_outputs_round_trip_and_flip_has_flags()
+    {
+        var context = NewContext();
+
+        context.HasCosmosAnalysis.Should().BeFalse();
+        context.HasSqlAssessment.Should().BeFalse();
+        context.HasDataQualityAnalysis.Should().BeFalse();
+        context.HasDataFactoryEstimate.Should().BeFalse();
+
+        var cosmos = new CosmosDbAnalysis();
+        var sql = new SqlMigrationAssessment();
+        var quality = new DataQualityAnalysis();
+        var estimate = new DataFactoryEstimate();
+
+        context.SetCosmosAnalysis("CosmosAnalyzer", cosmos);
+        context.SetSqlAssessment("SqlPlanner", sql);
+        context.SetDataQualityAnalysis("DataQuality", quality);
+        context.SetDataFactoryEstimate("Orchestrator", estimate);
+
+        context.CosmosAnalysis.Should().BeSameAs(cosmos);
+        context.SqlAssessment.Should().BeSameAs(sql);
+        context.DataQualityAnalysis.Should().BeSameAs(quality);
+        context.DataFactoryEstimate.Should().BeSameAs(estimate);
+
+        context.HasCosmosAnalysis.Should().BeTrue();
+        context.HasSqlAssessment.Should().BeTrue();
+        context.HasDataQualityAnalysis.Should().BeTrue();
+        context.HasDataFactoryEstimate.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Setting_a_domain_output_twice_throws()
+    {
+        var context = NewContext();
+        context.SetCosmosAnalysis("CosmosAnalyzer", new CosmosDbAnalysis());
+
+        var act = () => context.SetCosmosAnalysis("Rogue", new CosmosDbAnalysis());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*already been set*Rogue*");
+    }
+
+    [Fact]
+    public void Set_methods_reject_null_output()
+    {
+        var context = NewContext();
+        var act = () => context.SetSqlAssessment("SqlPlanner", null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Missing_required_outputs_excludes_optional_data_quality()
+    {
+        var context = NewContext();
+
+        context.GetMissingRequiredOutputs()
+            .Should().BeEquivalentTo(new[] { "CosmosAnalysis", "SqlAssessment", "DataFactoryEstimate" });
+        context.IsCompleteForAssessmentResult().Should().BeFalse();
+
+        context.SetCosmosAnalysis("CosmosAnalyzer", new CosmosDbAnalysis());
+        context.SetSqlAssessment("SqlPlanner", new SqlMigrationAssessment());
+        context.SetDataFactoryEstimate("Orchestrator", new DataFactoryEstimate());
+
+        // Data quality intentionally not set — it is optional.
+        context.GetMissingRequiredOutputs().Should().BeEmpty();
+        context.IsCompleteForAssessmentResult().Should().BeTrue();
+    }
+
+    [Fact]
+    public void Messages_returns_ordered_immutable_snapshot()
+    {
+        var context = NewContext();
+
+        context.LogInfo("CosmosAnalyzer", "starting");
+        context.LogWarning("DataQuality", "skipped");
+        context.LogError("Validator", "incomplete");
+
+        var snapshot = context.Messages;
+        snapshot.Should().HaveCount(3);
+        snapshot[0].Level.Should().Be(AgentMessageLevel.Info);
+        snapshot[1].Level.Should().Be(AgentMessageLevel.Warning);
+        snapshot[2].Level.Should().Be(AgentMessageLevel.Error);
+
+        // Snapshot is detached: further writes do not mutate an already-returned list.
+        context.LogInfo("CosmosAnalyzer", "more");
+        snapshot.Should().HaveCount(3);
+        context.Messages.Should().HaveCount(4);
+    }
+
+    [Fact]
+    public void Results_record_and_lookup_by_name_and_role()
+    {
+        var context = NewContext();
+
+        context.RecordResult(AgentResult.Succeeded("CosmosAnalyzer", AgentRole.CosmosAnalysis, TimeSpan.FromSeconds(1)));
+        context.RecordResult(AgentResult.Failed("DataQuality", AgentRole.DataQuality, "boom", TimeSpan.FromSeconds(2)));
+
+        context.GetResult("CosmosAnalyzer")!.Status.Should().Be(AgentRunStatus.Succeeded);
+        context.GetResult("DataQuality")!.Status.Should().Be(AgentRunStatus.Failed);
+        context.GetResult("Nope").Should().BeNull();
+
+        context.HasSucceeded(AgentRole.CosmosAnalysis).Should().BeTrue();
+        context.HasSucceeded(AgentRole.DataQuality).Should().BeFalse();
+        context.HasSucceeded(AgentRole.SqlPlanning).Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetResult_returns_latest_recorded_for_name()
+    {
+        var context = NewContext();
+        context.RecordResult(AgentResult.Skipped("Validator", AgentRole.Validation, "deps missing"));
+        context.RecordResult(AgentResult.Succeeded("Validator", AgentRole.Validation, TimeSpan.Zero));
+
+        context.GetResult("Validator")!.Status.Should().Be(AgentRunStatus.Succeeded);
+    }
+
+    [Fact]
+    public void ToAssessmentResult_is_best_effort_with_defaults()
+    {
+        var context = NewContext();
+        var result = context.ToAssessmentResult();
+
+        result.DatabaseName.Should().Be("AppDb");
+        result.CosmosAccountName.Should().Be("test-account");
+        result.CosmosAnalysis.Should().NotBeNull();
+        result.SqlAssessment.Should().NotBeNull();
+        result.DataFactoryEstimate.Should().NotBeNull();
+        result.DataQualityAnalysis.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToAssessmentResult_carries_committed_outputs()
+    {
+        var context = NewContext();
+        var cosmos = new CosmosDbAnalysis();
+        var quality = new DataQualityAnalysis();
+        context.SetCosmosAnalysis("CosmosAnalyzer", cosmos);
+        context.SetDataQualityAnalysis("DataQuality", quality);
+
+        var result = context.ToAssessmentResult();
+
+        result.CosmosAnalysis.Should().BeSameAs(cosmos);
+        result.DataQualityAnalysis.Should().BeSameAs(quality);
+    }
+
+    [Fact]
+    public async Task Concurrent_writers_do_not_lose_messages_or_results()
+    {
+        var context = NewContext();
+        const int writers = 16;
+        const int perWriter = 250;
+
+        var tasks = Enumerable.Range(0, writers).Select(w => Task.Run(() =>
+        {
+            for (var i = 0; i < perWriter; i++)
+            {
+                context.LogInfo($"agent-{w}", $"msg-{i}");
+                context.RecordResult(AgentResult.Succeeded($"agent-{w}-{i}", AgentRole.CosmosAnalysis, TimeSpan.Zero));
+            }
+        })).ToArray();
+
+        await Task.WhenAll(tasks);
+
+        context.Messages.Should().HaveCount(writers * perWriter);
+        context.Results.Should().HaveCount(writers * perWriter);
+    }
+
+    [Fact]
+    public async Task Concurrent_distinct_output_writes_all_succeed()
+    {
+        var context = NewContext();
+
+        await Task.WhenAll(
+            Task.Run(() => context.SetCosmosAnalysis("CosmosAnalyzer", new CosmosDbAnalysis())),
+            Task.Run(() => context.SetSqlAssessment("SqlPlanner", new SqlMigrationAssessment())),
+            Task.Run(() => context.SetDataQualityAnalysis("DataQuality", new DataQualityAnalysis())),
+            Task.Run(() => context.SetDataFactoryEstimate("Orchestrator", new DataFactoryEstimate())));
+
+        context.IsCompleteForAssessmentResult().Should().BeTrue();
+        context.HasDataQualityAnalysis.Should().BeTrue();
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Agents/SqlPlannerAgentTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Agents/SqlPlannerAgentTests.cs
@@ -1,0 +1,89 @@
+using CosmosToSqlAssessment.Agents;
+using CosmosToSqlAssessment.Tests.EndToEnd;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CosmosToSqlAssessment.Tests.Agents;
+
+/// <summary>
+/// Unit tests for <see cref="SqlPlannerAgent"/> (#212), exercised in isolation against the mock harness.
+/// </summary>
+public class SqlPlannerAgentTests
+{
+    private static SqlPlannerAgent NewAgent(SqlMigrationAssessmentService service) =>
+        new(service, NullLogger<SqlPlannerAgent>.Instance);
+
+    private static async Task<(E2EFixture Fixture, SharedAssessmentContext Context)> SeededAsync()
+    {
+        var fixture = new E2EFixture()
+            .WithDatabase("AppDb", db => db
+                .WithContainer("users", c => c
+                    .WithPartitionKey("/userId").WithThroughput(400)
+                    .WithDocuments(E2ESampleData.TwoUsers.ToArray()))
+                .WithContainer("orders", c => c
+                    .WithPartitionKey("/orderId").WithThroughput(800)
+                    .WithDocuments(E2ESampleData.ThreeOrders.ToArray())))
+            .Build();
+
+        var context = new SharedAssessmentContext("AppDb", "test-account");
+        var cosmos = await fixture.CosmosService.AnalyzeDatabaseAsync("AppDb");
+        context.SetCosmosAnalysis("CosmosAnalyzer", cosmos);
+        return (fixture, context);
+    }
+
+    [Fact]
+    public void Metadata_is_stable()
+    {
+        using var fixture = new E2EFixture().WithDatabase("AppDb").Build();
+        var agent = NewAgent(fixture.SqlAssessmentService);
+
+        agent.Name.Should().Be("SqlPlanner");
+        agent.Role.Should().Be(AgentRole.SqlPlanning);
+        agent.Dependencies.Should().BeEquivalentTo(new[] { AgentRole.CosmosAnalysis });
+    }
+
+    [Fact]
+    public async Task Run_plans_migration_when_cosmos_analysis_present()
+    {
+        var (fixture, context) = await SeededAsync();
+        using var _ = fixture;
+        var agent = NewAgent(fixture.SqlAssessmentService);
+
+        var result = await agent.RunAsync(context);
+
+        result.Status.Should().Be(AgentRunStatus.Succeeded);
+        context.HasSqlAssessment.Should().BeTrue();
+        context.SqlAssessment!.DatabaseMappings.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task Run_skips_when_cosmos_analysis_missing()
+    {
+        using var fixture = new E2EFixture().WithDatabase("AppDb").Build();
+        var context = new SharedAssessmentContext("AppDb", "test-account");
+        var agent = NewAgent(fixture.SqlAssessmentService);
+
+        var result = await agent.RunAsync(context);
+
+        result.Status.Should().Be(AgentRunStatus.Skipped);
+        result.Error.Should().Contain("Cosmos analysis is not available");
+        context.HasSqlAssessment.Should().BeFalse();
+        context.GetResult("SqlPlanner")!.Status.Should().Be(AgentRunStatus.Skipped);
+    }
+
+    [Fact]
+    public async Task Run_isolates_failure_without_throwing()
+    {
+        var (fixture, context) = await SeededAsync();
+        using var _ = fixture;
+        // Pre-set the SQL assessment so the agent's final write-once commit throws,
+        // deterministically exercising the base failure-isolation path through the real agent.
+        context.SetSqlAssessment("Intruder", new SqlMigrationAssessment());
+        var agent = NewAgent(fixture.SqlAssessmentService);
+
+        var result = await agent.RunAsync(context);
+
+        result.Status.Should().Be(AgentRunStatus.Failed);
+        result.Error.Should().Contain("InvalidOperationException");
+        context.Messages.Should().Contain(m => m.Level == AgentMessageLevel.Error);
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Agents/ValidatorAgentTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Agents/ValidatorAgentTests.cs
@@ -1,0 +1,198 @@
+using CosmosToSqlAssessment.Agents;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CosmosToSqlAssessment.Tests.Agents;
+
+/// <summary>
+/// Unit tests for <see cref="ValidatorAgent"/> (#214): completeness, consistency cross-checks,
+/// diagnostic-only handling of optional/failed outputs, hardening, and the write-once verdict.
+/// </summary>
+public class ValidatorAgentTests
+{
+    private static ValidatorAgent NewAgent() => new(NullLogger<ValidatorAgent>.Instance);
+
+    private static CosmosDbAnalysis Cosmos(params string[] containerNames) => new()
+    {
+        DatabaseMetrics = new DatabaseMetrics { ContainerCount = containerNames.Length },
+        Containers = containerNames.Select(n => new ContainerAnalysis { ContainerName = n }).ToList()
+    };
+
+    private static SqlMigrationAssessment Sql(params string[] sourceContainers) => new()
+    {
+        DatabaseMappings = new List<DatabaseMapping>
+        {
+            new()
+            {
+                ContainerMappings = sourceContainers
+                    .Select(c => new ContainerMapping { SourceContainer = c, TargetTable = c })
+                    .ToList()
+            }
+        }
+    };
+
+    private static SharedAssessmentContext FullyPopulated()
+    {
+        var context = new SharedAssessmentContext("AppDb", "test-account");
+        context.SetCosmosAnalysis("CosmosAnalyzer", Cosmos("users"));
+        context.SetSqlAssessment("SqlPlanner", Sql("users"));
+        context.SetDataFactoryEstimate("Orchestrator", new DataFactoryEstimate());
+        return context;
+    }
+
+    [Fact]
+    public void Metadata_is_stable_and_does_not_depend_on_optional_data_quality()
+    {
+        var agent = NewAgent();
+
+        agent.Name.Should().Be("Validator");
+        agent.Role.Should().Be(AgentRole.Validation);
+        agent.Dependencies.Should().BeEquivalentTo(new[] { AgentRole.CosmosAnalysis, AgentRole.SqlPlanning });
+        agent.Dependencies.Should().NotContain(AgentRole.DataQuality);
+    }
+
+    [Fact]
+    public async Task Acceptable_when_all_required_outputs_present_and_consistent()
+    {
+        var context = FullyPopulated();
+
+        var result = await NewAgent().RunAsync(context);
+
+        result.Status.Should().Be(AgentRunStatus.Succeeded);
+        context.HasValidationReport.Should().BeTrue();
+        var report = context.ValidationReport!;
+        report.IsComplete.Should().BeTrue();
+        report.IsConsistent.Should().BeTrue();
+        report.IsAcceptable.Should().BeTrue();
+        report.MissingRequiredOutputs.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Missing_required_output_flags_incomplete_but_agent_still_succeeds()
+    {
+        var context = new SharedAssessmentContext("AppDb", "test-account");
+        context.SetCosmosAnalysis("CosmosAnalyzer", Cosmos("users"));
+        // No SqlAssessment, no DataFactoryEstimate.
+
+        var result = await NewAgent().RunAsync(context);
+
+        result.Status.Should().Be(AgentRunStatus.Succeeded); // finding problems is a successful validation
+        var report = context.ValidationReport!;
+        report.IsComplete.Should().BeFalse();
+        report.IsAcceptable.Should().BeFalse();
+        report.MissingRequiredOutputs.Should().Contain("SqlAssessment").And.Contain("DataFactoryEstimate");
+        report.Findings.Should().Contain(f =>
+            f.Check == ValidatorAgent.CheckMissingRequiredOutput && f.Level == AgentMessageLevel.Error);
+    }
+
+    [Fact]
+    public async Task Unmapped_cosmos_container_makes_run_inconsistent()
+    {
+        var context = new SharedAssessmentContext("AppDb", "test-account");
+        context.SetCosmosAnalysis("CosmosAnalyzer", Cosmos("users", "orders"));
+        context.SetSqlAssessment("SqlPlanner", Sql("users")); // 'orders' has no mapping
+        context.SetDataFactoryEstimate("Orchestrator", new DataFactoryEstimate());
+
+        await NewAgent().RunAsync(context);
+
+        var report = context.ValidationReport!;
+        report.IsComplete.Should().BeTrue();
+        report.IsConsistent.Should().BeFalse();
+        report.IsAcceptable.Should().BeFalse();
+        report.Findings.Should().Contain(f =>
+            f.Check == ValidatorAgent.CheckUnmappedCosmosContainer
+            && f.Category == ValidationFindingCategory.Consistency
+            && f.Level == AgentMessageLevel.Error);
+    }
+
+    [Fact]
+    public async Task Failed_agent_and_missing_optional_data_quality_are_diagnostic_only()
+    {
+        var context = FullyPopulated();
+        context.RecordResult(AgentResult.Failed("SomeOptionalAgent", AgentRole.DataQuality, "boom", TimeSpan.Zero));
+
+        await NewAgent().RunAsync(context);
+
+        var report = context.ValidationReport!;
+        report.FailedAgents.Should().Contain("SomeOptionalAgent");
+        report.DataQualityAvailable.Should().BeFalse();
+        // Diagnostic findings must not flip the verdict.
+        report.IsAcceptable.Should().BeTrue();
+        report.Findings.Should().Contain(f => f.Check == ValidatorAgent.CheckDataQualityUnavailable);
+        report.Findings.Should().Contain(f => f.Check == ValidatorAgent.CheckAgentFailed);
+    }
+
+    [Fact]
+    public async Task Reports_data_quality_available_when_present()
+    {
+        var context = FullyPopulated();
+        context.SetDataQualityAnalysis("DataQuality", new DataQualityAnalysis());
+
+        await NewAgent().RunAsync(context);
+
+        var report = context.ValidationReport!;
+        report.DataQualityAvailable.Should().BeTrue();
+        report.Findings.Should().Contain(f => f.Check == ValidatorAgent.CheckDataQualityAvailable);
+    }
+
+    [Fact]
+    public async Task Hardened_against_null_collections_and_still_emits_report()
+    {
+        var context = new SharedAssessmentContext("AppDb", "test-account");
+        var cosmos = new CosmosDbAnalysis
+        {
+            DatabaseMetrics = new DatabaseMetrics { ContainerCount = 1 },
+            Containers = new List<ContainerAnalysis> { new() { ContainerName = "users" } }
+        };
+        var sql = new SqlMigrationAssessment { DatabaseMappings = null! }; // malformed: null mappings
+        context.SetCosmosAnalysis("CosmosAnalyzer", cosmos);
+        context.SetSqlAssessment("SqlPlanner", sql);
+        context.SetDataFactoryEstimate("Orchestrator", new DataFactoryEstimate());
+
+        var result = await NewAgent().RunAsync(context);
+
+        result.Status.Should().Be(AgentRunStatus.Succeeded); // no crash
+        context.HasValidationReport.Should().BeTrue();
+        var report = context.ValidationReport!;
+        // 'users' is unmapped because there were no mappings at all -> consistency error, not a crash.
+        report.IsConsistent.Should().BeFalse();
+        report.Findings.Should().Contain(f => f.Check == ValidatorAgent.CheckUnmappedCosmosContainer);
+    }
+
+    [Fact]
+    public async Task Container_count_mismatch_is_a_soft_warning_only()
+    {
+        var context = new SharedAssessmentContext("AppDb", "test-account");
+        var cosmos = new CosmosDbAnalysis
+        {
+            DatabaseMetrics = new DatabaseMetrics { ContainerCount = 5 }, // disagrees with the 1 analyzed
+            Containers = new List<ContainerAnalysis> { new() { ContainerName = "users" } }
+        };
+        context.SetCosmosAnalysis("CosmosAnalyzer", cosmos);
+        context.SetSqlAssessment("SqlPlanner", Sql("users"));
+        context.SetDataFactoryEstimate("Orchestrator", new DataFactoryEstimate());
+
+        await NewAgent().RunAsync(context);
+
+        var report = context.ValidationReport!;
+        report.Findings.Should().Contain(f =>
+            f.Check == ValidatorAgent.CheckContainerCountMismatch && f.Level == AgentMessageLevel.Warning);
+        // Warning-level consistency findings must not make the run inconsistent on their own.
+        report.IsConsistent.Should().BeTrue();
+        report.IsAcceptable.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Validation_is_single_run_per_context()
+    {
+        var context = FullyPopulated();
+        var agent = NewAgent();
+
+        var first = await agent.RunAsync(context);
+        var second = await agent.RunAsync(context);
+
+        first.Status.Should().Be(AgentRunStatus.Succeeded);
+        // Second run hits the write-once guard on SetValidationReport -> isolated as a failed result.
+        second.Status.Should().Be(AgentRunStatus.Failed);
+        second.Error.Should().Contain("InvalidOperationException");
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Cli/CliArgumentParserTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Cli/CliArgumentParserTests.cs
@@ -118,6 +118,39 @@ public class CliArgumentParserTests
         options!.Interactive.Should().BeTrue();
     }
 
+    [Theory]
+    [InlineData("--agentic")]
+    [InlineData("--AGENTIC")]
+    public void Parse_AgenticFlag_SetsAgentic(string flag)
+    {
+        var options = CliArgumentParser.Parse(new[] { flag }, new StringWriter());
+
+        options.Should().NotBeNull();
+        options!.Agentic.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Parse_DefaultOptions_AgenticIsFalse()
+    {
+        var options = CliArgumentParser.Parse(Array.Empty<string>(), new StringWriter());
+
+        options!.Agentic.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parse_AgenticWithSiblingFlags_KeepsAllFlags()
+    {
+        // Guards against a rebase/merge accidentally dropping a sibling's flag: --skip-auto-discovery
+        // (#76), --interactive (#71) and --agentic (#131) must all survive together.
+        var options = CliArgumentParser.Parse(
+            new[] { "--skip-auto-discovery", "--interactive", "--agentic" }, new StringWriter());
+
+        options.Should().NotBeNull();
+        options!.SkipAutoDiscovery.Should().BeTrue();
+        options.Interactive.Should().BeTrue();
+        options.Agentic.Should().BeTrue();
+    }
+
     // ---- Parse: value-taking flags -----------------------------------------
 
     [Theory]
@@ -332,6 +365,7 @@ public class CliArgumentParserTests
         text.Should().Contain("--project-only");
         text.Should().Contain("--test-connection");
         text.Should().Contain("--interactive");
+        text.Should().Contain("--agentic");
         text.Should().Contain("Examples:");
     }
 }

--- a/tests/CosmosToSqlAssessment.Tests/EndToEnd/AgentEquivalenceTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/EndToEnd/AgentEquivalenceTests.cs
@@ -1,0 +1,131 @@
+using CosmosToSqlAssessment.Agents;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CosmosToSqlAssessment.Tests.EndToEnd;
+
+/// <summary>
+/// End-to-end equivalence tests for the agentic pipeline (#215): the <see cref="AgentOrchestrator"/> driving
+/// the real production services (via the mock harness) must produce output equivalent to the single-pass
+/// <see cref="E2EFixture.RunAssessmentAsync"/> baseline. This is the acceptance regression for parent #131.
+/// </summary>
+public class AgentEquivalenceTests
+{
+    private static E2EFixture BuildFixture() => new E2EFixture()
+        .WithDatabase("AppDb", db => db
+            .WithContainer("users", c => c
+                .WithPartitionKey("/userId").WithThroughput(400)
+                .WithDocuments(E2ESampleData.TwoUsers.ToArray()))
+            .WithContainer("orders", c => c
+                .WithPartitionKey("/orderId").WithThroughput(800)
+                .WithDocuments(E2ESampleData.ThreeOrders.ToArray())))
+        .Build();
+
+    private static List<IAssessmentAgent> AgentsFor(E2EFixture fixture, bool includeDataQuality = true)
+    {
+        var agents = new List<IAssessmentAgent>
+        {
+            new CosmosAnalyzerAgent(fixture.CosmosService, NullLogger<CosmosAnalyzerAgent>.Instance),
+            new SqlPlannerAgent(fixture.SqlAssessmentService, NullLogger<SqlPlannerAgent>.Instance),
+            new DataFactoryEstimatorAgent(fixture.DataFactoryService, NullLogger<DataFactoryEstimatorAgent>.Instance),
+            new ValidatorAgent(NullLogger<ValidatorAgent>.Instance)
+        };
+
+        if (includeDataQuality)
+        {
+            agents.Add(new DataQualityAgent(fixture.DataQualityService, NullLogger<DataQualityAgent>.Instance));
+        }
+
+        return agents;
+    }
+
+    private static AgentOrchestrator OrchestratorFor(E2EFixture fixture, bool includeDataQuality = true) =>
+        new(AgentsFor(fixture, includeDataQuality), NullLogger<AgentOrchestrator>.Instance);
+
+    [Fact]
+    public async Task Agentic_sequential_mode_is_equivalent_to_single_pass()
+    {
+        // Two independent fixtures with identical sample data so each path reads fresh mocks.
+        using var baselineFixture = BuildFixture();
+        using var agenticFixture = BuildFixture();
+
+        var baseline = await baselineFixture.RunAssessmentAsync("AppDb");
+
+        var run = await OrchestratorFor(agenticFixture).RunAsync(
+            "AppDb", "test-account",
+            new AgentOrchestrationOptions { Mode = AgentExecutionMode.Sequential });
+
+        run.AssessmentResult.Should().BeEquivalentTo(baseline, opts => opts.Excluding(m =>
+            m.Name == "AssessmentId" ||
+            m.Name == "AssessmentDate" ||
+            m.Name == "AnalysisDate" ||
+            m.Name == "IssueId"));
+    }
+
+    [Fact]
+    public async Task Agentic_parallel_mode_is_equivalent_to_single_pass()
+    {
+        using var baselineFixture = BuildFixture();
+        using var agenticFixture = BuildFixture();
+
+        var baseline = await baselineFixture.RunAssessmentAsync("AppDb");
+
+        var run = await OrchestratorFor(agenticFixture).RunAsync(
+            "AppDb", "test-account",
+            new AgentOrchestrationOptions { Mode = AgentExecutionMode.Parallel });
+
+        run.AssessmentResult.Should().BeEquivalentTo(baseline, opts => opts.Excluding(m =>
+            m.Name == "AssessmentId" ||
+            m.Name == "AssessmentDate" ||
+            m.Name == "AnalysisDate" ||
+            m.Name == "IssueId"));
+    }
+
+    [Fact]
+    public async Task Complete_run_is_acceptable_and_maps_every_container()
+    {
+        using var fixture = BuildFixture();
+
+        var run = await OrchestratorFor(fixture).RunAsync("AppDb", "test-account");
+
+        run.IsAcceptable.Should().BeTrue();
+        run.Validation.Should().NotBeNull();
+        run.Validation!.IsComplete.Should().BeTrue();
+        run.Validation.IsConsistent.Should().BeTrue();
+        run.Validation.DataQualityAvailable.Should().BeTrue();
+        // Both containers were produced and mapped (no unmapped-container findings).
+        run.Validation.Findings.Should().NotContain(f => f.Check == ValidatorAgent.CheckUnmappedCosmosContainer);
+        run.AssessmentResult.CosmosAnalysis.Containers.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task Run_without_optional_data_quality_agent_is_still_acceptable()
+    {
+        using var fixture = BuildFixture();
+
+        var run = await OrchestratorFor(fixture, includeDataQuality: false).RunAsync("AppDb", "test-account");
+
+        run.IsAcceptable.Should().BeTrue();             // data quality is optional
+        run.Validation!.DataQualityAvailable.Should().BeFalse();
+        run.AssessmentResult.DataQualityAnalysis.Should().BeNull();
+        // Required outputs are all present.
+        run.Validation.MissingRequiredOutputs.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Every_agent_records_a_result_for_observability()
+    {
+        using var fixture = BuildFixture();
+
+        var run = await OrchestratorFor(fixture).RunAsync("AppDb", "test-account");
+
+        run.AgentResults.Select(r => r.AgentName).Should().Contain(new[]
+        {
+            CosmosAnalyzerAgent.AgentName,
+            SqlPlannerAgent.AgentName,
+            DataQualityAgent.AgentName,
+            DataFactoryEstimatorAgent.AgentName,
+            ValidatorAgent.AgentName
+        });
+        run.AgentResults.Should().OnlyContain(r => r.Status == AgentRunStatus.Succeeded);
+    }
+}


### PR DESCRIPTION
Closes #131

Foundation of the M4 agentic-intelligence epic (#130). Introduces a multi-agent orchestration layer that wraps the existing assessment services (`CosmosDbAnalysisService`, `SqlMigrationAssessmentService`, `DataQualityAnalysisService`) behind a stable `AgentOrchestrator` + `SharedAssessmentContext` contract that sub-issues #132/#133/#69 will build on.

## Sub-issues
- [x] #210 Design agent communication contract (message types, shared context shape)
- [x] #211 Implement `CosmosAnalyzerAgent` wrapping `CosmosDbAnalysisService`
- [x] #212 Implement `SqlPlannerAgent` wrapping `SqlMigrationAssessmentService`
- [x] #213 Implement `DataQualityAgent` wrapping `DataQualityAnalysisService`
- [x] #214 Implement `ValidatorAgent` that cross-checks outputs from other agents
- [x] #215 Implement `AgentOrchestrator` for coordination (sequential, parallel, conditional)
- [x] #216 Update CLI to support `--agentic` mode flag
- [x] #217 Document agent architecture in `docs/architecture.md`

## Implementation approach
New `CosmosToSqlAssessment.Agents` namespace (all types `public`, fully XML-documented):
- **`IAssessmentAgent`** — stable agent abstraction: `Name`, `Role`, `Dependencies`, `RunAsync(ISharedAssessmentContext, CancellationToken)`.
- **`AssessmentAgentBase`** — shared failure-isolation: times runs, records results, converts exceptions to `Failed` results (other agents keep running), **rethrows** `OperationCanceledException` (Ctrl+C → exit 130), and offers a `GetSkipReason` hook for conditional/dependency skipping.
- **`ISharedAssessmentContext` / `SharedAssessmentContext`** — thread-safe blackboard (single private lock). Write-once domain outputs (`Set*`), message + result logs, completeness checks (`GetMissingRequiredOutputs`, `IsCompleteForAssessmentResult`), a write-once `ValidationReport` slot, and `ToAssessmentResult()` so the **unchanged** downstream report/SQL-project/Data-Factory generation is reused (drives equivalence).
- **Agents**: `CosmosAnalyzerAgent` (root), `SqlPlannerAgent`, `DataQualityAgent` (optional), `ValidatorAgent` (cross-checks, never skips), plus an internal `DataFactoryEstimatorAgent`. Each wraps an existing service without changing its signature.
- **`AgentOrchestrator`** — one scheduling engine driving three modes (Sequential / Parallel / Conditional) over the agent dependency graph, with up-front graph validation, per-agent cooperative timeout, and failure isolation. Returns immutable `AgentOrchestrationResult` snapshots (never the live mutable context).
- **CLI**: a `--agentic` flag (`CliOptions.Agentic`, carried via `UserInputs.UseAgentic`) routes each database's assessment through the `AgentOrchestrator` (a child DI scope per database, explicit Sequential mode) and reuses the unchanged report/SQL-project generation. Failure parity is preserved by gating the fatal path on **completeness** (`ValidationReport.IsComplete`), so consistency-only findings and optional data-quality failures stay non-fatal — exactly like single-pass.
- **`AgentMessage` / `AgentResult` / `ValidationReport` / `ValidationFinding`** records; **`AgentRole` / `AgentMessageLevel` / `AgentRunStatus` / `AgentExecutionMode` / `ValidationFindingCategory`** enums.
- **Docs**: `docs/architecture.md` gains an *Agentic Mode* section (stable contract, dependency graph, three execution modes with mermaid sequence diagrams, failure isolation, equivalence guarantee, CLI usage, extensibility) alongside the existing layered overview.

Agents own one domain and communicate only through the shared context. Required-output absence (`CosmosAnalysis`/`SqlAssessment`/`DataFactoryEstimate`) makes the run incomplete; DataQuality skip/fail stays diagnostic only (matches single-pass non-fatal behaviour). The `ValidatorAgent` always runs and emits a typed verdict so failures are recoverable and surfaced.

## Testing
- Baseline at branch point: build clean, 659 tests passing (main test project).
- **#210**: +18 unit tests (contract, concurrency, single-assignment guards).
- **#211**: +4 tests (`CosmosAnalyzerAgent`: happy path, failure isolation, cancellation propagation, metadata).
- **#212**: +4 tests (`SqlPlannerAgent`: happy path, skip-on-missing-dependency, failure isolation, metadata).
- **#213**: +4 tests (`DataQualityAgent`: happy path, skip-on-missing-Cosmos stays optional, failure isolation, metadata).
- **#214**: +9 tests (`ValidatorAgent`: completeness/consistency verdicts, unmapped-container detection, hardened error path, never-skip).
- **#215**: +11 scheduling tests (fake agents: ordering, parallel waves, failure isolation, conditional skip, timeout, graph validation) and +5 end-to-end equivalence/acceptance tests asserting **agentic output == single-pass output** (Sequential & Parallel), complete runs are acceptable, and optional data quality can be omitted.
- **#216**: +4 CLI parser tests (flag set incl. case-insensitive, default false, **all sibling flags preserved** together, help text).
- Main test project now **717 passing**; full solution green.

## Branch-protection changes
_None introduced._