### PR TITLE
perf(#234): widen mean tolerance for GC-noisy BufferedRetainAllPattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,12 +453,14 @@ axis** in `baselines/baseline.json`:
 Allocations are effectively deterministic on the runner (observed run-to-run
 drift < 0.01%), so allocation stays pinned at the strict `1.10` default for
 **every** benchmark — including the ones below. Only the noisier **mean** axis is
-widened, for the two I/O-bound macro-benchmarks:
+widened, for the I/O-bound macro-benchmarks and the GC-heavy memory-profile
+patterns whose meaningful signal is allocation rather than wall-clock:
 
 | Benchmark (all sizes) | `meanToleranceFactor` | Why |
 |---|---|---|
-| `ReportGenerationBenchmarks.GenerateAssessmentReportAsync_EndToEnd` | `1.50` | Writes 4.4 MB → 343 MB to disk; wall-clock swings with runner I/O contention. |
-| `SqlAssessmentBenchmarks.AssessMigrationAsync_EndToEnd` | `1.20` | 8-phase orchestration macro; moderate timing variance. |
+| `ReportGenerationBenchmarks.GenerateAssessmentReportAsync_EndToEnd` | `1.50` | Writes 4.4 MB → 343 MB to disk; wall-clock swings with runner I/O contention (observed spread ≈ 1.19×). |
+| `SqlAssessmentBenchmarks.AssessMigrationAsync_EndToEnd` | `1.20` | 8-phase orchestration macro; moderate timing variance (observed spread ≈ 1.13×). |
+| `StreamingMemoryProfileBenchmarks.BufferedRetainAllPattern` (1000 & 10000 docs) | `1.30` | Deliberately buffers every document in memory as the allocation contrast to streaming; GC pressure makes wall-clock noisy (observed spread ≈ 1.13×). Allocation — the point of this benchmark — stays strict at `1.10`. |
 
 Per-benchmark overrides are preserved across `--update` runs. The baseline is
 seeded from the slower of two consecutive CI runs of the same commit

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/README.md
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/README.md
@@ -95,9 +95,12 @@ allocation budgets can be tuned separately:
 
 All per-benchmark overrides are preserved across `--update` runs. The shipped
 baseline keeps allocation pinned at the strict `1.10` default everywhere
-(allocations are deterministic) and widens only the mean axis for the two
+(allocations are deterministic) and widens only the mean axis for the
 I/O-bound macro-benchmarks (`GenerateAssessmentReportAsync_EndToEnd` → `1.50`,
-`AssessMigrationAsync_EndToEnd` → `1.20`).
+`AssessMigrationAsync_EndToEnd` → `1.20`) and the GC-heavy
+`StreamingMemoryProfileBenchmarks.BufferedRetainAllPattern` (1000 & 10000 docs)
+→ `1.30`, whose buffer-everything pattern is noisy on wall-clock but whose real
+signal — allocation — stays strict at `1.10`.
 
 ### Seeding / refreshing the baseline
 

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/baselines/baseline.json
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/baselines/baseline.json
@@ -154,7 +154,8 @@
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingMemoryProfileBenchmarks.BufferedRetainAllPattern(DocumentCount: 1000)": {
       "meanNs": 2825968.7313802084,
-      "allocatedBytes": 2012693
+      "allocatedBytes": 2012693,
+      "meanToleranceFactor": 1.3
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingMemoryProfileBenchmarks.StreamingWithSchemaExtraction(DocumentCount: 1000)": {
       "meanNs": 14774228.611177884,
@@ -170,7 +171,8 @@
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingMemoryProfileBenchmarks.BufferedRetainAllPattern(DocumentCount: 10000)": {
       "meanNs": 35568583.25333332,
-      "allocatedBytes": 29036779
+      "allocatedBytes": 29036779,
+      "meanToleranceFactor": 1.3
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingMemoryProfileBenchmarks.StreamingWithSchemaExtraction(DocumentCount: 10000)": {
       "meanNs": 149238303.05,


### PR DESCRIPTION
Follow-up to #244 (issue #234). The first post-merge `Performance Regression` run on `main` ([run 27797847077](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/actions/runs/27797847077)) flagged a single benchmark:

```
StreamingMemoryProfileBenchmarks.BufferedRetainAllPattern(DocumentCount: 1000)
  3,139,969 ns  +11.1% mean   2,012,693 B  +0.0% alloc   REGRESSION
```

This is a wall-clock false positive on a memory-profile benchmark, not a real regression.

## Root cause
`BufferedRetainAllPattern` deliberately buffers **every** document in memory — it's the allocation contrast to the streaming path. That makes its allocation byte-deterministic (the meaningful signal, ratio `1.000` across every run) but its wall-clock GC-noisy. Measured across **three** CI runs of identical code:

| Benchmark | mean spread (3 runs) | alloc spread |
|---|---|---|
| `BufferedRetainAllPattern(1000)` | **1.128×** | 1.000× |
| `BufferedRetainAllPattern(10000)` | **1.107×** | 1.000× |

Both exceed (or sit on) the `1.10` mean default purely from runner GC jitter.

## Fix
Add a **mean-only** `meanToleranceFactor: 1.30` override to both `BufferedRetainAllPattern` sizes in `baselines/baseline.json`. Allocation stays at the strict `1.10` default (no `allocationToleranceFactor`), so a real memory regression on these benchmarks still fails CI. Documented in both READMEs alongside the existing `EndToEnd` overrides.

## Verification
Replayed the exact `*-report-full.json` artifacts from the failing run 27797847077 through `compare-baseline` with the updated baseline: **58 compared, 0 regressions, worst exit code 0** across all 6 report files (the StreamingMemoryProfile file goes from `1 regression` → `0`). `dotnet build` clean.

After merge this becomes run 1 of the 3 consecutive clean `main` runs required by #234's acceptance criteria.