### PR TITLE
Parent #133: Real-time monitoring and alerting post-migration

### DIFF
--- a/Cli/CliArgumentParser.cs
+++ b/Cli/CliArgumentParser.cs
@@ -37,6 +37,37 @@ internal static class CliArgumentParser
                 case "-h":
                     DisplayHelp(output);
                     return null;
+                case "migration":
+                    // `migration status` subcommand for live progress reporting (#225).
+                    // Additive: leaves all existing flags/commands intact.
+                    if (i + 1 < args.Length && string.Equals(args[i + 1], "status", StringComparison.OrdinalIgnoreCase))
+                    {
+                        options.MigrationStatus = true;
+                        i++; // consume the "status" sub-token
+                    }
+                    else
+                    {
+                        output.WriteLine("Unknown command: 'migration'. Did you mean 'migration status'?");
+                        DisplayHelp(output);
+                        return null;
+                    }
+                    break;
+                case "--watch":
+                    options.Watch = true;
+                    break;
+                case "--poll-interval":
+                    if (i + 1 < args.Length && int.TryParse(args[i + 1], out var pollSeconds) && pollSeconds > 0)
+                    {
+                        options.PollIntervalSeconds = pollSeconds;
+                        i++;
+                    }
+                    else
+                    {
+                        output.WriteLine("Invalid value for --poll-interval: expected a positive integer (seconds).");
+                        DisplayHelp(output);
+                        return null;
+                    }
+                    break;
                 case "--all-databases":
                 case "-a":
                     options.AnalyzeAllDatabases = true;
@@ -173,6 +204,11 @@ internal static class CliArgumentParser
         output.WriteLine("  --save-config <path>      Save wizard configuration to a JSON file for reuse");
         output.WriteLine("  --resume                  Resume an interrupted interactive wizard session");
         output.WriteLine();
+        output.WriteLine("Subcommands:");
+        output.WriteLine("  migration status          Report live migration progress (rows migrated, RU consumption, error rate)");
+        output.WriteLine("    --watch                 Continuously poll and re-render progress until cancelled");
+        output.WriteLine("    --poll-interval <sec>   Polling interval in seconds for --watch (default 10)");
+        output.WriteLine();
         output.WriteLine("Examples:");
         output.WriteLine("  CosmosToSqlAssessment --all-databases");
         output.WriteLine("  CosmosToSqlAssessment --database MyDatabase --output C:\\Reports");
@@ -183,6 +219,8 @@ internal static class CliArgumentParser
         output.WriteLine("  CosmosToSqlAssessment --assessment-only --database MyDatabase");
         output.WriteLine("  CosmosToSqlAssessment --project-only --all-databases");
         output.WriteLine("  CosmosToSqlAssessment --test-connection");
+        output.WriteLine("  CosmosToSqlAssessment migration status");
+        output.WriteLine("  CosmosToSqlAssessment migration status --watch --poll-interval 5");
         output.WriteLine();
     }
 }

--- a/Cli/CliOptions.cs
+++ b/Cli/CliOptions.cs
@@ -21,4 +21,23 @@ internal sealed class CliOptions
     public string? ConfigFile { get; set; }
     public string? SaveConfigFile { get; set; }
     public bool ResumeSession { get; set; }
+
+    /// <summary>
+    /// When <c>true</c>, the tool runs the <c>migration status</c> subcommand: it reports
+    /// live migration progress instead of running an assessment. Set by the
+    /// <c>migration status</c> subcommand (#225).
+    /// </summary>
+    public bool MigrationStatus { get; set; }
+
+    /// <summary>
+    /// When <c>true</c> (and <see cref="MigrationStatus"/> is set), the status command keeps
+    /// polling and re-rendering progress until cancelled, rather than printing a single snapshot.
+    /// </summary>
+    public bool Watch { get; set; }
+
+    /// <summary>
+    /// Polling interval, in seconds, used by the <c>migration status --watch</c> loop.
+    /// Defaults to 10.
+    /// </summary>
+    public int PollIntervalSeconds { get; set; } = 10;
 }

--- a/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/DependencyInjection/ServiceCollectionExtensions.cs
@@ -82,6 +82,10 @@ namespace CosmosToSqlAssessment.DependencyInjection
             services.AddSingleton<AlertRuleTemplateBuilder>();
             services.AddScoped<AlertRuleTemplateGenerationService>();
             services.AddScoped<IMigrationStatusSource, AzureMonitorMigrationStatusSource>();
+            services.AddSingleton(_ =>
+                configuration.GetSection(AnomalyDetectionOptions.SectionName).Get<AnomalyDetectionOptions>()
+                ?? new AnomalyDetectionOptions());
+            services.AddScoped<AnomalyDetectionService>();
             services.AddScoped<MigrationStatusService>();
 
             // Orchestration

--- a/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/DependencyInjection/ServiceCollectionExtensions.cs
@@ -81,6 +81,8 @@ namespace CosmosToSqlAssessment.DependencyInjection
                 ?? new AlertRuleOptions());
             services.AddSingleton<AlertRuleTemplateBuilder>();
             services.AddScoped<AlertRuleTemplateGenerationService>();
+            services.AddScoped<IMigrationStatusSource, AzureMonitorMigrationStatusSource>();
+            services.AddScoped<MigrationStatusService>();
 
             // Orchestration
             services.AddScoped<AssessmentOrchestrator>();

--- a/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/DependencyInjection/ServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ using CosmosToSqlAssessment.Reporting;
 using CosmosToSqlAssessment.Services;
 using CosmosToSqlAssessment.Services.DataFactory;
 using CosmosToSqlAssessment.Services.Discovery;
+using CosmosToSqlAssessment.Services.Monitoring;
 using CosmosToSqlAssessment.SqlProject;
 
 namespace CosmosToSqlAssessment.DependencyInjection
@@ -66,6 +67,14 @@ namespace CosmosToSqlAssessment.DependencyInjection
             services.AddScoped<IResourceGraphDiscoveryService, ResourceGraphDiscoveryService>();
             services.AddScoped<IDiagnosticSettingsDiscoveryService, DiagnosticSettingsDiscoveryService>();
             services.AddSingleton<IAutoDiscoveryService, AutoDiscoveryService>();
+
+            // Real-time monitoring &amp; alerting services (parent #133).
+            services.AddSingleton(_ =>
+                configuration.GetSection(AzureMonitorMetricOptions.SectionName).Get<AzureMonitorMetricOptions>()
+                ?? new AzureMonitorMetricOptions());
+            services.AddSingleton<AzureMonitorMetricPayloadBuilder>();
+            services.AddSingleton<IMigrationMetricPublisher, AzureMonitorMetricPublisher>();
+            services.AddScoped<MigrationMonitoringService>();
 
             // Orchestration
             services.AddScoped<AssessmentOrchestrator>();

--- a/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/DependencyInjection/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Azure.Identity;
 using Azure.ResourceManager;
 using CosmosToSqlAssessment.Agents;
+using CosmosToSqlAssessment.Models.Monitoring;
 using CosmosToSqlAssessment.Orchestration;
 using CosmosToSqlAssessment.Reporting;
 using CosmosToSqlAssessment.Services;
@@ -75,6 +76,11 @@ namespace CosmosToSqlAssessment.DependencyInjection
             services.AddSingleton<AzureMonitorMetricPayloadBuilder>();
             services.AddSingleton<IMigrationMetricPublisher, AzureMonitorMetricPublisher>();
             services.AddScoped<MigrationMonitoringService>();
+            services.AddSingleton(_ =>
+                configuration.GetSection(AlertRuleOptions.SectionName).Get<AlertRuleOptions>()
+                ?? new AlertRuleOptions());
+            services.AddSingleton<AlertRuleTemplateBuilder>();
+            services.AddScoped<AlertRuleTemplateGenerationService>();
 
             // Orchestration
             services.AddScoped<AssessmentOrchestrator>();

--- a/Models/Monitoring/AlertRuleOptions.cs
+++ b/Models/Monitoring/AlertRuleOptions.cs
@@ -1,0 +1,122 @@
+using CosmosToSqlAssessment.Services.Monitoring;
+
+namespace CosmosToSqlAssessment.Models.Monitoring;
+
+/// <summary>
+/// Strongly-typed options controlling the Azure Monitor alert-rule ARM templates emitted
+/// for the migration custom metrics (#223) and the orchestrating Data Factory pipelines
+/// (#70). Bound from the <c>AzureMonitor:Alerts</c> configuration section.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The templates are deploy-time artifacts: they describe <c>Microsoft.Insights/metricAlerts</c>
+/// rules over the <see cref="MetricNamespace"/> custom metrics plus a
+/// <c>Microsoft.Insights/scheduledQueryRules</c> log alert over the
+/// <c>ADFPipelineRun</c>/<c>ADFActivityRun</c> Log Analytics tables. None of these settings
+/// trigger a live Azure call — they only shape the generated JSON.
+/// </para>
+/// <para>
+/// Threshold and severity defaults are conservative starting points an operator is expected
+/// to tune; every value is surfaced as an ARM template parameter default so the emitted
+/// templates remain deployable and overridable without regeneration.
+/// </para>
+/// </remarks>
+public sealed class AlertRuleOptions
+{
+    /// <summary>Configuration section these options bind from.</summary>
+    public const string SectionName = "AzureMonitor:Alerts";
+
+    /// <summary>
+    /// Custom-metric namespace the metric alerts target. Defaults to
+    /// <see cref="AzureMonitorMetricOptions.DefaultMetricNamespace"/> so it matches the
+    /// metrics published by <see cref="MigrationMonitoringService"/>.
+    /// </summary>
+    public string MetricNamespace { get; set; } = AzureMonitorMetricOptions.DefaultMetricNamespace;
+
+    /// <summary>
+    /// Whether the generated alert rules are created in the <c>enabled</c> state. Defaults to
+    /// <c>true</c> so a deployed template begins evaluating immediately.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// ISO-8601 duration for how often the metric alerts are evaluated. Defaults to
+    /// <c>PT1M</c> (every minute).
+    /// </summary>
+    public string EvaluationFrequency { get; set; } = "PT1M";
+
+    /// <summary>
+    /// ISO-8601 lookback window each metric-alert evaluation aggregates over. Defaults to
+    /// <c>PT5M</c>.
+    /// </summary>
+    public string WindowSize { get; set; } = "PT5M";
+
+    /// <summary>
+    /// ISO-8601 lookback window for the stalled-pipeline log alert. Defaults to <c>PT15M</c>,
+    /// longer than <see cref="WindowSize"/> because a stalled pipeline is defined by the
+    /// <em>absence</em> of progress over a sustained period.
+    /// </summary>
+    public string StalledWindowSize { get; set; } = "PT15M";
+
+    /// <summary>
+    /// KQL relative-time literal (e.g. <c>15m</c>) used inside the stalled-pipeline query's
+    /// <c>ago(...)</c> activity-gap filter. Kept distinct from <see cref="StalledWindowSize"/>
+    /// because KQL uses Timespan literals, not ISO-8601 durations.
+    /// </summary>
+    public string StalledActivityGap { get; set; } = "15m";
+
+    /// <summary>Error-rate fraction (0-1) above which the static error-rate alert fires. Defaults to <c>0.05</c>.</summary>
+    public double ErrorRateThreshold { get; set; } = 0.05;
+
+    /// <summary>Severity (0 = critical … 4 = verbose) of the error-rate alert. Defaults to <c>2</c>.</summary>
+    public int ErrorRateSeverity { get; set; } = 2;
+
+    /// <summary>
+    /// Dynamic-threshold sensitivity for the error-spike alert: <c>Low</c>, <c>Medium</c>, or
+    /// <c>High</c>. Defaults to <c>Medium</c>.
+    /// </summary>
+    public string ErrorSpikeSensitivity { get; set; } = "Medium";
+
+    /// <summary>Number of recent evaluation periods the dynamic error-spike alert inspects. Defaults to <c>4</c>.</summary>
+    public int ErrorSpikeNumberOfEvaluationPeriods { get; set; } = 4;
+
+    /// <summary>How many of <see cref="ErrorSpikeNumberOfEvaluationPeriods"/> must breach before the error-spike alert fires. Defaults to <c>3</c>.</summary>
+    public int ErrorSpikeMinFailingPeriods { get; set; } = 3;
+
+    /// <summary>Severity of the dynamic error-spike alert. Defaults to <c>2</c>.</summary>
+    public int ErrorSpikeSeverity { get; set; } = 2;
+
+    /// <summary>
+    /// Whether to emit the low/no-throughput metric alert. Defaults to <c>true</c>. Note this
+    /// alert fires on observed-but-zero throughput while telemetry is flowing; a truly dead
+    /// pipeline that stops emitting is caught by the stalled-pipeline log alert instead.
+    /// </summary>
+    public bool IncludeLowThroughputAlert { get; set; } = true;
+
+    /// <summary>Severity of the low-throughput alert. Defaults to <c>1</c>.</summary>
+    public int LowThroughputSeverity { get; set; } = 1;
+
+    /// <summary>Whether to emit the optional Request-Units ceiling alert. Off by default.</summary>
+    public bool IncludeRequestUnitsThresholdAlert { get; set; }
+
+    /// <summary>RU/s value above which the optional Request-Units alert fires (used only when <see cref="IncludeRequestUnitsThresholdAlert"/> is <c>true</c>).</summary>
+    public double RequestUnitsThreshold { get; set; }
+
+    /// <summary>Severity of the optional Request-Units alert. Defaults to <c>3</c>.</summary>
+    public int RequestUnitsSeverity { get; set; } = 3;
+
+    /// <summary>Severity of the stalled-pipeline log alert. Defaults to <c>1</c>.</summary>
+    public int StalledPipelineSeverity { get; set; } = 1;
+
+    /// <summary>
+    /// Emits <c>skipMetricValidation = true</c> on each custom-metric criterion so a template
+    /// deploys before the metrics have been ingested for the first time. Defaults to <c>true</c>.
+    /// </summary>
+    public bool SkipMetricValidation { get; set; } = true;
+
+    /// <summary>
+    /// Emits <c>skipQueryValidation = true</c> on the scheduled query rule so it deploys even
+    /// when the target Log Analytics tables are not yet populated. Defaults to <c>true</c>.
+    /// </summary>
+    public bool SkipQueryValidation { get; set; } = true;
+}

--- a/Models/Monitoring/AnomalyDetectionOptions.cs
+++ b/Models/Monitoring/AnomalyDetectionOptions.cs
@@ -1,0 +1,56 @@
+namespace CosmosToSqlAssessment.Models.Monitoring;
+
+/// <summary>
+/// Options for the rolling-window z-score anomaly detector (#226) applied to migration
+/// Request-Units/sec and throughput. Bound from the <c>AzureMonitor:Anomaly</c> section.
+/// </summary>
+/// <remarks>
+/// The detector is a deliberately simple statistical baseline: it assumes a roughly
+/// stationary, symmetric local distribution. Bursty / heavy-tailed metrics may produce false
+/// positives; the z-score threshold and relative-change guard are the primary tuning knobs.
+/// </remarks>
+public sealed class AnomalyDetectionOptions
+{
+    /// <summary>Configuration section these options bind from.</summary>
+    public const string SectionName = "AzureMonitor:Anomaly";
+
+    /// <summary>Whether anomaly detection is active. Defaults to <c>true</c>.</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>Maximum number of recent observations retained per key/metric baseline. Defaults to 20.</summary>
+    public int WindowSize { get; set; } = 20;
+
+    /// <summary>
+    /// Minimum number of prior observations required before the baseline is evaluated (warmup).
+    /// Must be at least 2 (sample standard deviation is undefined for one point). Defaults to 5.
+    /// </summary>
+    public int MinSamplesForBaseline { get; set; } = 5;
+
+    /// <summary>Absolute z-score at or above which an observation is flagged. Defaults to 3.0.</summary>
+    public double ZScoreThreshold { get; set; } = 3.0;
+
+    /// <summary>
+    /// Minimum fractional change from the baseline mean required to flag an anomaly, guarding
+    /// against flapping on near-constant baselines. Defaults to 0.25 (25%).
+    /// </summary>
+    public double MinRelativeChange { get; set; } = 0.25;
+
+    /// <summary>
+    /// Floor applied to the baseline standard deviation in the z-score denominator to avoid
+    /// divide-by-zero on constant series. Defaults to a tiny epsilon.
+    /// </summary>
+    public double MinBaselineStdDev { get; set; } = 1e-9;
+
+    /// <summary>Whether to watch <c>RequestUnitsPerSecond</c>. Defaults to <c>true</c>.</summary>
+    public bool WatchRequestUnits { get; set; } = true;
+
+    /// <summary>Whether to watch <c>ThroughputRowsPerSecond</c>. Defaults to <c>true</c>.</summary>
+    public bool WatchThroughput { get; set; } = true;
+
+    /// <summary>
+    /// When <c>true</c> (default), low-direction anomalies are suppressed for snapshots whose
+    /// status is terminal (e.g. <c>Succeeded</c>), so a natural ramp-down at completion does
+    /// not spam warnings.
+    /// </summary>
+    public bool SuppressLowOnTerminalStatus { get; set; } = true;
+}

--- a/Models/Monitoring/MigrationAnomaly.cs
+++ b/Models/Monitoring/MigrationAnomaly.cs
@@ -1,0 +1,51 @@
+namespace CosmosToSqlAssessment.Models.Monitoring;
+
+/// <summary>
+/// Direction of a detected metric anomaly relative to its rolling baseline.
+/// </summary>
+public enum AnomalyDirection
+{
+    /// <summary>The observed value was anomalously high (above the baseline mean).</summary>
+    High,
+
+    /// <summary>The observed value was anomalously low (below the baseline mean).</summary>
+    Low,
+}
+
+/// <summary>
+/// A single detected anomaly in a migration metric (Request-Units/sec or throughput) relative
+/// to a rolling-window statistical baseline. Produced by the anomaly detection service (#226)
+/// and surfaced as a warning by the <c>migration status</c> command (#225).
+/// </summary>
+public sealed record MigrationAnomaly
+{
+    /// <summary>UTC timestamp of the observation that triggered the anomaly.</summary>
+    public DateTimeOffset Timestamp { get; init; }
+
+    /// <summary>Name of the ADF pipeline the anomaly belongs to.</summary>
+    public string PipelineName { get; init; } = string.Empty;
+
+    /// <summary>Optional activity name within the pipeline.</summary>
+    public string? ActivityName { get; init; }
+
+    /// <summary>Optional ADF run identifier.</summary>
+    public string? RunId { get; init; }
+
+    /// <summary>Name of the metric that breached its baseline (e.g. <c>RequestUnitsPerSecond</c>).</summary>
+    public string MetricName { get; init; } = string.Empty;
+
+    /// <summary>The observed metric value.</summary>
+    public double ObservedValue { get; init; }
+
+    /// <summary>Mean of the prior rolling-window values that formed the baseline.</summary>
+    public double BaselineMean { get; init; }
+
+    /// <summary>Sample standard deviation of the prior rolling-window values.</summary>
+    public double BaselineStdDev { get; init; }
+
+    /// <summary>Signed z-score of the observation against the baseline.</summary>
+    public double ZScore { get; init; }
+
+    /// <summary>Whether the observation was anomalously high or low.</summary>
+    public AnomalyDirection Direction { get; init; }
+}

--- a/Models/Monitoring/MigrationMetricPoint.cs
+++ b/Models/Monitoring/MigrationMetricPoint.cs
@@ -1,0 +1,38 @@
+namespace CosmosToSqlAssessment.Models.Monitoring;
+
+/// <summary>
+/// A single custom-metric data point destined for Azure Monitor. The
+/// <see cref="AzureMonitorMetricPayloadBuilder"/> groups points that share a
+/// namespace, name, timestamp, and dimension shape into one ingestion payload.
+/// </summary>
+/// <remarks>
+/// <see cref="AzureMonitorMetricPayloadBuilder"/> lives in
+/// <c>CosmosToSqlAssessment.Services.Monitoring</c>.
+/// </remarks>
+public sealed record MigrationMetricPoint
+{
+    private static readonly IReadOnlyDictionary<string, string> EmptyDimensions =
+        new Dictionary<string, string>(0);
+
+    /// <summary>The metric name (e.g. <c>MigrationRowsMigrated</c>).</summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>The custom-metric namespace the point is published under.</summary>
+    public string Namespace { get; init; } = string.Empty;
+
+    /// <summary>The metric value for this point.</summary>
+    public double Value { get; init; }
+
+    /// <summary>UTC timestamp the value was observed at.</summary>
+    public DateTimeOffset Timestamp { get; init; }
+
+    /// <summary>The metric unit (e.g. <c>Count</c>, <c>Percent</c>). Informational only.</summary>
+    public string Unit { get; init; } = "Count";
+
+    /// <summary>
+    /// Dimension name/value pairs attached to the point. Dimension <em>names</em> become the
+    /// Azure Monitor <c>dimNames</c> array and the <em>values</em> become a series'
+    /// <c>dimValues</c>. Defaults to an empty, read-only dictionary.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Dimensions { get; init; } = EmptyDimensions;
+}

--- a/Models/Monitoring/MigrationMetricPoint.cs
+++ b/Models/Monitoring/MigrationMetricPoint.cs
@@ -2,12 +2,13 @@ namespace CosmosToSqlAssessment.Models.Monitoring;
 
 /// <summary>
 /// A single custom-metric data point destined for Azure Monitor. The
-/// <see cref="AzureMonitorMetricPayloadBuilder"/> groups points that share a
-/// namespace, name, timestamp, and dimension shape into one ingestion payload.
+/// <see cref="CosmosToSqlAssessment.Services.Monitoring.AzureMonitorMetricPayloadBuilder"/>
+/// groups points that share a namespace, name, timestamp, and dimension shape into one
+/// ingestion payload.
 /// </summary>
 /// <remarks>
-/// <see cref="AzureMonitorMetricPayloadBuilder"/> lives in
-/// <c>CosmosToSqlAssessment.Services.Monitoring</c>.
+/// <see cref="CosmosToSqlAssessment.Services.Monitoring.AzureMonitorMetricPayloadBuilder"/>
+/// lives in <c>CosmosToSqlAssessment.Services.Monitoring</c>.
 /// </remarks>
 public sealed record MigrationMetricPoint
 {

--- a/Models/Monitoring/MigrationProgressSample.cs
+++ b/Models/Monitoring/MigrationProgressSample.cs
@@ -1,0 +1,45 @@
+namespace CosmosToSqlAssessment.Models.Monitoring;
+
+/// <summary>
+/// A single point-in-time observation of an in-flight migration, typically derived
+/// from an Azure Data Factory pipeline/activity run (parent #70). Each sample carries
+/// the <em>delta</em> work completed since the previous sample for the same
+/// pipeline/activity/run so the monitoring pipeline can derive both windowed rates and
+/// cumulative totals.
+/// </summary>
+public sealed record MigrationProgressSample
+{
+    /// <summary>UTC timestamp at which this sample was observed. Defaults to <see cref="DateTimeOffset.UtcNow"/>.</summary>
+    public DateTimeOffset Timestamp { get; init; } = DateTimeOffset.UtcNow;
+
+    /// <summary>Name of the ADF pipeline the sample belongs to. Used as a metric dimension and accumulation key.</summary>
+    public string PipelineName { get; init; } = string.Empty;
+
+    /// <summary>Optional name of the specific copy/activity within the pipeline.</summary>
+    public string? ActivityName { get; init; }
+
+    /// <summary>Optional ADF run identifier. Kept on the snapshot and logs; only emitted as a metric dimension when opted in.</summary>
+    public string? RunId { get; init; }
+
+    /// <summary>Rows successfully migrated during this sample window (a delta, not a running total).</summary>
+    public long RowsMigrated { get; init; }
+
+    /// <summary>
+    /// Rows read from the source during this sample window, when known. Used as the
+    /// denominator for the windowed error rate. When <c>null</c>, the rate falls back to
+    /// <c>ErrorCount / (RowsMigrated + ErrorCount)</c>.
+    /// </summary>
+    public long? RowsRead { get; init; }
+
+    /// <summary>Total rows expected for the activity/run, when known. Drives percent-complete on the snapshot.</summary>
+    public long? TotalRows { get; init; }
+
+    /// <summary>Request Units consumed during this sample window (a delta).</summary>
+    public double RequestUnitsConsumed { get; init; }
+
+    /// <summary>Errors encountered during this sample window (a delta).</summary>
+    public long ErrorCount { get; init; }
+
+    /// <summary>Free-form status string for the run/activity (e.g. <c>InProgress</c>, <c>Succeeded</c>, <c>Failed</c>).</summary>
+    public string Status { get; init; } = "InProgress";
+}

--- a/Models/Monitoring/MigrationProgressSnapshot.cs
+++ b/Models/Monitoring/MigrationProgressSnapshot.cs
@@ -1,0 +1,56 @@
+namespace CosmosToSqlAssessment.Models.Monitoring;
+
+/// <summary>
+/// An enriched, consumer-facing view of a single <see cref="MigrationProgressSample"/>.
+/// Carries the windowed values from the sample plus cumulative totals and derived rates
+/// for the originating pipeline/activity/run, and the custom-metric points that were
+/// emitted for the sample. Produced by the migration monitoring pipeline and consumed by
+/// the <c>migration status</c> CLI command (#225) and anomaly detection (#226).
+/// </summary>
+public sealed record MigrationProgressSnapshot
+{
+    /// <summary>The original sample this snapshot was derived from.</summary>
+    public MigrationProgressSample Sample { get; init; } = new();
+
+    /// <summary>Running total of rows migrated for this pipeline/activity/run.</summary>
+    public long CumulativeRowsMigrated { get; init; }
+
+    /// <summary>Running total of rows read for this pipeline/activity/run.</summary>
+    public long CumulativeRowsRead { get; init; }
+
+    /// <summary>Running total of errors for this pipeline/activity/run.</summary>
+    public long CumulativeErrorCount { get; init; }
+
+    /// <summary>Running total of Request Units consumed for this pipeline/activity/run.</summary>
+    public double CumulativeRequestUnits { get; init; }
+
+    /// <summary>
+    /// Percent of <see cref="MigrationProgressSample.TotalRows"/> migrated so far (0-100),
+    /// or <c>null</c> when the total is unknown.
+    /// </summary>
+    public double? PercentComplete { get; init; }
+
+    /// <summary>
+    /// Windowed error rate for this sample: errors divided by rows read in the window
+    /// (or rows migrated + errors when rows read is unknown). Range 0-1.
+    /// </summary>
+    public double ErrorRate { get; init; }
+
+    /// <summary>Cumulative error rate for this pipeline/activity/run. Range 0-1.</summary>
+    public double CumulativeErrorRate { get; init; }
+
+    /// <summary>
+    /// Throughput in rows per second for this window, when an inter-sample duration could
+    /// be derived; otherwise <c>null</c> (e.g. the first sample for a key).
+    /// </summary>
+    public double? ThroughputRowsPerSecond { get; init; }
+
+    /// <summary>
+    /// Request Units per second for this window, when an inter-sample duration could be
+    /// derived; otherwise <c>null</c>.
+    /// </summary>
+    public double? RequestUnitsPerSecond { get; init; }
+
+    /// <summary>The custom-metric points emitted to Azure Monitor for this sample.</summary>
+    public IReadOnlyList<MigrationMetricPoint> Metrics { get; init; } = Array.Empty<MigrationMetricPoint>();
+}

--- a/Models/Monitoring/MigrationStatusReportOptions.cs
+++ b/Models/Monitoring/MigrationStatusReportOptions.cs
@@ -1,0 +1,17 @@
+namespace CosmosToSqlAssessment.Models.Monitoring;
+
+/// <summary>
+/// Options controlling the <c>migration status</c> CLI command (#225): whether to keep
+/// watching and how frequently to poll.
+/// </summary>
+public sealed record MigrationStatusReportOptions
+{
+    /// <summary>
+    /// When <c>true</c>, the command continuously polls and re-renders progress until
+    /// cancelled. When <c>false</c> (the default) it renders a single snapshot and exits.
+    /// </summary>
+    public bool Watch { get; init; }
+
+    /// <summary>Polling interval, in seconds, used by the watch loop. Defaults to 10.</summary>
+    public int PollIntervalSeconds { get; init; } = 10;
+}

--- a/Orchestration/AssessmentOrchestrator.cs
+++ b/Orchestration/AssessmentOrchestrator.cs
@@ -6,10 +6,12 @@ using CosmosToSqlAssessment.Agents;
 using CosmosToSqlAssessment.Cli;
 using CosmosToSqlAssessment.DependencyInjection;
 using CosmosToSqlAssessment.Models;
+using CosmosToSqlAssessment.Models.Monitoring;
 using CosmosToSqlAssessment.Reporting;
 using CosmosToSqlAssessment.Services;
 using CosmosToSqlAssessment.Services.DataFactory;
 using CosmosToSqlAssessment.Services.Discovery;
+using CosmosToSqlAssessment.Services.Monitoring;
 using CosmosToSqlAssessment.SqlProject;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Configuration;
@@ -69,6 +71,12 @@ internal sealed class AssessmentOrchestrator
     /// </summary>
     public async Task<int> RunAsync(CliOptions options, CancellationToken cancellationToken)
     {
+        if (options.MigrationStatus)
+        {
+            _logger.LogInformation("Running migration status report");
+            return await RunMigrationStatusAsync(options, cancellationToken);
+        }
+
         if (options.TestConnection)
         {
             _logger.LogInformation("Running connection test");
@@ -963,6 +971,22 @@ internal sealed class AssessmentOrchestrator
             _logger.LogWarning("Some connection tests failed");
             return 1;
         }
+    }
+
+    /// <summary>
+    /// Runs the <c>migration status</c> subcommand (#225): resolves the
+    /// <see cref="MigrationStatusService"/> and renders live progress to the console.
+    /// </summary>
+    private async Task<int> RunMigrationStatusAsync(CliOptions options, CancellationToken cancellationToken)
+    {
+        var statusService = _services.GetRequiredService<MigrationStatusService>();
+        var reportOptions = new MigrationStatusReportOptions
+        {
+            Watch = options.Watch,
+            PollIntervalSeconds = options.PollIntervalSeconds,
+        };
+
+        return await statusService.RunAsync(reportOptions, Console.Out, cancellationToken);
     }
 
     /// <summary>

--- a/Services/Monitoring/AlertRuleTemplateBuilder.cs
+++ b/Services/Monitoring/AlertRuleTemplateBuilder.cs
@@ -1,0 +1,368 @@
+using CosmosToSqlAssessment.Models.Monitoring;
+
+namespace CosmosToSqlAssessment.Services.Monitoring;
+
+/// <summary>
+/// Builds deployable Azure Monitor alert-rule ARM templates for the migration custom metrics
+/// (#223) and the orchestrating Data Factory pipelines (#70).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two templates are produced:
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     <description>
+///     A <c>Microsoft.Insights/metricAlerts</c> template covering threshold breaches
+///     (static error-rate), error spikes (a dynamic-threshold criterion), low/no throughput,
+///     and an optional Request-Units ceiling, all over the
+///     <see cref="MigrationMonitoringService"/> custom metrics.
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///     A <c>Microsoft.Insights/scheduledQueryRules</c> log-alert template that detects stalled
+///     pipelines from the <c>ADFPipelineRun</c>/<c>ADFActivityRun</c> Log Analytics tables —
+///     the reliable dead-pipeline detector, because metric alerts do not fire on
+///     <em>missing</em> data.
+///     </description>
+///   </item>
+/// </list>
+/// <para>
+/// Each <c>Build…</c> method returns a fully-formed ARM template object (<c>$schema</c>,
+/// <c>contentVersion</c>, <c>parameters</c>, <c>resources</c>) intended to be serialized with
+/// <see cref="DataFactory.AdfJsonSerializer"/>, which preserves dictionary keys such as
+/// <c>odata.type</c> verbatim.
+/// </para>
+/// </remarks>
+public sealed class AlertRuleTemplateBuilder
+{
+    /// <summary>ARM resource type for metric alert rules.</summary>
+    public const string MetricAlertResourceType = "Microsoft.Insights/metricAlerts";
+
+    /// <summary>API version used for the metric alert rules.</summary>
+    public const string MetricAlertApiVersion = "2018-03-01";
+
+    /// <summary>ARM resource type for scheduled query (log) alert rules.</summary>
+    public const string ScheduledQueryRuleResourceType = "Microsoft.Insights/scheduledQueryRules";
+
+    /// <summary>API version used for the scheduled query (log) alert rule.</summary>
+    public const string ScheduledQueryRuleApiVersion = "2021-08-01";
+
+    /// <summary><c>odata.type</c> for static-threshold metric criteria.</summary>
+    public const string StaticCriteriaODataType = "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria";
+
+    /// <summary><c>odata.type</c> for dynamic-threshold metric criteria.</summary>
+    public const string DynamicCriteriaODataType = "Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria";
+
+    /// <summary>ARM template parameter: prefix applied to every generated alert-rule name.</summary>
+    public const string ParamAlertNamePrefix = "alertNamePrefix";
+
+    /// <summary>ARM template parameter: resource ID the metric alerts are scoped to.</summary>
+    public const string ParamTargetResourceId = "targetResourceId";
+
+    /// <summary>ARM template parameter: action-group resource ID alerts notify.</summary>
+    public const string ParamActionGroupResourceId = "actionGroupResourceId";
+
+    /// <summary>ARM template parameter: Log Analytics workspace resource ID the log alert queries.</summary>
+    public const string ParamWorkspaceResourceId = "workspaceResourceId";
+
+    private const string DeploymentSchema =
+        "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#";
+    private const string ContentVersion = "1.0.0.0";
+    private const string DefaultAlertNamePrefix = "cosmos-migration";
+
+    /// <summary>
+    /// Builds the metric-alerts ARM template: static error-rate breach, dynamic error-spike,
+    /// optional low-throughput, and optional Request-Units ceiling rules.
+    /// </summary>
+    /// <param name="options">Threshold/severity/window settings driving the generated rules.</param>
+    /// <returns>An ARM template object ready to serialize.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="options"/> is <c>null</c>.</exception>
+    public Dictionary<string, object?> BuildMetricAlertsTemplate(AlertRuleOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var resources = new List<object?>
+        {
+            BuildStaticMetricAlertResource(
+                options,
+                suffix: "error-rate",
+                description: "Migration error rate exceeded the configured threshold over the evaluation window.",
+                severity: options.ErrorRateSeverity,
+                criterionName: "ErrorRateHigh",
+                metricName: MigrationMonitoringService.MetricErrorRate,
+                @operator: "GreaterThan",
+                threshold: options.ErrorRateThreshold,
+                timeAggregation: "Average"),
+            BuildDynamicMetricAlertResource(
+                options,
+                suffix: "error-spike",
+                description: "Migration error count deviated sharply from its recent baseline (dynamic threshold).",
+                severity: options.ErrorSpikeSeverity,
+                criterionName: "ErrorCountSpike",
+                metricName: MigrationMonitoringService.MetricErrorCount,
+                @operator: "GreaterThan",
+                timeAggregation: "Total"),
+        };
+
+        if (options.IncludeLowThroughputAlert)
+        {
+            resources.Add(BuildStaticMetricAlertResource(
+                options,
+                suffix: "low-throughput",
+                description: "Migration reported zero rows migrated while telemetry was flowing — a truly dead pipeline is caught by the stalled-pipeline log alert.",
+                severity: options.LowThroughputSeverity,
+                criterionName: "RowsMigratedLowOrZero",
+                metricName: MigrationMonitoringService.MetricRowsMigrated,
+                @operator: "LessThanOrEqual",
+                threshold: 0,
+                timeAggregation: "Total"));
+        }
+
+        if (options.IncludeRequestUnitsThresholdAlert)
+        {
+            resources.Add(BuildStaticMetricAlertResource(
+                options,
+                suffix: "request-units-high",
+                description: "Migration Request-Units consumption exceeded the configured ceiling over the evaluation window.",
+                severity: options.RequestUnitsSeverity,
+                criterionName: "RequestUnitsHigh",
+                metricName: MigrationMonitoringService.MetricRequestUnits,
+                @operator: "GreaterThan",
+                threshold: options.RequestUnitsThreshold,
+                timeAggregation: "Total"));
+        }
+
+        var parameters = new Dictionary<string, object?>
+        {
+            [ParamAlertNamePrefix] = StringParameter(
+                DefaultAlertNamePrefix,
+                "Prefix applied to every generated alert-rule name."),
+            [ParamTargetResourceId] = RequiredStringParameter(
+                "Full resource ID the custom metrics are emitted against (e.g. the Data Factory or Cosmos account)."),
+            [ParamActionGroupResourceId] = RequiredStringParameter(
+                "Full resource ID of the action group notified when an alert fires."),
+        };
+
+        return new Dictionary<string, object?>
+        {
+            ["$schema"] = DeploymentSchema,
+            ["contentVersion"] = ContentVersion,
+            ["parameters"] = parameters,
+            ["resources"] = resources,
+        };
+    }
+
+    /// <summary>
+    /// Builds the stalled-pipeline log-alert ARM template (a <c>scheduledQueryRules</c> rule
+    /// over the ADF Log Analytics tables).
+    /// </summary>
+    /// <param name="options">Window/severity settings driving the generated rule.</param>
+    /// <returns>An ARM template object ready to serialize.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="options"/> is <c>null</c>.</exception>
+    public Dictionary<string, object?> BuildStalledPipelineLogAlertTemplate(AlertRuleOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var criterion = new Dictionary<string, object?>
+        {
+            ["query"] = BuildStalledPipelineQuery(options.StalledActivityGap),
+            ["timeAggregation"] = "Count",
+            ["operator"] = "GreaterThan",
+            ["threshold"] = 0,
+            ["failingPeriods"] = new Dictionary<string, object?>
+            {
+                ["numberOfEvaluationPeriods"] = 1,
+                ["minFailingPeriodsToAlert"] = 1,
+            },
+            ["dimensions"] = new List<object?>(),
+        };
+
+        var properties = new Dictionary<string, object?>
+        {
+            ["description"] = "An in-progress migration pipeline has shown no activity progress within the stall window — likely stalled or stuck.",
+            ["severity"] = options.StalledPipelineSeverity,
+            ["enabled"] = options.Enabled,
+            ["evaluationFrequency"] = options.EvaluationFrequency,
+            ["windowSize"] = options.StalledWindowSize,
+            ["scopes"] = new List<object?> { $"[parameters('{ParamWorkspaceResourceId}')]" },
+            ["criteria"] = new Dictionary<string, object?>
+            {
+                ["allOf"] = new List<object?> { criterion },
+            },
+            // scheduledQueryRules expects actionGroups as an array of resource-id STRINGS.
+            ["actions"] = new Dictionary<string, object?>
+            {
+                ["actionGroups"] = new List<object?> { $"[parameters('{ParamActionGroupResourceId}')]" },
+            },
+            ["autoMitigate"] = true,
+            ["skipQueryValidation"] = options.SkipQueryValidation,
+        };
+
+        var resource = new Dictionary<string, object?>
+        {
+            ["type"] = ScheduledQueryRuleResourceType,
+            ["apiVersion"] = ScheduledQueryRuleApiVersion,
+            ["name"] = $"[concat(parameters('{ParamAlertNamePrefix}'), '-stalled-pipeline')]",
+            ["location"] = "[resourceGroup().location]",
+            ["kind"] = "LogAlert",
+            ["properties"] = properties,
+        };
+
+        var parameters = new Dictionary<string, object?>
+        {
+            [ParamAlertNamePrefix] = StringParameter(
+                DefaultAlertNamePrefix,
+                "Prefix applied to the generated alert-rule name."),
+            [ParamWorkspaceResourceId] = RequiredStringParameter(
+                "Full resource ID of the Log Analytics workspace receiving ADF diagnostic logs."),
+            [ParamActionGroupResourceId] = RequiredStringParameter(
+                "Full resource ID of the action group notified when the alert fires."),
+        };
+
+        return new Dictionary<string, object?>
+        {
+            ["$schema"] = DeploymentSchema,
+            ["contentVersion"] = ContentVersion,
+            ["parameters"] = parameters,
+            ["resources"] = new List<object?> { resource },
+        };
+    }
+
+    private static Dictionary<string, object?> BuildStaticMetricAlertResource(
+        AlertRuleOptions options,
+        string suffix,
+        string description,
+        int severity,
+        string criterionName,
+        string metricName,
+        string @operator,
+        double threshold,
+        string timeAggregation)
+    {
+        var criterion = new Dictionary<string, object?>
+        {
+            ["name"] = criterionName,
+            ["metricName"] = metricName,
+            ["metricNamespace"] = options.MetricNamespace,
+            ["operator"] = @operator,
+            ["threshold"] = threshold,
+            ["timeAggregation"] = timeAggregation,
+            ["criterionType"] = "StaticThresholdCriterion",
+            ["dimensions"] = new List<object?>(),
+            ["skipMetricValidation"] = options.SkipMetricValidation,
+        };
+
+        var criteria = new Dictionary<string, object?>
+        {
+            ["odata.type"] = StaticCriteriaODataType,
+            ["allOf"] = new List<object?> { criterion },
+        };
+
+        return BuildMetricAlertResource(options, suffix, description, severity, criteria);
+    }
+
+    private static Dictionary<string, object?> BuildDynamicMetricAlertResource(
+        AlertRuleOptions options,
+        string suffix,
+        string description,
+        int severity,
+        string criterionName,
+        string metricName,
+        string @operator,
+        string timeAggregation)
+    {
+        var criterion = new Dictionary<string, object?>
+        {
+            ["name"] = criterionName,
+            ["metricName"] = metricName,
+            ["metricNamespace"] = options.MetricNamespace,
+            ["operator"] = @operator,
+            ["alertSensitivity"] = options.ErrorSpikeSensitivity,
+            ["failingPeriods"] = new Dictionary<string, object?>
+            {
+                ["numberOfEvaluationPeriods"] = options.ErrorSpikeNumberOfEvaluationPeriods,
+                ["minFailingPeriodsToAlert"] = options.ErrorSpikeMinFailingPeriods,
+            },
+            ["timeAggregation"] = timeAggregation,
+            ["criterionType"] = "DynamicThresholdCriterion",
+            ["dimensions"] = new List<object?>(),
+            ["skipMetricValidation"] = options.SkipMetricValidation,
+        };
+
+        var criteria = new Dictionary<string, object?>
+        {
+            ["odata.type"] = DynamicCriteriaODataType,
+            ["allOf"] = new List<object?> { criterion },
+        };
+
+        return BuildMetricAlertResource(options, suffix, description, severity, criteria);
+    }
+
+    private static Dictionary<string, object?> BuildMetricAlertResource(
+        AlertRuleOptions options,
+        string suffix,
+        string description,
+        int severity,
+        Dictionary<string, object?> criteria)
+    {
+        var properties = new Dictionary<string, object?>
+        {
+            ["description"] = description,
+            ["severity"] = severity,
+            ["enabled"] = options.Enabled,
+            ["scopes"] = new List<object?> { $"[parameters('{ParamTargetResourceId}')]" },
+            ["evaluationFrequency"] = options.EvaluationFrequency,
+            ["windowSize"] = options.WindowSize,
+            ["criteria"] = criteria,
+            ["autoMitigate"] = true,
+            ["actions"] = new List<object?>
+            {
+                new Dictionary<string, object?>
+                {
+                    ["actionGroupId"] = $"[parameters('{ParamActionGroupResourceId}')]",
+                },
+            },
+        };
+
+        return new Dictionary<string, object?>
+        {
+            ["type"] = MetricAlertResourceType,
+            ["apiVersion"] = MetricAlertApiVersion,
+            ["name"] = $"[concat(parameters('{ParamAlertNamePrefix}'), '-{suffix}')]",
+            ["location"] = "global",
+            ["properties"] = properties,
+        };
+    }
+
+    private static string BuildStalledPipelineQuery(string activityGap) =>
+$$"""
+// Migration pipelines still running but with no activity progress in the last {{activityGap}}.
+ADFPipelineRun
+| where Status == "InProgress"
+| join kind=leftouter (
+    ADFActivityRun
+    | where Status in ("Succeeded", "InProgress")
+    | summarize LastActivity = max(TimeGenerated) by RunId
+  ) on RunId
+| extend LastActivity = coalesce(LastActivity, Start)
+| where LastActivity < ago({{activityGap}})
+| project PipelineName, RunId, Status, LastActivity
+""";
+
+    private static Dictionary<string, object?> StringParameter(string defaultValue, string description) =>
+        new()
+        {
+            ["type"] = "string",
+            ["defaultValue"] = defaultValue,
+            ["metadata"] = new Dictionary<string, object?> { ["description"] = description },
+        };
+
+    private static Dictionary<string, object?> RequiredStringParameter(string description) =>
+        new()
+        {
+            ["type"] = "string",
+            ["metadata"] = new Dictionary<string, object?> { ["description"] = description },
+        };
+}

--- a/Services/Monitoring/AlertRuleTemplateGenerationService.cs
+++ b/Services/Monitoring/AlertRuleTemplateGenerationService.cs
@@ -1,0 +1,194 @@
+using System.Text;
+using CosmosToSqlAssessment.Models.Monitoring;
+using CosmosToSqlAssessment.Services.DataFactory;
+using Microsoft.Extensions.Logging;
+
+namespace CosmosToSqlAssessment.Services.Monitoring;
+
+/// <summary>
+/// Result of an <see cref="AlertRuleTemplateGenerationService.GenerateAsync"/> call: the
+/// absolute paths of every artifact written, plus any non-fatal warnings.
+/// </summary>
+public sealed class AlertRuleGenerationResult
+{
+    /// <summary>Absolute path of the emitted metric-alerts ARM template.</summary>
+    public required string MetricAlertsTemplatePath { get; init; }
+
+    /// <summary>Absolute path of the emitted stalled-pipeline log-alert ARM template.</summary>
+    public required string StalledPipelineTemplatePath { get; init; }
+
+    /// <summary>Absolute path of the emitted README describing the alert rules and how to deploy them.</summary>
+    public required string ReadmePath { get; init; }
+
+    /// <summary>Non-fatal warnings raised while generating the templates.</summary>
+    public IReadOnlyList<string> Warnings { get; init; } = Array.Empty<string>();
+}
+
+/// <summary>
+/// Writes the Azure Monitor alert-rule ARM templates (built by
+/// <see cref="AlertRuleTemplateBuilder"/>) and a companion README into a
+/// <c>Monitoring/AlertRules</c> folder under a caller-supplied output directory.
+/// </summary>
+/// <remarks>
+/// Templates are serialized with <see cref="AdfJsonSerializer"/> so they are deterministic,
+/// indented, and preserve dictionary keys such as <c>odata.type</c>. Generation is purely
+/// local file I/O — it performs no Azure calls.
+/// </remarks>
+public sealed class AlertRuleTemplateGenerationService
+{
+    /// <summary>Sub-folder (under the output directory) the alert-rule artifacts are written to.</summary>
+    public const string AlertRulesFolder = "Monitoring/AlertRules";
+
+    /// <summary>File name of the metric-alerts ARM template.</summary>
+    public const string MetricAlertsTemplateFileName = "metric-alerts.template.json";
+
+    /// <summary>File name of the stalled-pipeline log-alert ARM template.</summary>
+    public const string StalledPipelineTemplateFileName = "stalled-pipeline-log-alert.template.json";
+
+    /// <summary>File name of the README describing the generated alert rules.</summary>
+    public const string ReadmeFileName = "README.md";
+
+    private readonly AlertRuleTemplateBuilder _builder;
+    private readonly AlertRuleOptions _options;
+    private readonly ILogger<AlertRuleTemplateGenerationService> _logger;
+
+    /// <summary>
+    /// Creates the alert-rule template generation service.
+    /// </summary>
+    /// <param name="builder">Builder that produces the ARM template objects.</param>
+    /// <param name="options">Threshold/severity/window settings driving the templates.</param>
+    /// <param name="logger">Logger for diagnostics.</param>
+    /// <exception cref="ArgumentNullException">Any argument is <c>null</c>.</exception>
+    public AlertRuleTemplateGenerationService(
+        AlertRuleTemplateBuilder builder,
+        AlertRuleOptions options,
+        ILogger<AlertRuleTemplateGenerationService> logger)
+    {
+        _builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Generates the alert-rule templates and README under
+    /// <paramref name="outputDirectory"/>/<see cref="AlertRulesFolder"/>.
+    /// </summary>
+    /// <param name="outputDirectory">Root output directory; the alert-rules sub-folder is created beneath it.</param>
+    /// <param name="cancellationToken">Token to cancel the file writes.</param>
+    /// <returns>The paths of the written artifacts plus any warnings.</returns>
+    /// <exception cref="ArgumentException"><paramref name="outputDirectory"/> is null or whitespace.</exception>
+    public async Task<AlertRuleGenerationResult> GenerateAsync(
+        string outputDirectory,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(outputDirectory))
+        {
+            throw new ArgumentException("Output directory must be provided.", nameof(outputDirectory));
+        }
+
+        var warnings = new List<string>();
+        if (_options.IncludeRequestUnitsThresholdAlert && _options.RequestUnitsThreshold <= 0)
+        {
+            warnings.Add(
+                "Request-Units alert is enabled but RequestUnitsThreshold is <= 0; the generated rule would fire continuously. Set a positive threshold before deploying.");
+        }
+
+        var targetDir = Path.Combine(outputDirectory, AlertRulesFolder.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(targetDir);
+
+        var metricAlertsTemplate = _builder.BuildMetricAlertsTemplate(_options);
+        var stalledTemplate = _builder.BuildStalledPipelineLogAlertTemplate(_options);
+
+        var metricAlertsPath = Path.Combine(targetDir, MetricAlertsTemplateFileName);
+        var stalledPath = Path.Combine(targetDir, StalledPipelineTemplateFileName);
+        var readmePath = Path.Combine(targetDir, ReadmeFileName);
+
+        await File.WriteAllTextAsync(
+            metricAlertsPath,
+            AdfJsonSerializer.Serialize(metricAlertsTemplate),
+            Encoding.UTF8,
+            cancellationToken).ConfigureAwait(false);
+
+        await File.WriteAllTextAsync(
+            stalledPath,
+            AdfJsonSerializer.Serialize(stalledTemplate),
+            Encoding.UTF8,
+            cancellationToken).ConfigureAwait(false);
+
+        await File.WriteAllTextAsync(
+            readmePath,
+            BuildReadme(),
+            Encoding.UTF8,
+            cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Generated Azure Monitor alert-rule templates in {Directory} ({WarningCount} warning(s)).",
+            targetDir,
+            warnings.Count);
+
+        return new AlertRuleGenerationResult
+        {
+            MetricAlertsTemplatePath = metricAlertsPath,
+            StalledPipelineTemplatePath = stalledPath,
+            ReadmePath = readmePath,
+            Warnings = warnings,
+        };
+    }
+
+    private string BuildReadme()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("# Migration alert rules");
+        sb.AppendLine();
+        sb.AppendLine("Deployable Azure Monitor alert rules for the Cosmos DB → SQL migration. The metric");
+        sb.AppendLine($"alerts target the `{_options.MetricNamespace}` custom-metric namespace emitted by the");
+        sb.AppendLine("monitoring service; the log alert reads the ADF diagnostic tables in Log Analytics.");
+        sb.AppendLine();
+        sb.AppendLine($"## `{MetricAlertsTemplateFileName}`");
+        sb.AppendLine();
+        sb.AppendLine("`Microsoft.Insights/metricAlerts` rules:");
+        sb.AppendLine();
+        sb.AppendLine($"- **Error rate high** (static, severity {_options.ErrorRateSeverity}) — `{MigrationMonitoringService.MetricErrorRate}` average `> {_options.ErrorRateThreshold}`.");
+        sb.AppendLine($"- **Error spike** (dynamic, severity {_options.ErrorSpikeSeverity}) — `{MigrationMonitoringService.MetricErrorCount}` deviates from baseline (`{_options.ErrorSpikeSensitivity}` sensitivity, {_options.ErrorSpikeMinFailingPeriods}/{_options.ErrorSpikeNumberOfEvaluationPeriods} periods).");
+        if (_options.IncludeLowThroughputAlert)
+        {
+            sb.AppendLine($"- **Low throughput** (static, severity {_options.LowThroughputSeverity}) — `{MigrationMonitoringService.MetricRowsMigrated}` total `<= 0` while telemetry is flowing.");
+        }
+
+        if (_options.IncludeRequestUnitsThresholdAlert)
+        {
+            sb.AppendLine($"- **Request Units high** (static, severity {_options.RequestUnitsSeverity}) — `{MigrationMonitoringService.MetricRequestUnits}` total `> {_options.RequestUnitsThreshold}`.");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("> Metric alerts do **not** fire on *missing* data, so a pipeline that stops emitting");
+        sb.AppendLine("> entirely is detected by the stalled-pipeline log alert below, not by the");
+        sb.AppendLine("> low-throughput metric alert. `skipMetricValidation` is set so the template deploys");
+        sb.AppendLine("> before the custom metrics are first ingested.");
+        sb.AppendLine();
+        sb.AppendLine("Deploy:");
+        sb.AppendLine();
+        sb.AppendLine("```bash");
+        sb.AppendLine($"az deployment group create --resource-group <rg> --template-file {MetricAlertsTemplateFileName} \\");
+        sb.AppendLine($"  --parameters {AlertRuleTemplateBuilder.ParamTargetResourceId}=<resourceId> {AlertRuleTemplateBuilder.ParamActionGroupResourceId}=<actionGroupId>");
+        sb.AppendLine("```");
+        sb.AppendLine();
+        sb.AppendLine($"## `{StalledPipelineTemplateFileName}`");
+        sb.AppendLine();
+        sb.AppendLine($"`Microsoft.Insights/scheduledQueryRules` log alert (severity {_options.StalledPipelineSeverity}) that flags in-progress");
+        sb.AppendLine($"pipelines with no activity progress in the last `{_options.StalledActivityGap}`. This is the reliable");
+        sb.AppendLine("dead-pipeline detector. `skipQueryValidation` is set so it deploys before the ADF");
+        sb.AppendLine("tables are populated.");
+        sb.AppendLine();
+        sb.AppendLine("Deploy:");
+        sb.AppendLine();
+        sb.AppendLine("```bash");
+        sb.AppendLine($"az deployment group create --resource-group <rg> --template-file {StalledPipelineTemplateFileName} \\");
+        sb.AppendLine($"  --parameters {AlertRuleTemplateBuilder.ParamWorkspaceResourceId}=<workspaceId> {AlertRuleTemplateBuilder.ParamActionGroupResourceId}=<actionGroupId>");
+        sb.AppendLine("```");
+        sb.AppendLine();
+        sb.AppendLine("Adjust thresholds, severities, and evaluation windows via the `parameters` block or by");
+        sb.AppendLine("re-running generation with a tuned `AzureMonitor:Alerts` configuration section.");
+        return sb.ToString();
+    }
+}

--- a/Services/Monitoring/AnomalyDetectionService.cs
+++ b/Services/Monitoring/AnomalyDetectionService.cs
@@ -1,0 +1,224 @@
+using System.Runtime.CompilerServices;
+using CosmosToSqlAssessment.Models.Monitoring;
+using Microsoft.Extensions.Logging;
+
+namespace CosmosToSqlAssessment.Services.Monitoring;
+
+/// <summary>
+/// Detects anomalies in migration Request-Units/sec and throughput using a simple
+/// rolling-window z-score baseline (#226). Feeds from the enriched
+/// <see cref="MigrationProgressSnapshot"/> stream produced by <see cref="MigrationMonitoringService"/>
+/// and is surfaced as warnings by the <c>migration status</c> command (#225).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The detector keeps a fixed-length window of recent observed values per
+/// (pipeline, run, activity, metric) key. For each new observation it evaluates the value
+/// against the baseline formed by the <em>prior</em> values in the window (so a value never
+/// contaminates its own baseline), then appends it.
+/// </para>
+/// <para>
+/// <b>This type is stateful and not thread-safe.</b> It is intended to be driven by a single
+/// streaming loop (the scoped CLI run). Do not share one instance across concurrent consumers.
+/// The fixed sample-count window is a heuristic and does not model elapsed time or migration
+/// phase changes; tune <see cref="AnomalyDetectionOptions.ZScoreThreshold"/> and
+/// <see cref="AnomalyDetectionOptions.MinRelativeChange"/> if false positives occur.
+/// </para>
+/// </remarks>
+public sealed class AnomalyDetectionService
+{
+    /// <summary>Metric name for the Request-Units-per-second series.</summary>
+    public const string MetricRequestUnitsPerSecond = "RequestUnitsPerSecond";
+
+    /// <summary>Metric name for the throughput (rows-per-second) series.</summary>
+    public const string MetricThroughputRowsPerSecond = "ThroughputRowsPerSecond";
+
+    private static readonly IReadOnlySet<string> TerminalStatuses = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "Succeeded",
+        "Failed",
+        "Cancelled",
+        "Canceled",
+        "Completed",
+    };
+
+    private readonly AnomalyDetectionOptions _options;
+    private readonly ILogger<AnomalyDetectionService> _logger;
+    private readonly Dictionary<AnomalyKey, Queue<double>> _windows = new();
+
+    /// <summary>
+    /// Creates the anomaly detection service.
+    /// </summary>
+    /// <param name="options">Detector configuration.</param>
+    /// <param name="logger">Logger for diagnostics.</param>
+    /// <exception cref="ArgumentNullException">Any argument is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="options"/> contains an invalid combination.</exception>
+    public AnomalyDetectionService(AnomalyDetectionOptions options, ILogger<AnomalyDetectionService> logger)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        if (_options.WindowSize <= 0)
+        {
+            throw new ArgumentException("WindowSize must be greater than 0.", nameof(options));
+        }
+
+        if (_options.MinSamplesForBaseline < 2)
+        {
+            throw new ArgumentException("MinSamplesForBaseline must be at least 2.", nameof(options));
+        }
+
+        if (_options.WindowSize < _options.MinSamplesForBaseline)
+        {
+            throw new ArgumentException("WindowSize must be >= MinSamplesForBaseline.", nameof(options));
+        }
+
+        if (_options.ZScoreThreshold <= 0)
+        {
+            throw new ArgumentException("ZScoreThreshold must be greater than 0.", nameof(options));
+        }
+
+        if (_options.MinBaselineStdDev <= 0)
+        {
+            throw new ArgumentException("MinBaselineStdDev must be greater than 0.", nameof(options));
+        }
+
+        if (_options.MinRelativeChange < 0)
+        {
+            throw new ArgumentException("MinRelativeChange must be >= 0.", nameof(options));
+        }
+    }
+
+    /// <summary>
+    /// Evaluates a single snapshot against the rolling baselines and returns any anomalies.
+    /// Updates internal per-key window state as a side effect.
+    /// </summary>
+    /// <param name="snapshot">The progress snapshot to evaluate.</param>
+    /// <returns>The anomalies detected for this snapshot (possibly empty).</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="snapshot"/> is <c>null</c>.</exception>
+    public IReadOnlyList<MigrationAnomaly> Detect(MigrationProgressSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        if (!_options.Enabled)
+        {
+            return Array.Empty<MigrationAnomaly>();
+        }
+
+        var anomalies = new List<MigrationAnomaly>();
+
+        if (_options.WatchRequestUnits && snapshot.RequestUnitsPerSecond is { } ru)
+        {
+            EvaluateMetric(snapshot, MetricRequestUnitsPerSecond, ru, anomalies);
+        }
+
+        if (_options.WatchThroughput && snapshot.ThroughputRowsPerSecond is { } throughput)
+        {
+            EvaluateMetric(snapshot, MetricThroughputRowsPerSecond, throughput, anomalies);
+        }
+
+        return anomalies;
+    }
+
+    /// <summary>
+    /// Streams anomalies detected across a snapshot stream.
+    /// </summary>
+    /// <param name="snapshots">The source snapshot stream.</param>
+    /// <param name="cancellationToken">Token that stops enumeration.</param>
+    /// <returns>A stream of detected anomalies.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="snapshots"/> is <c>null</c>.</exception>
+    public async IAsyncEnumerable<MigrationAnomaly> DetectAsync(
+        IAsyncEnumerable<MigrationProgressSnapshot> snapshots,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(snapshots);
+
+        await foreach (var snapshot in snapshots.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            foreach (var anomaly in Detect(snapshot))
+            {
+                yield return anomaly;
+            }
+        }
+    }
+
+    private void EvaluateMetric(
+        MigrationProgressSnapshot snapshot,
+        string metricName,
+        double value,
+        List<MigrationAnomaly> anomalies)
+    {
+        var sample = snapshot.Sample;
+        var key = new AnomalyKey(sample.PipelineName, sample.RunId, sample.ActivityName, metricName);
+
+        if (!_windows.TryGetValue(key, out var window))
+        {
+            window = new Queue<double>(_options.WindowSize);
+            _windows[key] = window;
+        }
+
+        if (window.Count >= _options.MinSamplesForBaseline)
+        {
+            var (mean, stdDev) = MeanAndSampleStdDev(window);
+            var effectiveStdDev = Math.Max(stdDev, _options.MinBaselineStdDev);
+            var zScore = (value - mean) / effectiveStdDev;
+            var relativeChange = Math.Abs(value - mean) / Math.Max(Math.Abs(mean), _options.MinBaselineStdDev);
+
+            if (Math.Abs(zScore) >= _options.ZScoreThreshold && relativeChange >= _options.MinRelativeChange)
+            {
+                var direction = value >= mean ? AnomalyDirection.High : AnomalyDirection.Low;
+                var suppress = direction == AnomalyDirection.Low
+                    && _options.SuppressLowOnTerminalStatus
+                    && TerminalStatuses.Contains(sample.Status);
+
+                if (!suppress)
+                {
+                    anomalies.Add(new MigrationAnomaly
+                    {
+                        Timestamp = sample.Timestamp,
+                        PipelineName = sample.PipelineName,
+                        ActivityName = sample.ActivityName,
+                        RunId = sample.RunId,
+                        MetricName = metricName,
+                        ObservedValue = value,
+                        BaselineMean = mean,
+                        BaselineStdDev = stdDev,
+                        ZScore = zScore,
+                        Direction = direction,
+                    });
+
+                    _logger.LogInformation(
+                        "Anomaly detected for {Pipeline}/{Activity} {Metric}: value={Value} z={Z} (mean={Mean}, stddev={StdDev}).",
+                        sample.PipelineName,
+                        sample.ActivityName,
+                        metricName,
+                        value,
+                        zScore,
+                        mean,
+                        stdDev);
+                }
+            }
+        }
+
+        window.Enqueue(value);
+        while (window.Count > _options.WindowSize)
+        {
+            window.Dequeue();
+        }
+    }
+
+    private static (double Mean, double StdDev) MeanAndSampleStdDev(IReadOnlyCollection<double> values)
+    {
+        var count = values.Count;
+        var mean = values.Sum() / count;
+        var sumSquaredDeviations = values.Sum(v => (v - mean) * (v - mean));
+        var variance = sumSquaredDeviations / (count - 1);
+        return (mean, Math.Sqrt(variance));
+    }
+
+    private readonly record struct AnomalyKey(
+        string PipelineName,
+        string? RunId,
+        string? ActivityName,
+        string MetricName);
+}

--- a/Services/Monitoring/AzureMonitorMetricOptions.cs
+++ b/Services/Monitoring/AzureMonitorMetricOptions.cs
@@ -1,0 +1,48 @@
+namespace CosmosToSqlAssessment.Services.Monitoring;
+
+/// <summary>
+/// Strongly-typed options for publishing migration progress metrics to Azure Monitor as
+/// custom metrics. Bound from the <c>AzureMonitor:Metrics</c> configuration section.
+/// </summary>
+/// <remarks>
+/// Metric ingestion is a distinct write surface from the Azure Monitor Query SDK used for
+/// reading metrics (#76); it shares the same credential and the <c>AzureMonitor</c>
+/// configuration root but uses these write-specific settings. <see cref="Enabled"/>
+/// defaults to <c>false</c> so offline / CI runs never attempt a live call.
+/// </remarks>
+public sealed class AzureMonitorMetricOptions
+{
+    /// <summary>Configuration section these options bind from.</summary>
+    public const string SectionName = "AzureMonitor:Metrics";
+
+    /// <summary>Default custom-metric namespace when none is configured.</summary>
+    public const string DefaultMetricNamespace = "CosmosToSqlMigration";
+
+    /// <summary>
+    /// When <c>true</c>, the publisher POSTs metrics to Azure Monitor. When <c>false</c>
+    /// (the default) the publisher is a no-op, which keeps offline and CI runs side-effect free.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Azure region of the target resource (e.g. <c>eastus</c>). Combined with
+    /// <see cref="ResourceId"/> to form the regional ingestion endpoint
+    /// <c>https://&lt;region&gt;.monitoring.azure.com&lt;resourceId&gt;/metrics</c>. Required when enabled.
+    /// </summary>
+    public string? Region { get; set; }
+
+    /// <summary>
+    /// Full ARM resource ID of the resource the custom metrics are emitted against
+    /// (e.g. the Data Factory or Cosmos account), beginning with <c>/subscriptions/</c>. Required when enabled.
+    /// </summary>
+    public string? ResourceId { get; set; }
+
+    /// <summary>Custom-metric namespace metrics are published under. Defaults to <see cref="DefaultMetricNamespace"/>.</summary>
+    public string MetricNamespace { get; set; } = DefaultMetricNamespace;
+
+    /// <summary>
+    /// When <c>true</c>, the ADF run id is included as a metric dimension. Off by default to
+    /// avoid high-cardinality metric series; the run id always remains available on the snapshot and logs.
+    /// </summary>
+    public bool IncludeRunIdDimension { get; set; }
+}

--- a/Services/Monitoring/AzureMonitorMetricPayloadBuilder.cs
+++ b/Services/Monitoring/AzureMonitorMetricPayloadBuilder.cs
@@ -1,0 +1,123 @@
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using CosmosToSqlAssessment.Models.Monitoring;
+
+namespace CosmosToSqlAssessment.Services.Monitoring;
+
+/// <summary>
+/// Builds Azure Monitor custom-metric ingestion payloads from
+/// <see cref="MigrationMetricPoint"/>s. The output matches the documented schema:
+/// <code>
+/// { "time": "&lt;ISO-8601 UTC&gt;",
+///   "data": { "baseData": { "metric": "...", "namespace": "...",
+///     "dimNames": ["..."], "series": [ { "dimValues": ["..."], "min": n, "max": n, "sum": n, "count": n } ] } } }
+/// </code>
+/// Points that share a namespace, metric name, timestamp, and dimension-name shape are
+/// grouped into a single payload with one series per point. This keeps each payload valid
+/// (Azure Monitor requires a stable <c>dimNames</c> array across all series in a payload).
+/// The class is pure and deterministic, so it is exercised directly in unit tests without a live call.
+/// </summary>
+public sealed class AzureMonitorMetricPayloadBuilder
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
+    /// <summary>
+    /// Builds one payload object per (namespace, metric, timestamp, dimension-name shape) group.
+    /// </summary>
+    /// <param name="points">Metric points to convert. <c>null</c> or empty yields an empty list.</param>
+    /// <returns>An ordered, deterministic list of payload dictionaries.</returns>
+    public IReadOnlyList<Dictionary<string, object?>> BuildPayloads(IEnumerable<MigrationMetricPoint>? points)
+    {
+        if (points is null)
+        {
+            return Array.Empty<Dictionary<string, object?>>();
+        }
+
+        var groups = new Dictionary<string, List<MigrationMetricPoint>>(StringComparer.Ordinal);
+        var order = new List<string>();
+
+        foreach (var point in points)
+        {
+            var dimNames = OrderedDimensionNames(point);
+            var time = FormatTimestamp(point.Timestamp);
+            var key = string.Join('\u001f', point.Namespace, point.Name, time, string.Join(',', dimNames));
+
+            if (!groups.TryGetValue(key, out var list))
+            {
+                list = new List<MigrationMetricPoint>();
+                groups[key] = list;
+                order.Add(key);
+            }
+            list.Add(point);
+        }
+
+        var payloads = new List<Dictionary<string, object?>>(order.Count);
+        foreach (var key in order)
+        {
+            payloads.Add(BuildPayload(groups[key]));
+        }
+        return payloads;
+    }
+
+    /// <summary>
+    /// Builds the payloads (see <see cref="BuildPayloads"/>) and serializes each to a
+    /// compact, camelCase JSON string ready to POST to the metrics ingestion endpoint.
+    /// </summary>
+    /// <param name="points">Metric points to convert.</param>
+    /// <returns>One JSON string per payload group.</returns>
+    public IReadOnlyList<string> BuildPayloadJson(IEnumerable<MigrationMetricPoint>? points)
+        => BuildPayloads(points).Select(p => JsonSerializer.Serialize(p, SerializerOptions)).ToList();
+
+    private static Dictionary<string, object?> BuildPayload(IReadOnlyList<MigrationMetricPoint> group)
+    {
+        var representative = group[0];
+        var dimNames = OrderedDimensionNames(representative);
+
+        var series = new List<object?>(group.Count);
+        foreach (var point in group)
+        {
+            var dimValues = dimNames
+                .Select(name => point.Dimensions.TryGetValue(name, out var value) ? value : string.Empty)
+                .Cast<object?>()
+                .ToList();
+
+            series.Add(new Dictionary<string, object?>
+            {
+                ["dimValues"] = dimValues,
+                ["min"] = point.Value,
+                ["max"] = point.Value,
+                ["sum"] = point.Value,
+                ["count"] = 1,
+            });
+        }
+
+        var baseData = new Dictionary<string, object?>
+        {
+            ["metric"] = representative.Name,
+            ["namespace"] = representative.Namespace,
+            ["dimNames"] = dimNames.Cast<object?>().ToList(),
+            ["series"] = series,
+        };
+
+        return new Dictionary<string, object?>
+        {
+            ["time"] = FormatTimestamp(representative.Timestamp),
+            ["data"] = new Dictionary<string, object?>
+            {
+                ["baseData"] = baseData,
+            },
+        };
+    }
+
+    private static List<string> OrderedDimensionNames(MigrationMetricPoint point)
+        => point.Dimensions.Keys.OrderBy(k => k, StringComparer.Ordinal).ToList();
+
+    private static string FormatTimestamp(DateTimeOffset timestamp)
+        => timestamp.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
+}

--- a/Services/Monitoring/AzureMonitorMetricPublisher.cs
+++ b/Services/Monitoring/AzureMonitorMetricPublisher.cs
@@ -1,0 +1,162 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using Azure.Core;
+using Azure.Identity;
+using CosmosToSqlAssessment.Models.Monitoring;
+using Microsoft.Extensions.Logging;
+
+namespace CosmosToSqlAssessment.Services.Monitoring;
+
+/// <summary>
+/// Default <see cref="IMigrationMetricPublisher"/> that streams custom metrics to the
+/// Azure Monitor regional ingestion endpoint
+/// (<c>https://&lt;region&gt;.monitoring.azure.com&lt;resourceId&gt;/metrics</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Reuses the Azure Monitor surface introduced by #76 — the same
+/// <see cref="DefaultAzureCredential"/> auth and the <c>AzureMonitor</c> configuration
+/// root — but targets the metric-ingestion REST API rather than the read-only Query SDK.
+/// </para>
+/// <para>
+/// Publishing is gated by <see cref="AzureMonitorMetricOptions.Enabled"/> (default
+/// <c>false</c>), so offline / CI runs never make a live call. When enabled but missing
+/// the region or resource id, the publisher logs an error once and no-ops. Per-payload
+/// HTTP failures are logged and swallowed so a publish failure never aborts the caller's
+/// progress stream.
+/// </para>
+/// </remarks>
+public sealed class AzureMonitorMetricPublisher : IMigrationMetricPublisher
+{
+    private static readonly string[] IngestionScopes = { "https://monitoring.azure.com/.default" };
+
+    private readonly AzureMonitorMetricOptions _options;
+    private readonly ILogger<AzureMonitorMetricPublisher> _logger;
+    private readonly TokenCredential _credential;
+    private readonly HttpClient _httpClient;
+    private readonly AzureMonitorMetricPayloadBuilder _payloadBuilder;
+
+    private bool _loggedDisabled;
+    private bool _loggedMisconfigured;
+
+    /// <summary>
+    /// Production constructor. Builds a <see cref="DefaultAzureCredential"/> and an
+    /// <see cref="HttpClient"/> internally.
+    /// </summary>
+    /// <param name="options">Metric publishing options.</param>
+    /// <param name="logger">Logger for diagnostics.</param>
+    public AzureMonitorMetricPublisher(
+        AzureMonitorMetricOptions options,
+        ILogger<AzureMonitorMetricPublisher> logger)
+        : this(options, logger, new DefaultAzureCredential(), new HttpClient(), new AzureMonitorMetricPayloadBuilder())
+    {
+    }
+
+    /// <summary>
+    /// Test/advanced constructor that accepts the credential, HTTP client, and payload
+    /// builder so unit tests can inject fakes and never make a live call.
+    /// </summary>
+    /// <param name="options">Metric publishing options.</param>
+    /// <param name="logger">Logger for diagnostics.</param>
+    /// <param name="credential">Token credential used to acquire ingestion tokens.</param>
+    /// <param name="httpClient">HTTP client used to POST payloads.</param>
+    /// <param name="payloadBuilder">Builder that converts metric points to ingestion payloads.</param>
+    internal AzureMonitorMetricPublisher(
+        AzureMonitorMetricOptions options,
+        ILogger<AzureMonitorMetricPublisher> logger,
+        TokenCredential credential,
+        HttpClient httpClient,
+        AzureMonitorMetricPayloadBuilder payloadBuilder)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _credential = credential ?? throw new ArgumentNullException(nameof(credential));
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _payloadBuilder = payloadBuilder ?? throw new ArgumentNullException(nameof(payloadBuilder));
+    }
+
+    /// <inheritdoc />
+    public async Task PublishAsync(IReadOnlyList<MigrationMetricPoint> metrics, CancellationToken cancellationToken = default)
+    {
+        if (metrics is null || metrics.Count == 0)
+        {
+            return;
+        }
+
+        if (!_options.Enabled)
+        {
+            if (!_loggedDisabled)
+            {
+                _loggedDisabled = true;
+                _logger.LogInformation("Azure Monitor metric publishing is disabled (AzureMonitor:Metrics:Enabled=false). Metrics will not be sent.");
+            }
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(_options.Region) || string.IsNullOrWhiteSpace(_options.ResourceId))
+        {
+            if (!_loggedMisconfigured)
+            {
+                _loggedMisconfigured = true;
+                _logger.LogError("Azure Monitor metric publishing is enabled but AzureMonitor:Metrics:Region or :ResourceId is missing. Metrics will not be sent.");
+            }
+            return;
+        }
+
+        var endpoint = BuildEndpoint(_options.Region!, _options.ResourceId!);
+
+        string accessToken;
+        try
+        {
+            var token = await _credential.GetTokenAsync(new TokenRequestContext(IngestionScopes), cancellationToken).ConfigureAwait(false);
+            accessToken = token.Token;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Failed to acquire an Azure Monitor ingestion token; skipping metric publish.");
+            return;
+        }
+
+        foreach (var json in _payloadBuilder.BuildPayloadJson(metrics))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json"),
+                };
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+                using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                if (!response.IsSuccessStatusCode)
+                {
+                    var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                    _logger.LogWarning(
+                        "Azure Monitor metric ingestion returned {StatusCode}: {Body}",
+                        (int)response.StatusCode,
+                        body);
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex, "Failed to POST a metric payload to Azure Monitor; continuing.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Builds the regional metric-ingestion endpoint for the supplied region and resource id.
+    /// </summary>
+    /// <param name="region">Azure region (e.g. <c>eastus</c>).</param>
+    /// <param name="resourceId">Full ARM resource id beginning with <c>/subscriptions/</c>.</param>
+    /// <returns>The absolute ingestion URL.</returns>
+    public static string BuildEndpoint(string region, string resourceId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(region);
+        ArgumentException.ThrowIfNullOrWhiteSpace(resourceId);
+        var normalizedResource = resourceId.StartsWith('/') ? resourceId : "/" + resourceId;
+        return $"https://{region}.monitoring.azure.com{normalizedResource}/metrics";
+    }
+}

--- a/Services/Monitoring/AzureMonitorMigrationStatusSource.cs
+++ b/Services/Monitoring/AzureMonitorMigrationStatusSource.cs
@@ -1,0 +1,287 @@
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Azure.Identity;
+using Azure.Monitor.Query;
+using Azure.Monitor.Query.Models;
+using CosmosToSqlAssessment.Models.Monitoring;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace CosmosToSqlAssessment.Services.Monitoring;
+
+/// <summary>
+/// Default <see cref="IMigrationStatusSource"/> that reads in-flight migration progress from
+/// Azure Data Factory Copy-activity telemetry (parent #70) surfaced in Log Analytics
+/// (parent #76). Reuses the existing <c>AzureMonitor:WorkspaceId</c> configuration and
+/// <see cref="DefaultAzureCredential"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// When no Log Analytics workspace is configured the source yields nothing (and performs no
+/// network call), so offline / CI runs of <c>migration status</c> simply report that no live
+/// source is available. ADF activity output reports <em>cumulative</em> rows per activity, so
+/// the source diffs successive observations into the per-window deltas the monitoring pipeline
+/// (#223) expects.
+/// </para>
+/// <para>
+/// Request-Unit consumption is not present in ADF logs; it flows through the custom-metric
+/// publishing path instead, so the samples produced here carry rows/throughput/status only.
+/// </para>
+/// </remarks>
+public sealed class AzureMonitorMigrationStatusSource : IMigrationStatusSource
+{
+    /// <summary>Default Log Analytics lookback window, in minutes, when none is configured.</summary>
+    public const int DefaultLookbackMinutes = 60;
+
+    private const string LookbackConfigKey = "AzureMonitor:Status:LookbackMinutes";
+    private const string WorkspaceConfigKey = "AzureMonitor:WorkspaceId";
+
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<AzureMonitorMigrationStatusSource> _logger;
+    private readonly LogsQueryClient? _logsQueryClient;
+
+    /// <summary>
+    /// Production constructor. Builds a <see cref="LogsQueryClient"/> with
+    /// <see cref="DefaultAzureCredential"/> when a workspace is configured.
+    /// </summary>
+    /// <param name="configuration">Application configuration carrying the Azure Monitor settings.</param>
+    /// <param name="logger">Logger for diagnostics.</param>
+    /// <exception cref="ArgumentNullException">Any argument is <c>null</c>.</exception>
+    public AzureMonitorMigrationStatusSource(
+        IConfiguration configuration,
+        ILogger<AzureMonitorMigrationStatusSource> logger)
+    {
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        var workspaceId = _configuration[WorkspaceConfigKey];
+        if (!string.IsNullOrWhiteSpace(workspaceId))
+        {
+            try
+            {
+                _logsQueryClient = new LogsQueryClient(new DefaultAzureCredential());
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to initialize Azure Monitor logs client for migration status.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Test-friendly constructor accepting a pre-built <see cref="LogsQueryClient"/>.
+    /// </summary>
+    /// <param name="configuration">Application configuration carrying the Azure Monitor settings.</param>
+    /// <param name="logger">Logger for diagnostics.</param>
+    /// <param name="logsQueryClient">Pre-built logs query client (or <c>null</c> for the no-source path).</param>
+    internal AzureMonitorMigrationStatusSource(
+        IConfiguration configuration,
+        ILogger<AzureMonitorMigrationStatusSource> logger,
+        LogsQueryClient? logsQueryClient)
+    {
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _logsQueryClient = logsQueryClient;
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<MigrationProgressSample> ReadSamplesAsync(
+        MigrationStatusReportOptions options,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var workspaceId = _configuration[WorkspaceConfigKey];
+        if (_logsQueryClient is null || string.IsNullOrWhiteSpace(workspaceId))
+        {
+            _logger.LogWarning(
+                "Azure Monitor workspace not configured ({Key}); migration status has no live source.",
+                WorkspaceConfigKey);
+            yield break;
+        }
+
+        var lookbackMinutes = GetLookbackMinutes();
+        var lastRowsByKey = new Dictionary<string, long>(StringComparer.Ordinal);
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var observations = await QueryObservationsAsync(workspaceId!, lookbackMinutes, cancellationToken)
+                .ConfigureAwait(false);
+
+            foreach (var observation in observations)
+            {
+                var previous = lastRowsByKey.TryGetValue(observation.Key, out var p) ? p : 0L;
+                var delta = observation.CumulativeRowsCopied - previous;
+                if (delta < 0)
+                {
+                    // Activity restarted / counter reset — treat the current value as the delta.
+                    delta = observation.CumulativeRowsCopied;
+                }
+
+                lastRowsByKey[observation.Key] = observation.CumulativeRowsCopied;
+
+                yield return new MigrationProgressSample
+                {
+                    Timestamp = observation.Timestamp,
+                    PipelineName = observation.PipelineName,
+                    ActivityName = observation.ActivityName,
+                    RunId = observation.RunId,
+                    Status = observation.Status,
+                    RowsMigrated = delta,
+                };
+            }
+
+            if (!options.Watch)
+            {
+                yield break;
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(options.PollIntervalSeconds), cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private int GetLookbackMinutes()
+    {
+        var raw = _configuration[LookbackConfigKey];
+        return int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var minutes) && minutes > 0
+            ? minutes
+            : DefaultLookbackMinutes;
+    }
+
+    private async Task<IReadOnlyList<ActivityObservation>> QueryObservationsAsync(
+        string workspaceId,
+        int lookbackMinutes,
+        CancellationToken cancellationToken)
+    {
+        var query = BuildQuery(lookbackMinutes);
+        var endTime = DateTimeOffset.UtcNow;
+        var startTime = endTime.AddMinutes(-lookbackMinutes);
+
+        try
+        {
+            var response = await _logsQueryClient!.QueryWorkspaceAsync(
+                workspaceId,
+                query,
+                new QueryTimeRange(startTime, endTime),
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            var table = response.Value?.Table;
+            if (table is null || table.Rows.Count == 0)
+            {
+                return Array.Empty<ActivityObservation>();
+            }
+
+            var observations = new List<ActivityObservation>(table.Rows.Count);
+            foreach (var row in table.Rows)
+            {
+                observations.Add(MapRow(row));
+            }
+
+            return observations;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Querying Azure Monitor for migration status failed; returning no updates this cycle.");
+            return Array.Empty<ActivityObservation>();
+        }
+    }
+
+    /// <summary>
+    /// KQL that projects the latest Copy-activity progress per activity run from the
+    /// Dedicated-mode <c>ADFActivityRun</c> table.
+    /// </summary>
+    /// <param name="lookbackMinutes">How far back, in minutes, to scan.</param>
+    /// <returns>The KQL query text.</returns>
+    internal static string BuildQuery(int lookbackMinutes) =>
+$$"""
+ADFActivityRun
+| where TimeGenerated > ago({{lookbackMinutes}}m)
+| where ActivityType == "Copy"
+| extend out = parse_json(Output)
+| summarize arg_max(TimeGenerated, Status, RowsCopied = tolong(out.rowsCopied), RowsRead = tolong(out.rowsRead))
+    by PipelineName, ActivityName, RunId
+| project TimeGenerated, PipelineName, ActivityName, RunId, Status, RowsCopied, RowsRead
+| order by TimeGenerated asc
+""";
+
+    /// <summary>
+    /// Maps a projected <c>ADFActivityRun</c> row into an <see cref="ActivityObservation"/>.
+    /// Column order matches <see cref="BuildQuery"/>.
+    /// </summary>
+    /// <param name="row">The Log Analytics row to map.</param>
+    /// <returns>The mapped observation.</returns>
+    internal static ActivityObservation MapRow(LogsTableRow row)
+    {
+        ArgumentNullException.ThrowIfNull(row);
+
+        return new ActivityObservation(
+            Timestamp: ReadDateTime(row, 0),
+            PipelineName: ReadString(row, 1),
+            ActivityName: ReadNullableString(row, 2),
+            RunId: ReadNullableString(row, 3),
+            Status: ReadString(row, 4, fallback: "InProgress"),
+            CumulativeRowsCopied: ReadLong(row, 5),
+            CumulativeRowsRead: ReadLong(row, 6));
+    }
+
+    private static DateTimeOffset ReadDateTime(LogsTableRow row, int index)
+    {
+        var value = row[index];
+        return value switch
+        {
+            DateTimeOffset dto => dto,
+            DateTime dt => new DateTimeOffset(dt, TimeSpan.Zero),
+            _ => DateTimeOffset.UtcNow,
+        };
+    }
+
+    private static string ReadString(LogsTableRow row, int index, string fallback = "")
+    {
+        var value = row[index];
+        return value is null ? fallback : value.ToString() ?? fallback;
+    }
+
+    private static string? ReadNullableString(LogsTableRow row, int index)
+    {
+        var value = row[index];
+        var text = value?.ToString();
+        return string.IsNullOrEmpty(text) ? null : text;
+    }
+
+    private static long ReadLong(LogsTableRow row, int index)
+    {
+        var value = row[index];
+        return value switch
+        {
+            null => 0L,
+            long l => l,
+            int i => i,
+            _ => long.TryParse(value.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) ? parsed : 0L,
+        };
+    }
+
+    /// <summary>
+    /// A single latest-progress observation for one ADF Copy activity run.
+    /// </summary>
+    /// <param name="Timestamp">When the observation was generated.</param>
+    /// <param name="PipelineName">Owning pipeline name.</param>
+    /// <param name="ActivityName">Copy activity name, if present.</param>
+    /// <param name="RunId">ADF run identifier, if present.</param>
+    /// <param name="Status">Activity status (e.g. InProgress, Succeeded, Failed).</param>
+    /// <param name="CumulativeRowsCopied">Cumulative rows copied reported by ADF.</param>
+    /// <param name="CumulativeRowsRead">Cumulative rows read reported by ADF.</param>
+    internal sealed record ActivityObservation(
+        DateTimeOffset Timestamp,
+        string PipelineName,
+        string? ActivityName,
+        string? RunId,
+        string Status,
+        long CumulativeRowsCopied,
+        long CumulativeRowsRead)
+    {
+        /// <summary>Stable accumulation key for diffing successive observations.</summary>
+        public string Key => $"{PipelineName}|{RunId}|{ActivityName}";
+    }
+}

--- a/Services/Monitoring/IMigrationMetricPublisher.cs
+++ b/Services/Monitoring/IMigrationMetricPublisher.cs
@@ -1,0 +1,19 @@
+using CosmosToSqlAssessment.Models.Monitoring;
+
+namespace CosmosToSqlAssessment.Services.Monitoring;
+
+/// <summary>
+/// Publishes migration custom-metric points to a sink (Azure Monitor in production).
+/// Implementations must be resilient: a publish failure should never abort the caller's
+/// progress stream.
+/// </summary>
+public interface IMigrationMetricPublisher
+{
+    /// <summary>
+    /// Publishes a batch of metric points. Implementations may group, batch, or no-op
+    /// (e.g. when disabled). Must not throw on transient sink failures.
+    /// </summary>
+    /// <param name="metrics">The metric points to publish. An empty list is a no-op.</param>
+    /// <param name="cancellationToken">Token used to cancel the publish.</param>
+    Task PublishAsync(IReadOnlyList<MigrationMetricPoint> metrics, CancellationToken cancellationToken = default);
+}

--- a/Services/Monitoring/IMigrationStatusSource.cs
+++ b/Services/Monitoring/IMigrationStatusSource.cs
@@ -1,0 +1,27 @@
+using CosmosToSqlAssessment.Models.Monitoring;
+
+namespace CosmosToSqlAssessment.Services.Monitoring;
+
+/// <summary>
+/// Supplies the raw migration progress samples that the <c>migration status</c> command
+/// (#225) renders. Implementations typically read from the Azure Data Factory pipeline run
+/// telemetry (parent #70) surfaced through Azure Monitor (parent #76).
+/// </summary>
+/// <remarks>
+/// In one-shot mode the returned stream yields the currently-known samples and completes.
+/// In watch mode (<see cref="MigrationStatusReportOptions.Watch"/>) the stream keeps yielding
+/// newly observed samples — polling at <see cref="MigrationStatusReportOptions.PollIntervalSeconds"/>
+/// — until the supplied <see cref="CancellationToken"/> is cancelled.
+/// </remarks>
+public interface IMigrationStatusSource
+{
+    /// <summary>
+    /// Reads migration progress samples for the requested reporting mode.
+    /// </summary>
+    /// <param name="options">Watch/poll settings for the read.</param>
+    /// <param name="cancellationToken">Token that stops enumeration (and any polling loop).</param>
+    /// <returns>A stream of progress samples, ordered oldest-to-newest.</returns>
+    IAsyncEnumerable<MigrationProgressSample> ReadSamplesAsync(
+        MigrationStatusReportOptions options,
+        CancellationToken cancellationToken = default);
+}

--- a/Services/Monitoring/MigrationMonitoringService.cs
+++ b/Services/Monitoring/MigrationMonitoringService.cs
@@ -1,0 +1,228 @@
+using System.Runtime.CompilerServices;
+using CosmosToSqlAssessment.Models.Monitoring;
+using Microsoft.Extensions.Logging;
+
+namespace CosmosToSqlAssessment.Services.Monitoring;
+
+/// <summary>
+/// Streams migration progress metrics (rows migrated, RU consumption, error rate) to
+/// Azure Monitor and yields enriched <see cref="MigrationProgressSnapshot"/>s for live
+/// CLI reporting (#225) and anomaly detection (#226).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The service consumes an <see cref="IAsyncEnumerable{T}"/> of
+/// <see cref="MigrationProgressSample"/> (the streaming convention from #129), derives
+/// per-sample custom metrics, publishes them through an
+/// <see cref="IMigrationMetricPublisher"/>, and yields a snapshot for each sample.
+/// </para>
+/// <para>
+/// Cumulative totals and rates are accumulated <em>per</em>
+/// pipeline/run/activity key, so interleaved samples from concurrent runs never
+/// cross-contaminate. A publish failure is logged and swallowed by the publisher so it
+/// never aborts the stream.
+/// </para>
+/// </remarks>
+public sealed class MigrationMonitoringService
+{
+    /// <summary>Metric name for rows migrated in a sample window.</summary>
+    public const string MetricRowsMigrated = "MigrationRowsMigrated";
+
+    /// <summary>Metric name for Request Units consumed in a sample window.</summary>
+    public const string MetricRequestUnits = "MigrationRequestUnitsConsumed";
+
+    /// <summary>Metric name for the windowed error rate (0-1).</summary>
+    public const string MetricErrorRate = "MigrationErrorRate";
+
+    /// <summary>Metric name for the error count in a sample window.</summary>
+    public const string MetricErrorCount = "MigrationErrorCount";
+
+    /// <summary>Dimension name carrying the pipeline name.</summary>
+    public const string DimensionPipeline = "PipelineName";
+
+    /// <summary>Dimension name carrying the activity name.</summary>
+    public const string DimensionActivity = "ActivityName";
+
+    /// <summary>Dimension name carrying the run status.</summary>
+    public const string DimensionStatus = "Status";
+
+    /// <summary>Dimension name carrying the run id (only emitted when opted in).</summary>
+    public const string DimensionRunId = "RunId";
+
+    private readonly IMigrationMetricPublisher _publisher;
+    private readonly AzureMonitorMetricOptions _options;
+    private readonly ILogger<MigrationMonitoringService> _logger;
+
+    /// <summary>
+    /// Creates the monitoring service.
+    /// </summary>
+    /// <param name="publisher">Sink that custom metrics are published to.</param>
+    /// <param name="options">Metric publishing options (namespace, dimension policy).</param>
+    /// <param name="logger">Logger for diagnostics.</param>
+    public MigrationMonitoringService(
+        IMigrationMetricPublisher publisher,
+        AzureMonitorMetricOptions options,
+        ILogger<MigrationMonitoringService> logger)
+    {
+        _publisher = publisher ?? throw new ArgumentNullException(nameof(publisher));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Consumes a stream of progress samples, publishes derived custom metrics for each,
+    /// and yields an enriched snapshot per sample.
+    /// </summary>
+    /// <param name="samples">The source stream of progress samples.</param>
+    /// <param name="cancellationToken">Token that stops enumeration and publishing.</param>
+    /// <returns>A stream of enriched <see cref="MigrationProgressSnapshot"/>s.</returns>
+    public async IAsyncEnumerable<MigrationProgressSnapshot> MonitorAsync(
+        IAsyncEnumerable<MigrationProgressSample> samples,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(samples);
+
+        var state = new Dictionary<string, RunAccumulator>(StringComparer.Ordinal);
+
+        await foreach (var sample in samples.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            if (sample is null)
+            {
+                continue;
+            }
+
+            var snapshot = BuildSnapshot(sample, state);
+
+            // Publish out-of-band of the yield: a publish failure must never break the stream.
+            try
+            {
+                await _publisher.PublishAsync(snapshot.Metrics, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex, "Publishing migration metrics failed for pipeline {Pipeline}; continuing.", sample.PipelineName);
+            }
+
+            yield return snapshot;
+        }
+    }
+
+    private MigrationProgressSnapshot BuildSnapshot(
+        MigrationProgressSample sample,
+        Dictionary<string, RunAccumulator> state)
+    {
+        var key = BuildKey(sample);
+        if (!state.TryGetValue(key, out var acc))
+        {
+            acc = new RunAccumulator();
+            state[key] = acc;
+        }
+
+        double? windowSeconds = acc.LastTimestamp is { } last && sample.Timestamp > last
+            ? (sample.Timestamp - last).TotalSeconds
+            : null;
+
+        acc.RowsMigrated += sample.RowsMigrated;
+        acc.RowsRead += sample.RowsRead ?? 0;
+        acc.ErrorCount += sample.ErrorCount;
+        acc.RequestUnits += sample.RequestUnitsConsumed;
+        acc.LastTimestamp = sample.Timestamp;
+
+        var windowDenominator = sample.RowsRead ?? (sample.RowsMigrated + sample.ErrorCount);
+        var errorRate = windowDenominator > 0 ? (double)sample.ErrorCount / windowDenominator : 0d;
+
+        var cumulativeDenominator = acc.RowsRead > 0 ? acc.RowsRead : acc.RowsMigrated + acc.ErrorCount;
+        var cumulativeErrorRate = cumulativeDenominator > 0 ? (double)acc.ErrorCount / cumulativeDenominator : 0d;
+
+        double? percentComplete = sample.TotalRows is { } total && total > 0
+            ? Math.Min(100d, 100d * acc.RowsMigrated / total)
+            : null;
+
+        double? throughputRowsPerSecond = windowSeconds is { } secs && secs > 0
+            ? sample.RowsMigrated / secs
+            : null;
+        double? requestUnitsPerSecond = windowSeconds is { } secs2 && secs2 > 0
+            ? sample.RequestUnitsConsumed / secs2
+            : null;
+
+        var metrics = BuildMetricPoints(sample, errorRate);
+
+        return new MigrationProgressSnapshot
+        {
+            Sample = sample,
+            CumulativeRowsMigrated = acc.RowsMigrated,
+            CumulativeRowsRead = acc.RowsRead,
+            CumulativeErrorCount = acc.ErrorCount,
+            CumulativeRequestUnits = acc.RequestUnits,
+            PercentComplete = percentComplete,
+            ErrorRate = errorRate,
+            CumulativeErrorRate = cumulativeErrorRate,
+            ThroughputRowsPerSecond = throughputRowsPerSecond,
+            RequestUnitsPerSecond = requestUnitsPerSecond,
+            Metrics = metrics,
+        };
+    }
+
+    private IReadOnlyList<MigrationMetricPoint> BuildMetricPoints(MigrationProgressSample sample, double errorRate)
+    {
+        var dimensions = BuildDimensions(sample);
+        var ns = string.IsNullOrWhiteSpace(_options.MetricNamespace)
+            ? AzureMonitorMetricOptions.DefaultMetricNamespace
+            : _options.MetricNamespace;
+
+        return new List<MigrationMetricPoint>
+        {
+            NewPoint(MetricRowsMigrated, ns, sample.RowsMigrated, sample.Timestamp, "Count", dimensions),
+            NewPoint(MetricRequestUnits, ns, sample.RequestUnitsConsumed, sample.Timestamp, "Count", dimensions),
+            NewPoint(MetricErrorCount, ns, sample.ErrorCount, sample.Timestamp, "Count", dimensions),
+            NewPoint(MetricErrorRate, ns, errorRate, sample.Timestamp, "Percent", dimensions),
+        };
+    }
+
+    private IReadOnlyDictionary<string, string> BuildDimensions(MigrationProgressSample sample)
+    {
+        var dimensions = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [DimensionPipeline] = sample.PipelineName ?? string.Empty,
+            [DimensionStatus] = sample.Status ?? string.Empty,
+        };
+        if (!string.IsNullOrWhiteSpace(sample.ActivityName))
+        {
+            dimensions[DimensionActivity] = sample.ActivityName!;
+        }
+        if (_options.IncludeRunIdDimension && !string.IsNullOrWhiteSpace(sample.RunId))
+        {
+            dimensions[DimensionRunId] = sample.RunId!;
+        }
+        return dimensions;
+    }
+
+    private static MigrationMetricPoint NewPoint(
+        string name,
+        string ns,
+        double value,
+        DateTimeOffset timestamp,
+        string unit,
+        IReadOnlyDictionary<string, string> dimensions)
+        => new()
+        {
+            Name = name,
+            Namespace = ns,
+            Value = value,
+            Timestamp = timestamp,
+            Unit = unit,
+            Dimensions = dimensions,
+        };
+
+    private static string BuildKey(MigrationProgressSample sample)
+        => string.Join('|', sample.PipelineName ?? string.Empty, sample.RunId ?? string.Empty, sample.ActivityName ?? string.Empty);
+
+    private sealed class RunAccumulator
+    {
+        public long RowsMigrated;
+        public long RowsRead;
+        public long ErrorCount;
+        public double RequestUnits;
+        public DateTimeOffset? LastTimestamp;
+    }
+}

--- a/Services/Monitoring/MigrationStatusService.cs
+++ b/Services/Monitoring/MigrationStatusService.cs
@@ -1,0 +1,166 @@
+using System.Globalization;
+using CosmosToSqlAssessment.Models.Monitoring;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CosmosToSqlAssessment.Services.Monitoring;
+
+/// <summary>
+/// Renders live migration progress for the <c>migration status</c> CLI command (#225).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Pulls progress samples from an <see cref="IMigrationStatusSource"/> (backed by ADF run
+/// telemetry from parents #70/#76), enriches them through the same
+/// <see cref="MigrationMonitoringService"/> derivation used by the publishing path (#223),
+/// and writes a concise per-update line plus a closing summary to a caller-supplied
+/// <see cref="TextWriter"/>.
+/// </para>
+/// <para>
+/// Status reporting is strictly read-only: it derives snapshots with a
+/// <see cref="NullMigrationMetricPublisher"/> so viewing progress never re-publishes custom
+/// metrics to Azure Monitor.
+/// </para>
+/// </remarks>
+public sealed class MigrationStatusService
+{
+    private readonly IMigrationStatusSource _source;
+    private readonly MigrationMonitoringService _monitoring;
+    private readonly ILogger<MigrationStatusService> _logger;
+
+    /// <summary>
+    /// Creates the status service.
+    /// </summary>
+    /// <param name="source">Source of migration progress samples.</param>
+    /// <param name="metricOptions">Metric options reused for snapshot derivation (namespace/dimensions).</param>
+    /// <param name="logger">Logger for diagnostics.</param>
+    /// <exception cref="ArgumentNullException">Any argument is <c>null</c>.</exception>
+    public MigrationStatusService(
+        IMigrationStatusSource source,
+        AzureMonitorMetricOptions metricOptions,
+        ILogger<MigrationStatusService> logger)
+    {
+        _source = source ?? throw new ArgumentNullException(nameof(source));
+        ArgumentNullException.ThrowIfNull(metricOptions);
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        // Read-only derivation: a null publisher guarantees status never re-publishes metrics.
+        _monitoring = new MigrationMonitoringService(
+            new NullMigrationMetricPublisher(),
+            metricOptions,
+            NullLogger<MigrationMonitoringService>.Instance);
+    }
+
+    /// <summary>
+    /// Renders migration progress to <paramref name="writer"/> and returns a process exit code
+    /// (0 on success).
+    /// </summary>
+    /// <param name="options">Watch/poll settings for the report.</param>
+    /// <param name="writer">Destination for the rendered output.</param>
+    /// <param name="cancellationToken">Token that stops a watch loop and ends the report gracefully.</param>
+    /// <returns>0 on success.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="options"/> or <paramref name="writer"/> is <c>null</c>.</exception>
+    public async Task<int> RunAsync(
+        MigrationStatusReportOptions options,
+        TextWriter writer,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        writer.WriteLine("Migration status");
+        writer.WriteLine(options.Watch
+            ? $"Watching live progress (poll every {options.PollIntervalSeconds}s; press Ctrl+C to stop)…"
+            : "Live progress snapshot:");
+        writer.WriteLine();
+
+        var latestByKey = new Dictionary<string, MigrationProgressSnapshot>(StringComparer.Ordinal);
+        var updateCount = 0;
+
+        try
+        {
+            await foreach (var snapshot in _monitoring
+                .MonitorAsync(_source.ReadSamplesAsync(options, cancellationToken), cancellationToken)
+                .ConfigureAwait(false))
+            {
+                updateCount++;
+                latestByKey[BuildKey(snapshot)] = snapshot;
+                writer.WriteLine(FormatLine(snapshot));
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Watch mode stop (Ctrl+C) is an expected, graceful exit — fall through to summary.
+            writer.WriteLine();
+            writer.WriteLine("Stopped watching.");
+        }
+
+        writer.WriteLine();
+        if (updateCount == 0)
+        {
+            writer.WriteLine("No active migration progress found.");
+            writer.WriteLine("Ensure migration telemetry is being emitted and that AzureMonitor:WorkspaceId is configured.");
+            return 0;
+        }
+
+        WriteSummary(writer, latestByKey.Values, updateCount);
+        return 0;
+    }
+
+    private static string FormatLine(MigrationProgressSnapshot snapshot)
+    {
+        var sample = snapshot.Sample;
+        var activity = string.IsNullOrEmpty(sample.ActivityName) ? string.Empty : $"/{sample.ActivityName}";
+        var percent = snapshot.PercentComplete is { } pct
+            ? string.Create(CultureInfo.InvariantCulture, $"{pct:0.0}%")
+            : "—";
+        var throughput = snapshot.ThroughputRowsPerSecond is { } thr
+            ? string.Create(CultureInfo.InvariantCulture, $"{thr:0.0} rows/s")
+            : "—";
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"[{sample.Timestamp:HH:mm:ss}] {sample.PipelineName}{activity} {sample.Status} | " +
+            $"rows={snapshot.CumulativeRowsMigrated} ({percent}) | " +
+            $"RU={snapshot.CumulativeRequestUnits:0.##} | " +
+            $"errRate={snapshot.CumulativeErrorRate * 100:0.00}% | " +
+            $"thr={throughput}");
+    }
+
+    private static void WriteSummary(
+        TextWriter writer,
+        IEnumerable<MigrationProgressSnapshot> latest,
+        int updateCount)
+    {
+        long totalRows = 0;
+        long totalRead = 0;
+        long totalErrors = 0;
+        double totalRu = 0;
+        var pipelines = 0;
+
+        foreach (var snapshot in latest)
+        {
+            pipelines++;
+            totalRows += snapshot.CumulativeRowsMigrated;
+            totalRead += snapshot.CumulativeRowsRead;
+            totalErrors += snapshot.CumulativeErrorCount;
+            totalRu += snapshot.CumulativeRequestUnits;
+        }
+
+        var denominator = totalRead > 0 ? totalRead : totalRows + totalErrors;
+        var overallErrorRate = denominator > 0 ? (double)totalErrors / denominator : 0d;
+
+        writer.WriteLine("── Summary ──");
+        writer.WriteLine(string.Create(CultureInfo.InvariantCulture, $"Updates rendered:     {updateCount}"));
+        writer.WriteLine(string.Create(CultureInfo.InvariantCulture, $"Pipelines/activities: {pipelines}"));
+        writer.WriteLine(string.Create(CultureInfo.InvariantCulture, $"Total rows migrated:  {totalRows}"));
+        writer.WriteLine(string.Create(CultureInfo.InvariantCulture, $"Total RU consumed:    {totalRu:0.##}"));
+        writer.WriteLine(string.Create(CultureInfo.InvariantCulture, $"Overall error rate:   {overallErrorRate * 100:0.00}%"));
+    }
+
+    private static string BuildKey(MigrationProgressSnapshot snapshot)
+    {
+        var sample = snapshot.Sample;
+        return $"{sample.PipelineName}|{sample.RunId}|{sample.ActivityName}";
+    }
+}

--- a/Services/Monitoring/MigrationStatusService.cs
+++ b/Services/Monitoring/MigrationStatusService.cs
@@ -26,10 +26,12 @@ public sealed class MigrationStatusService
 {
     private readonly IMigrationStatusSource _source;
     private readonly MigrationMonitoringService _monitoring;
+    private readonly AnomalyDetectionService _anomalyDetector;
     private readonly ILogger<MigrationStatusService> _logger;
 
     /// <summary>
-    /// Creates the status service.
+    /// Creates the status service without anomaly detection (back-compat). Anomaly warnings
+    /// are disabled.
     /// </summary>
     /// <param name="source">Source of migration progress samples.</param>
     /// <param name="metricOptions">Metric options reused for snapshot derivation (namespace/dimensions).</param>
@@ -39,9 +41,31 @@ public sealed class MigrationStatusService
         IMigrationStatusSource source,
         AzureMonitorMetricOptions metricOptions,
         ILogger<MigrationStatusService> logger)
+        : this(
+            source,
+            metricOptions,
+            new AnomalyDetectionService(new AnomalyDetectionOptions { Enabled = false }, NullLogger<AnomalyDetectionService>.Instance),
+            logger)
+    {
+    }
+
+    /// <summary>
+    /// Creates the status service with anomaly detection (#226).
+    /// </summary>
+    /// <param name="source">Source of migration progress samples.</param>
+    /// <param name="metricOptions">Metric options reused for snapshot derivation (namespace/dimensions).</param>
+    /// <param name="anomalyDetector">Detector that surfaces RU/throughput anomalies as warnings.</param>
+    /// <param name="logger">Logger for diagnostics.</param>
+    /// <exception cref="ArgumentNullException">Any argument is <c>null</c>.</exception>
+    public MigrationStatusService(
+        IMigrationStatusSource source,
+        AzureMonitorMetricOptions metricOptions,
+        AnomalyDetectionService anomalyDetector,
+        ILogger<MigrationStatusService> logger)
     {
         _source = source ?? throw new ArgumentNullException(nameof(source));
         ArgumentNullException.ThrowIfNull(metricOptions);
+        _anomalyDetector = anomalyDetector ?? throw new ArgumentNullException(nameof(anomalyDetector));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
         // Read-only derivation: a null publisher guarantees status never re-publishes metrics.
@@ -86,6 +110,11 @@ public sealed class MigrationStatusService
                 updateCount++;
                 latestByKey[BuildKey(snapshot)] = snapshot;
                 writer.WriteLine(FormatLine(snapshot));
+
+                foreach (var anomaly in _anomalyDetector.Detect(snapshot))
+                {
+                    writer.WriteLine(FormatAnomaly(anomaly));
+                }
             }
         }
         catch (OperationCanceledException)
@@ -126,6 +155,13 @@ public sealed class MigrationStatusService
             $"errRate={snapshot.CumulativeErrorRate * 100:0.00}% | " +
             $"thr={throughput}");
     }
+
+    private static string FormatAnomaly(MigrationAnomaly anomaly) =>
+        string.Create(
+            CultureInfo.InvariantCulture,
+            $"  ⚠ anomaly: {anomaly.MetricName} {anomaly.Direction} " +
+            $"value={anomaly.ObservedValue:0.##} " +
+            $"(z={anomaly.ZScore:0.0}, baseline μ={anomaly.BaselineMean:0.##}, σ={anomaly.BaselineStdDev:0.##})");
 
     private static void WriteSummary(
         TextWriter writer,

--- a/Services/Monitoring/NullMigrationMetricPublisher.cs
+++ b/Services/Monitoring/NullMigrationMetricPublisher.cs
@@ -1,0 +1,15 @@
+using CosmosToSqlAssessment.Models.Monitoring;
+
+namespace CosmosToSqlAssessment.Services.Monitoring;
+
+/// <summary>
+/// An <see cref="IMigrationMetricPublisher"/> that discards every batch. Used by read-only
+/// consumers such as the <c>migration status</c> command (#225) so that re-deriving
+/// snapshots for display never re-publishes custom metrics to Azure Monitor.
+/// </summary>
+public sealed class NullMigrationMetricPublisher : IMigrationMetricPublisher
+{
+    /// <inheritdoc />
+    public Task PublishAsync(IReadOnlyList<MigrationMetricPoint> metrics, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ The application follows enterprise-grade patterns with:
 - **[Getting Started](getting-started.md)** - Installation and first-time setup
 - **[Configuration Guide](configuration.md)** - Detailed configuration options
 - **[Usage Guide](usage.md)** - How to run assessments and interpret results
+- **[Real-Time Monitoring and Alerting](monitoring.md)** - Stream migration progress metrics, generate alert-rule ARM templates, the `migration status` CLI, and RU/throughput anomaly detection (parent #133)
 - **[SQL Project Generation](sql-project-generation.md)** - Generate SQL Database Projects from assessments
 - **[Transformation Logic](transformation-logic.md)** - Data transformation stored procedures and implementation
 - **[Architecture Overview](architecture.md)** - Technical architecture and design patterns

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,302 @@
+# Real-Time Monitoring and Alerting
+
+This guide explains how to observe an in-flight Cosmos DB → Azure SQL migration in
+real time, raise alerts when something goes wrong, and tune the behaviour to your
+environment. It documents the monitoring subsystem delivered under parent issue
+[#133](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/issues/133).
+
+The subsystem pairs with the Azure Data Factory pipelines the tool generates
+([#70](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/issues/70)) and reuses
+the Azure Monitor credential/configuration surface introduced for metric auto-discovery
+([#76](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/issues/76)).
+
+## Capability map
+
+| Capability | What it does | Type namespace |
+| --- | --- | --- |
+| **Metric streaming** (#223) | Streams rows-migrated, RU consumption, and error-rate as Azure Monitor **custom metrics** while a migration runs. | `MigrationMonitoringService`, `AzureMonitorMetricPublisher` |
+| **Alert rule templates** (#224) | Generates deployable ARM templates for metric/log alert rules (threshold breaches, error spikes, stalled pipelines). | `AlertRuleTemplateGenerationService`, `AlertRuleTemplateBuilder` |
+| **`migration status` CLI** (#225) | Renders live migration progress in the console, optionally watching until cancelled. | `MigrationStatusService`, `AzureMonitorMigrationStatusSource` |
+| **Anomaly detection** (#226) | Flags abnormal RU/throughput swings with a rolling-window z-score baseline, surfaced inline in `migration status`. | `AnomalyDetectionService` |
+
+All of these read from, or write to, the **same** ADF pipeline/activity run telemetry, so a
+single migration produces one coherent picture across metrics, alerts, the live CLI, and
+anomaly warnings.
+
+```mermaid
+flowchart LR
+    ADF[ADF pipeline / activity runs] -->|Log Analytics| SRC[AzureMonitorMigrationStatusSource]
+    SRC --> MON[MigrationMonitoringService]
+    MON -->|custom metrics| AM[(Azure Monitor)]
+    MON --> ANOM[AnomalyDetectionService]
+    MON --> CLI[migration status CLI]
+    ANOM --> CLI
+    AM --> ALERTS[Alert rules from ARM templates]
+```
+
+## Prerequisites
+
+1. **.NET 9 SDK** and the built tool (`dotnet build`).
+2. **Azure authentication** via `DefaultAzureCredential` — run `az login`, or supply a
+   managed identity / service principal. See
+   [Azure Permissions](azure-permissions.md) and
+   [Production Hardening](production-hardening.md).
+3. **Role assignments**:
+   - *Reading* progress (CLI + anomaly detection) needs **Log Analytics Reader** /
+     **Monitoring Reader** on the workspace that collects the ADF diagnostic logs. The
+     bundled least-privilege role is in
+     [`docs/security/rbac/cosmos-assessment-monitor-reader.json`](security/rbac/README.md).
+   - *Publishing* custom metrics (#223) needs **Monitoring Metrics Publisher** on the
+     target resource.
+4. **ADF diagnostic settings** must forward `PipelineRuns` and `ActivityRuns` to the Log
+   Analytics workspace so the `ADFPipelineRun` / `ADFActivityRun` tables are populated.
+
+## Configuration reference
+
+All settings live under the `AzureMonitor` root in `appsettings.json` (or any
+`IConfiguration` source — environment variables, Key Vault, etc.). Every section is
+optional; sensible defaults apply and nothing calls Azure unless explicitly enabled.
+
+```jsonc
+{
+  "AzureMonitor": {
+    // Log Analytics workspace (GUID) that collects ADF diagnostic logs.
+    // Required for `migration status` to read live progress; when unset the
+    // status source is a no-op and reports "No active migration progress found."
+    "WorkspaceId": "00000000-0000-0000-0000-000000000000",
+
+    // #223 — custom-metric ingestion (write surface). Disabled by default.
+    "Metrics": {
+      "Enabled": false,
+      "Region": "eastus",
+      "ResourceId": "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.DataFactory/factories/<adf>",
+      "MetricNamespace": "CosmosToSqlMigration",
+      "IncludeRunIdDimension": false
+    },
+
+    // #225 — live status reader tuning.
+    "Status": {
+      "LookbackMinutes": 60
+    },
+
+    // #226 — anomaly detection on RU/throughput.
+    "Anomaly": {
+      "Enabled": true,
+      "WindowSize": 20,
+      "MinSamplesForBaseline": 5,
+      "ZScoreThreshold": 3.0,
+      "MinRelativeChange": 0.25,
+      "MinBaselineStdDev": 1e-9,
+      "WatchRequestUnits": true,
+      "WatchThroughput": true,
+      "SuppressLowOnTerminalStatus": true
+    },
+
+    // #224 — alert-rule ARM template generation (deploy-time artifacts only).
+    "Alerts": {
+      "MetricNamespace": "CosmosToSqlMigration",
+      "Enabled": true,
+      "EvaluationFrequency": "PT1M",
+      "WindowSize": "PT5M",
+      "StalledWindowSize": "PT15M",
+      "StalledActivityGap": "15m",
+      "ErrorRateThreshold": 0.05,
+      "ErrorRateSeverity": 2,
+      "ErrorSpikeSensitivity": "Medium",
+      "ErrorSpikeNumberOfEvaluationPeriods": 4,
+      "ErrorSpikeMinFailingPeriods": 3,
+      "ErrorSpikeSeverity": 2,
+      "IncludeLowThroughputAlert": true,
+      "LowThroughputSeverity": 1,
+      "IncludeRequestUnitsThresholdAlert": false,
+      "RequestUnitsThreshold": 0,
+      "RequestUnitsSeverity": 3,
+      "StalledPipelineSeverity": 1,
+      "SkipMetricValidation": true,
+      "SkipQueryValidation": true
+    }
+  }
+}
+```
+
+## Streaming progress metrics (#223)
+
+`MigrationMonitoringService` consumes a stream of `MigrationProgressSample` values (one per
+ADF activity observation), derives per-window and cumulative figures, and publishes custom
+metrics through `IMigrationMetricPublisher`. The default `AzureMonitorMetricPublisher` POSTs
+to the regional ingestion endpoint
+`https://<region>.monitoring.azure.com<resourceId>/metrics` using `DefaultAzureCredential`.
+
+### Published metrics
+
+| Metric | Unit | Meaning |
+| --- | --- | --- |
+| `MigrationRowsMigrated` | Count | Rows migrated in the sample window. |
+| `MigrationRequestUnitsConsumed` | Count | RU consumed in the sample window. |
+| `MigrationErrorCount` | Count | Errors in the sample window. |
+| `MigrationErrorRate` | Percent | Errors ÷ rows read for the window (0–1). |
+
+Dimensions: `PipelineName`, `Status`, and (when present) `ActivityName`. `RunId` is **opt-in**
+via `IncludeRunIdDimension` to avoid high-cardinality metric series.
+
+### Enabling publishing
+
+Publishing is **off by default** (`AzureMonitor:Metrics:Enabled = false`) so offline and CI
+runs never call Azure. To turn it on, set `Enabled`, `Region`, and `ResourceId`. A
+misconfigured or disabled publisher degrades to a no-op rather than failing the run; a
+publish failure is logged and swallowed so it never aborts the migration stream.
+
+## Alert rule ARM templates (#224)
+
+`AlertRuleTemplateGenerationService.GenerateAsync(outputDirectory)` writes deployable ARM
+templates (and a README) under `<outputDirectory>/Monitoring/AlertRules/`:
+
+| File | Resource | Purpose |
+| --- | --- | --- |
+| `metric-alerts.template.json` | `Microsoft.Insights/metricAlerts` | Static error-rate breach, **dynamic** error-spike, low/no-throughput, and an optional RU ceiling — over the custom metrics from #223. |
+| `stalled-pipeline-log-alert.template.json` | `Microsoft.Insights/scheduledQueryRules` (`LogAlert`) | KQL query over `ADFPipelineRun` / `ADFActivityRun` that fires when **no** activity progress is seen for `StalledActivityGap` — the reliable stalled-pipeline detector. |
+| `README.md` | — | Per-template parameters and `az` deploy commands. |
+
+Every tunable is emitted as an ARM **parameter default**, so the templates stay deployable
+and overridable without regenerating them.
+
+### Static vs dynamic thresholds
+
+- The **error-rate** alert is a *static* threshold (`SingleResourceMultipleMetricCriteria`)
+  — fires when the rate exceeds `ErrorRateThreshold` (default 5%). Use this when you know the
+  acceptable ceiling.
+- The **error-spike** alert is a *dynamic* threshold
+  (`MultipleResourceMultipleMetricCriteria`) — Azure Monitor learns the metric's normal
+  pattern and fires on statistically abnormal jumps. Tune via `ErrorSpikeSensitivity`,
+  `ErrorSpikeNumberOfEvaluationPeriods`, and `ErrorSpikeMinFailingPeriods`. Use this when you
+  cannot predict a fixed threshold.
+
+`SkipMetricValidation` / `SkipQueryValidation` default to `true` so a template deploys before
+the custom metrics or Log Analytics tables have been populated for the first time.
+
+### Deploying
+
+```bash
+# Create or reuse an Action Group for notifications first, then:
+az deployment group create \
+  --resource-group <rg> \
+  --template-file metric-alerts.template.json \
+  --parameters actionGroupId=/subscriptions/<sub>/resourceGroups/<rg>/providers/microsoft.insights/actionGroups/<ag> \
+               targetResourceId=/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.DataFactory/factories/<adf>
+
+az deployment group create \
+  --resource-group <rg> \
+  --template-file stalled-pipeline-log-alert.template.json \
+  --parameters actionGroupId=/subscriptions/<sub>/resourceGroups/<rg>/providers/microsoft.insights/actionGroups/<ag> \
+               workspaceResourceId=/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.OperationalInsights/workspaces/<ws>
+```
+
+> **Note:** the templates are validated for JSON well-formedness and schema shape by the unit
+> test suite; no live Azure deployment is required to produce them.
+
+## Live progress: `migration status` (#225)
+
+Report live migration progress directly in the console:
+
+```bash
+# One-shot snapshot
+CosmosToSqlAssessment migration status
+
+# Watch continuously, polling every 5 seconds, until Ctrl+C
+CosmosToSqlAssessment migration status --watch --poll-interval 5
+```
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| `--watch` | Continuously poll and re-render progress until cancelled. | off (single snapshot) |
+| `--poll-interval <sec>` | Polling interval for `--watch`, in seconds. | 10 |
+
+The command reads Copy-activity progress from the `ADFActivityRun` table in the workspace
+named by `AzureMonitor:WorkspaceId`, diffs cumulative rows into per-window deltas, and prints
+a line per observed pipeline/activity plus a summary. It is **read-only**: status derivation
+uses a null metric publisher internally, so viewing progress never re-publishes metrics.
+
+When `WorkspaceId` is unset the source is a no-op and the command prints
+`No active migration progress found.` rather than attempting a network call.
+
+Sample output:
+
+```text
+── Migration status ──
+Migrate_Orders  rows=500  50.0%  ru/s=1180  err=0.0%  [InProgress]
+  ⚠ anomaly: RequestUnitsPerSecond High value=4200 (z=6.4, baseline μ=1180, σ=190)
+── Summary ──
+Total rows migrated:  500
+```
+
+## Anomaly detection (#226)
+
+`AnomalyDetectionService` watches the derived `RequestUnitsPerSecond` and
+`ThroughputRowsPerSecond` series and flags abnormal swings, which `migration status` renders
+inline as `⚠ anomaly` lines.
+
+### How the baseline works
+
+For each `(pipeline, run, activity, metric)` key the detector keeps a rolling window of the
+most recent `WindowSize` observations. For every new value it:
+
+1. Forms a baseline from the **prior** values in the window (a value never seeds its own
+   baseline), once at least `MinSamplesForBaseline` exist.
+2. Computes the sample mean and sample (n-1) standard deviation.
+3. Flags the value when **both** of these hold:
+   - `|z-score| ≥ ZScoreThreshold` (default 3.0), and
+   - `relativeChange = |value − mean| / max(|mean|, ε) ≥ MinRelativeChange` (default 0.25).
+
+The standard deviation is **floored** at `MinBaselineStdDev` so a perfectly flat baseline
+doesn't divide by zero. The **relative-change guard** is what stops a near-constant series
+from flapping on trivial noise while still catching genuine spikes and drops.
+
+`Direction` is `High` (above baseline) or `Low` (below). When
+`SuppressLowOnTerminalStatus` is `true` (default), `Low` anomalies are suppressed once a
+run reaches a terminal status (`Succeeded`/`Failed`/`Cancelled`/`Completed`) so the natural
+ramp-down at completion doesn't generate noise. `High` anomalies are always reported.
+
+### Tuning
+
+| Setting | Effect | Raise to… | Lower to… |
+| --- | --- | --- | --- |
+| `ZScoreThreshold` | Statistical strictness. | reduce false positives | catch subtler swings |
+| `MinRelativeChange` | Minimum % move required. | ignore small wiggles | flag smaller changes |
+| `WindowSize` | How much history forms the baseline. | smooth, slower to adapt | more reactive |
+| `MinSamplesForBaseline` | Warmup before any flag. | longer warmup | flag sooner |
+
+> The detector is a deliberately simple, single-threaded statistical baseline. It assumes a
+> roughly stationary, symmetric local distribution; bursty or heavy-tailed metrics may need a
+> higher `ZScoreThreshold`. Set `Enabled: false` to turn it off entirely.
+
+## On-call runbook
+
+1. **A metric/error alert fired.** Open the metric in Azure Monitor, filter by
+   `PipelineName` (and `ActivityName`). Confirm whether it is a transient spike or a
+   sustained breach.
+2. **A stalled-pipeline log alert fired.** The pipeline emitted no activity progress for
+   `StalledActivityGap`. Check the ADF run in the portal for a hung or throttled Copy
+   activity; inspect Cosmos RU throttling (429s) and SQL-side back-pressure.
+3. **`⚠ anomaly` in `migration status`.** A `High` RU anomaly usually means a hot
+   partition or a large batch; a `Low` throughput anomaly mid-run suggests throttling or a
+   downstream stall. Cross-check the alert rules and the ADF run.
+4. **No data.** If `migration status` reports no progress, verify `AzureMonitor:WorkspaceId`,
+   ADF diagnostic settings, and that the Log Analytics ingestion delay (typically a few
+   minutes) has elapsed.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| `No active migration progress found.` | `WorkspaceId` unset, no recent runs, or ingestion lag. | Set `AzureMonitor:WorkspaceId`; widen `AzureMonitor:Status:LookbackMinutes`; wait for Log Analytics ingestion. |
+| Custom metrics never appear | `AzureMonitor:Metrics:Enabled` is `false`, or `Region`/`ResourceId` missing. | Enable and configure the `Metrics` section; grant **Monitoring Metrics Publisher**. |
+| Anomaly warnings too noisy | Bursty metric vs. defaults. | Raise `ZScoreThreshold` and/or `MinRelativeChange`; increase `WindowSize`. |
+| Anomaly warnings never appear | Detection disabled, or warmup not reached. | Set `AzureMonitor:Anomaly:Enabled: true`; lower `MinSamplesForBaseline`. |
+| Alert template won't deploy | Action Group / target resource parameter not supplied. | Pass `actionGroupId` and the target/workspace resource id parameters shown above. |
+
+## Related documentation
+
+- [Configuration Guide](configuration.md)
+- [Azure Permissions](azure-permissions.md)
+- [Custom RBAC role definitions](security/rbac/README.md)
+- [Architecture Overview](architecture.md)

--- a/tests/CosmosToSqlAssessment.Tests/Cli/CliArgumentParserMigrationStatusTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Cli/CliArgumentParserMigrationStatusTests.cs
@@ -1,0 +1,111 @@
+using CosmosToSqlAssessment.Cli;
+
+namespace CosmosToSqlAssessment.Tests.Cli;
+
+public class CliArgumentParserMigrationStatusTests
+{
+    [Fact]
+    public void Parse_MigrationStatus_SetsFlag()
+    {
+        var output = new StringWriter();
+
+        var options = CliArgumentParser.Parse(new[] { "migration", "status" }, output);
+
+        options.Should().NotBeNull();
+        options!.MigrationStatus.Should().BeTrue();
+        options.Watch.Should().BeFalse();
+        options.PollIntervalSeconds.Should().Be(10);
+        output.ToString().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_MigrationStatus_IsCaseInsensitive()
+    {
+        var output = new StringWriter();
+
+        var options = CliArgumentParser.Parse(new[] { "MIGRATION", "STATUS" }, output);
+
+        options.Should().NotBeNull();
+        options!.MigrationStatus.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Parse_MigrationStatusWithWatchAndPollInterval_SetsBoth()
+    {
+        var output = new StringWriter();
+
+        var options = CliArgumentParser.Parse(
+            new[] { "migration", "status", "--watch", "--poll-interval", "5" },
+            output);
+
+        options.Should().NotBeNull();
+        options!.MigrationStatus.Should().BeTrue();
+        options.Watch.Should().BeTrue();
+        options.PollIntervalSeconds.Should().Be(5);
+    }
+
+    [Fact]
+    public void Parse_MigrationStatus_IsAdditiveWithSiblingFlags()
+    {
+        var output = new StringWriter();
+
+        var options = CliArgumentParser.Parse(
+            new[] { "migration", "status", "--skip-auto-discovery", "--interactive", "--agentic" },
+            output);
+
+        options.Should().NotBeNull();
+        options!.MigrationStatus.Should().BeTrue();
+        options.SkipAutoDiscovery.Should().BeTrue();
+        options.Interactive.Should().BeTrue();
+        options.Agentic.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Parse_MigrationWithoutStatus_ReturnsNullAndWritesHelp()
+    {
+        var output = new StringWriter();
+
+        var options = CliArgumentParser.Parse(new[] { "migration" }, output);
+
+        options.Should().BeNull();
+        output.ToString().Should().Contain("Did you mean 'migration status'");
+    }
+
+    [Fact]
+    public void Parse_InvalidPollInterval_ReturnsNull()
+    {
+        var output = new StringWriter();
+
+        var options = CliArgumentParser.Parse(
+            new[] { "migration", "status", "--poll-interval", "abc" },
+            output);
+
+        options.Should().BeNull();
+        output.ToString().Should().Contain("Invalid value for --poll-interval");
+    }
+
+    [Fact]
+    public void Parse_NonPositivePollInterval_ReturnsNull()
+    {
+        var output = new StringWriter();
+
+        var options = CliArgumentParser.Parse(
+            new[] { "migration", "status", "--poll-interval", "0" },
+            output);
+
+        options.Should().BeNull();
+    }
+
+    [Fact]
+    public void DisplayHelp_IncludesMigrationStatusSubcommand()
+    {
+        var output = new StringWriter();
+
+        CliArgumentParser.DisplayHelp(output);
+
+        var text = output.ToString();
+        text.Should().Contain("migration status");
+        text.Should().Contain("--watch");
+        text.Should().Contain("--poll-interval");
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/Monitoring/AlertRuleTemplateBuilderTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/Monitoring/AlertRuleTemplateBuilderTests.cs
@@ -1,0 +1,250 @@
+using System.Text.Json;
+using CosmosToSqlAssessment.Models.Monitoring;
+using CosmosToSqlAssessment.Services.DataFactory;
+using CosmosToSqlAssessment.Services.Monitoring;
+
+namespace CosmosToSqlAssessment.Tests.Services.Monitoring;
+
+public class AlertRuleTemplateBuilderTests
+{
+    private static AlertRuleTemplateBuilder CreateBuilder() => new();
+
+    private static IDictionary<string, object?> Resource(IDictionary<string, object?> template, int index) =>
+        (IDictionary<string, object?>)((List<object?>)template["resources"]!)[index]!;
+
+    private static IDictionary<string, object?> Properties(IDictionary<string, object?> resource) =>
+        (IDictionary<string, object?>)resource["properties"]!;
+
+    private static IDictionary<string, object?> FirstCriterion(IDictionary<string, object?> resource)
+    {
+        var criteria = (IDictionary<string, object?>)Properties(resource)["criteria"]!;
+        return (IDictionary<string, object?>)((List<object?>)criteria["allOf"]!)[0]!;
+    }
+
+    [Fact]
+    public void BuildMetricAlertsTemplate_ReturnsFullDeployableArmTemplate()
+    {
+        var template = CreateBuilder().BuildMetricAlertsTemplate(new AlertRuleOptions());
+
+        template["$schema"].Should().Be("https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#");
+        template["contentVersion"].Should().Be("1.0.0.0");
+        template.Should().ContainKey("parameters");
+        template.Should().ContainKey("resources");
+    }
+
+    [Fact]
+    public void BuildMetricAlertsTemplate_SerializesToWellFormedJson()
+    {
+        var template = CreateBuilder().BuildMetricAlertsTemplate(new AlertRuleOptions());
+
+        var json = AdfJsonSerializer.Serialize(template);
+
+        var act = () => JsonDocument.Parse(json);
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BuildMetricAlertsTemplate_DefaultOptions_EmitsErrorRateSpikeAndLowThroughput()
+    {
+        var template = CreateBuilder().BuildMetricAlertsTemplate(new AlertRuleOptions());
+
+        var resources = (List<object?>)template["resources"]!;
+        resources.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void BuildMetricAlertsTemplate_WithRequestUnitsAlert_AddsFourthResource()
+    {
+        var options = new AlertRuleOptions
+        {
+            IncludeRequestUnitsThresholdAlert = true,
+            RequestUnitsThreshold = 10000,
+        };
+
+        var template = CreateBuilder().BuildMetricAlertsTemplate(options);
+
+        var resources = (List<object?>)template["resources"]!;
+        resources.Should().HaveCount(4);
+        var ruCriterion = FirstCriterion(Resource(template, 3));
+        ruCriterion["metricName"].Should().Be(MigrationMonitoringService.MetricRequestUnits);
+        ruCriterion["threshold"].Should().Be(10000d);
+    }
+
+    [Fact]
+    public void BuildMetricAlertsTemplate_WithoutLowThroughput_OmitsThatResource()
+    {
+        var options = new AlertRuleOptions { IncludeLowThroughputAlert = false };
+
+        var template = CreateBuilder().BuildMetricAlertsTemplate(options);
+
+        var resources = (List<object?>)template["resources"]!;
+        resources.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void BuildMetricAlertsTemplate_ResourcesUseCorrectTypeAndApiVersionAndGlobalLocation()
+    {
+        var template = CreateBuilder().BuildMetricAlertsTemplate(new AlertRuleOptions());
+
+        foreach (var item in (List<object?>)template["resources"]!)
+        {
+            var resource = (IDictionary<string, object?>)item!;
+            resource["type"].Should().Be(AlertRuleTemplateBuilder.MetricAlertResourceType);
+            resource["apiVersion"].Should().Be(AlertRuleTemplateBuilder.MetricAlertApiVersion);
+            resource["location"].Should().Be("global");
+        }
+    }
+
+    [Fact]
+    public void BuildMetricAlertsTemplate_ErrorRateUsesStaticCriteriaAndConfiguredThreshold()
+    {
+        var options = new AlertRuleOptions { ErrorRateThreshold = 0.1 };
+        var template = CreateBuilder().BuildMetricAlertsTemplate(options);
+
+        var errorRate = Resource(template, 0);
+        var criteria = (IDictionary<string, object?>)Properties(errorRate)["criteria"]!;
+        criteria["odata.type"].Should().Be(AlertRuleTemplateBuilder.StaticCriteriaODataType);
+
+        var criterion = FirstCriterion(errorRate);
+        criterion["metricName"].Should().Be(MigrationMonitoringService.MetricErrorRate);
+        criterion["criterionType"].Should().Be("StaticThresholdCriterion");
+        criterion["operator"].Should().Be("GreaterThan");
+        criterion["threshold"].Should().Be(0.1);
+        criterion["skipMetricValidation"].Should().Be(true);
+    }
+
+    [Fact]
+    public void BuildMetricAlertsTemplate_ErrorSpikeUsesDynamicMultiResourceCriteria()
+    {
+        var template = CreateBuilder().BuildMetricAlertsTemplate(new AlertRuleOptions());
+
+        var errorSpike = Resource(template, 1);
+        var criteria = (IDictionary<string, object?>)Properties(errorSpike)["criteria"]!;
+        criteria["odata.type"].Should().Be(AlertRuleTemplateBuilder.DynamicCriteriaODataType);
+
+        var criterion = FirstCriterion(errorSpike);
+        criterion["metricName"].Should().Be(MigrationMonitoringService.MetricErrorCount);
+        criterion["criterionType"].Should().Be("DynamicThresholdCriterion");
+        criterion["alertSensitivity"].Should().Be("Medium");
+        criterion.Should().ContainKey("failingPeriods");
+        criterion["skipMetricValidation"].Should().Be(true);
+    }
+
+    [Fact]
+    public void BuildMetricAlertsTemplate_LowThroughputUsesRowsMigratedLessThanOrEqualZero()
+    {
+        var template = CreateBuilder().BuildMetricAlertsTemplate(new AlertRuleOptions());
+
+        var lowThroughput = Resource(template, 2);
+        var criterion = FirstCriterion(lowThroughput);
+        criterion["metricName"].Should().Be(MigrationMonitoringService.MetricRowsMigrated);
+        criterion["operator"].Should().Be("LessThanOrEqual");
+        criterion["threshold"].Should().Be(0d);
+    }
+
+    [Fact]
+    public void BuildMetricAlertsTemplate_WiresScopeAndActionToParameters()
+    {
+        var template = CreateBuilder().BuildMetricAlertsTemplate(new AlertRuleOptions());
+        var props = Properties(Resource(template, 0));
+
+        var scopes = (List<object?>)props["scopes"]!;
+        scopes.Should().ContainSingle().Which.Should().Be($"[parameters('{AlertRuleTemplateBuilder.ParamTargetResourceId}')]");
+
+        var actions = (List<object?>)props["actions"]!;
+        var action = (IDictionary<string, object?>)actions[0]!;
+        action["actionGroupId"].Should().Be($"[parameters('{AlertRuleTemplateBuilder.ParamActionGroupResourceId}')]");
+
+        props["autoMitigate"].Should().Be(true);
+    }
+
+    [Fact]
+    public void BuildMetricAlertsTemplate_DeclaresExpectedParameters()
+    {
+        var template = CreateBuilder().BuildMetricAlertsTemplate(new AlertRuleOptions());
+        var parameters = (IDictionary<string, object?>)template["parameters"]!;
+
+        parameters.Should().ContainKeys(
+            AlertRuleTemplateBuilder.ParamAlertNamePrefix,
+            AlertRuleTemplateBuilder.ParamTargetResourceId,
+            AlertRuleTemplateBuilder.ParamActionGroupResourceId);
+    }
+
+    [Fact]
+    public void BuildStalledPipelineLogAlertTemplate_SerializesToWellFormedJson()
+    {
+        var template = CreateBuilder().BuildStalledPipelineLogAlertTemplate(new AlertRuleOptions());
+
+        var json = AdfJsonSerializer.Serialize(template);
+
+        var act = () => JsonDocument.Parse(json);
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BuildStalledPipelineLogAlertTemplate_UsesScheduledQueryRuleTypeAndLogAlertKind()
+    {
+        var template = CreateBuilder().BuildStalledPipelineLogAlertTemplate(new AlertRuleOptions());
+        var resource = Resource(template, 0);
+
+        resource["type"].Should().Be(AlertRuleTemplateBuilder.ScheduledQueryRuleResourceType);
+        resource["apiVersion"].Should().Be(AlertRuleTemplateBuilder.ScheduledQueryRuleApiVersion);
+        resource["kind"].Should().Be("LogAlert");
+    }
+
+    [Fact]
+    public void BuildStalledPipelineLogAlertTemplate_ActionGroupsIsArrayOfStrings()
+    {
+        var template = CreateBuilder().BuildStalledPipelineLogAlertTemplate(new AlertRuleOptions());
+        var props = Properties(Resource(template, 0));
+
+        var actions = (IDictionary<string, object?>)props["actions"]!;
+        var actionGroups = (List<object?>)actions["actionGroups"]!;
+        actionGroups.Should().ContainSingle()
+            .Which.Should().Be($"[parameters('{AlertRuleTemplateBuilder.ParamActionGroupResourceId}')]");
+    }
+
+    [Fact]
+    public void BuildStalledPipelineLogAlertTemplate_SetsSkipQueryValidationAndQueriesAdfTables()
+    {
+        var template = CreateBuilder().BuildStalledPipelineLogAlertTemplate(new AlertRuleOptions());
+        var props = Properties(Resource(template, 0));
+
+        props["skipQueryValidation"].Should().Be(true);
+
+        var criteria = (IDictionary<string, object?>)props["criteria"]!;
+        var criterion = (IDictionary<string, object?>)((List<object?>)criteria["allOf"]!)[0]!;
+        var query = (string)criterion["query"]!;
+        query.Should().Contain("ADFPipelineRun");
+        query.Should().Contain("ADFActivityRun");
+        query.Should().Contain("ago(15m)");
+        criterion["operator"].Should().Be("GreaterThan");
+        criterion["threshold"].Should().Be(0);
+    }
+
+    [Fact]
+    public void BuildStalledPipelineLogAlertTemplate_DeclaresWorkspaceParameter()
+    {
+        var template = CreateBuilder().BuildStalledPipelineLogAlertTemplate(new AlertRuleOptions());
+        var parameters = (IDictionary<string, object?>)template["parameters"]!;
+
+        parameters.Should().ContainKeys(
+            AlertRuleTemplateBuilder.ParamAlertNamePrefix,
+            AlertRuleTemplateBuilder.ParamWorkspaceResourceId,
+            AlertRuleTemplateBuilder.ParamActionGroupResourceId);
+    }
+
+    [Fact]
+    public void BuildMetricAlertsTemplate_NullOptions_Throws()
+    {
+        var act = () => CreateBuilder().BuildMetricAlertsTemplate(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void BuildStalledPipelineLogAlertTemplate_NullOptions_Throws()
+    {
+        var act = () => CreateBuilder().BuildStalledPipelineLogAlertTemplate(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/Monitoring/AlertRuleTemplateGenerationServiceTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/Monitoring/AlertRuleTemplateGenerationServiceTests.cs
@@ -1,0 +1,123 @@
+using System.Text.Json;
+using CosmosToSqlAssessment.Models.Monitoring;
+using CosmosToSqlAssessment.Services.Monitoring;
+using Microsoft.Extensions.Logging;
+
+namespace CosmosToSqlAssessment.Tests.Services.Monitoring;
+
+public class AlertRuleTemplateGenerationServiceTests : IDisposable
+{
+    private readonly string _outputDir;
+
+    public AlertRuleTemplateGenerationServiceTests()
+    {
+        _outputDir = Path.Combine(Path.GetTempPath(), "alert-rule-gen-" + Guid.NewGuid().ToString("N"));
+    }
+
+    private static AlertRuleTemplateGenerationService CreateService(AlertRuleOptions options) =>
+        new(new AlertRuleTemplateBuilder(), options, Mock.Of<ILogger<AlertRuleTemplateGenerationService>>());
+
+    [Fact]
+    public async Task GenerateAsync_WritesTemplatesAndReadme()
+    {
+        var service = CreateService(new AlertRuleOptions());
+
+        var result = await service.GenerateAsync(_outputDir);
+
+        File.Exists(result.MetricAlertsTemplatePath).Should().BeTrue();
+        File.Exists(result.StalledPipelineTemplatePath).Should().BeTrue();
+        File.Exists(result.ReadmePath).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GenerateAsync_WritesUnderMonitoringAlertRulesFolder()
+    {
+        var service = CreateService(new AlertRuleOptions());
+
+        var result = await service.GenerateAsync(_outputDir);
+
+        var expectedDir = Path.Combine(
+            _outputDir,
+            AlertRuleTemplateGenerationService.AlertRulesFolder.Replace('/', Path.DirectorySeparatorChar));
+        Path.GetDirectoryName(result.MetricAlertsTemplatePath).Should().Be(expectedDir);
+        Path.GetFileName(result.MetricAlertsTemplatePath)
+            .Should().Be(AlertRuleTemplateGenerationService.MetricAlertsTemplateFileName);
+        Path.GetFileName(result.StalledPipelineTemplatePath)
+            .Should().Be(AlertRuleTemplateGenerationService.StalledPipelineTemplateFileName);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_EmittedTemplatesAreValidJson()
+    {
+        var service = CreateService(new AlertRuleOptions());
+
+        var result = await service.GenerateAsync(_outputDir);
+
+        var metricsJson = await File.ReadAllTextAsync(result.MetricAlertsTemplatePath);
+        var stalledJson = await File.ReadAllTextAsync(result.StalledPipelineTemplatePath);
+
+        var parseMetrics = () => JsonDocument.Parse(metricsJson);
+        var parseStalled = () => JsonDocument.Parse(stalledJson);
+        parseMetrics.Should().NotThrow();
+        parseStalled.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task GenerateAsync_NoWarnings_ForValidDefaults()
+    {
+        var service = CreateService(new AlertRuleOptions());
+
+        var result = await service.GenerateAsync(_outputDir);
+
+        result.Warnings.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GenerateAsync_WarnsWhenRequestUnitsAlertEnabledWithNonPositiveThreshold()
+    {
+        var service = CreateService(new AlertRuleOptions
+        {
+            IncludeRequestUnitsThresholdAlert = true,
+            RequestUnitsThreshold = 0,
+        });
+
+        var result = await service.GenerateAsync(_outputDir);
+
+        result.Warnings.Should().ContainSingle().Which.Should().Contain("RequestUnitsThreshold");
+    }
+
+    [Fact]
+    public async Task GenerateAsync_NullOrEmptyOutputDirectory_Throws()
+    {
+        var service = CreateService(new AlertRuleOptions());
+
+        var act = async () => await service.GenerateAsync("  ");
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public void Constructor_NullArguments_Throw()
+    {
+        var builder = new AlertRuleTemplateBuilder();
+        var options = new AlertRuleOptions();
+        var logger = Mock.Of<ILogger<AlertRuleTemplateGenerationService>>();
+
+        ((Func<AlertRuleTemplateGenerationService>)(() => new AlertRuleTemplateGenerationService(null!, options, logger)))
+            .Should().Throw<ArgumentNullException>();
+        ((Func<AlertRuleTemplateGenerationService>)(() => new AlertRuleTemplateGenerationService(builder, null!, logger)))
+            .Should().Throw<ArgumentNullException>();
+        ((Func<AlertRuleTemplateGenerationService>)(() => new AlertRuleTemplateGenerationService(builder, options, null!)))
+            .Should().Throw<ArgumentNullException>();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_outputDir))
+        {
+            Directory.Delete(_outputDir, recursive: true);
+        }
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/Monitoring/AnomalyDetectionServiceTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/Monitoring/AnomalyDetectionServiceTests.cs
@@ -1,0 +1,270 @@
+using CosmosToSqlAssessment.Models.Monitoring;
+using CosmosToSqlAssessment.Services.Monitoring;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CosmosToSqlAssessment.Tests.Services.Monitoring;
+
+public class AnomalyDetectionServiceTests
+{
+    private static AnomalyDetectionService CreateService(AnomalyDetectionOptions? options = null) =>
+        new(options ?? new AnomalyDetectionOptions(), NullLogger<AnomalyDetectionService>.Instance);
+
+    private static MigrationProgressSnapshot RuSnapshot(
+        double requestUnitsPerSecond,
+        string pipeline = "P",
+        string status = "InProgress",
+        string? runId = null,
+        string? activity = null) =>
+        new()
+        {
+            Sample = new MigrationProgressSample
+            {
+                PipelineName = pipeline,
+                ActivityName = activity,
+                RunId = runId,
+                Status = status,
+                Timestamp = DateTimeOffset.UtcNow,
+            },
+            RequestUnitsPerSecond = requestUnitsPerSecond,
+        };
+
+    private static List<MigrationAnomaly> Feed(AnomalyDetectionService service, IEnumerable<MigrationProgressSnapshot> snapshots)
+    {
+        var all = new List<MigrationAnomaly>();
+        foreach (var snapshot in snapshots)
+        {
+            all.AddRange(service.Detect(snapshot));
+        }
+
+        return all;
+    }
+
+    [Fact]
+    public void Detect_HighSpike_AfterStableBaseline_IsFlagged()
+    {
+        var service = CreateService();
+        var baseline = new[] { 100d, 101d, 99d, 100d, 100d }.Select(v => RuSnapshot(v));
+        Feed(service, baseline).Should().BeEmpty("baseline values are not anomalous");
+
+        var anomalies = service.Detect(RuSnapshot(200d));
+
+        anomalies.Should().ContainSingle();
+        var anomaly = anomalies[0];
+        anomaly.Direction.Should().Be(AnomalyDirection.High);
+        anomaly.MetricName.Should().Be(AnomalyDetectionService.MetricRequestUnitsPerSecond);
+        anomaly.ObservedValue.Should().Be(200d);
+        anomaly.BaselineMean.Should().BeApproximately(100d, 0.5);
+        anomaly.ZScore.Should().BeGreaterThan(3d);
+    }
+
+    [Fact]
+    public void Detect_LowDrop_AfterStableBaseline_IsFlagged()
+    {
+        var service = CreateService();
+        Feed(service, new[] { 100d, 101d, 99d, 100d, 100d }.Select(v => RuSnapshot(v)));
+
+        var anomalies = service.Detect(RuSnapshot(10d));
+
+        anomalies.Should().ContainSingle();
+        anomalies[0].Direction.Should().Be(AnomalyDirection.Low);
+        anomalies[0].ZScore.Should().BeLessThan(-3d);
+    }
+
+    [Fact]
+    public void Detect_DuringWarmup_NeverFlags()
+    {
+        var service = CreateService(new AnomalyDetectionOptions { MinSamplesForBaseline = 5 });
+
+        // Only 4 prior samples exist when the 5th wild value arrives -> below warmup threshold.
+        var anomalies = Feed(service, new[] { 100d, 100d, 100d, 100d, 9999d }.Select(v => RuSnapshot(v)));
+
+        anomalies.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Detect_ConstantBaselineThenTinyNoise_DoesNotFlap()
+    {
+        var service = CreateService();
+        Feed(service, Enumerable.Repeat(100d, 6).Select(v => RuSnapshot(v)));
+
+        // A near-zero deviation has a huge z-score against a constant baseline, but the
+        // relative-change guard suppresses it.
+        var anomalies = service.Detect(RuSnapshot(100.0001d));
+
+        anomalies.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Detect_ConstantBaselineThenRealDrop_IsFlagged()
+    {
+        var service = CreateService();
+        Feed(service, Enumerable.Repeat(100d, 6).Select(v => RuSnapshot(v)));
+
+        // A genuine drop clears both the z-score and the relative-change guard even though
+        // the baseline standard deviation is zero (floored).
+        var anomalies = service.Detect(RuSnapshot(40d));
+
+        anomalies.Should().ContainSingle();
+        anomalies[0].Direction.Should().Be(AnomalyDirection.Low);
+    }
+
+    [Fact]
+    public void Detect_ModerateDeviationBelowThreshold_IsNotFlagged()
+    {
+        var service = CreateService();
+        // Wide-spread baseline -> a +30 move yields z < 3.
+        Feed(service, new[] { 80d, 120d, 90d, 110d, 100d }.Select(v => RuSnapshot(v)));
+
+        var anomalies = service.Detect(RuSnapshot(130d));
+
+        anomalies.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Detect_KeysAreIsolated()
+    {
+        var service = CreateService();
+        Feed(service, new[] { 100d, 101d, 99d, 100d, 100d }.Select(v => RuSnapshot(v, pipeline: "A")));
+        Feed(service, new[] { 10d, 11d, 9d, 10d, 10d }.Select(v => RuSnapshot(v, pipeline: "B")));
+
+        var anomalies = service.Detect(RuSnapshot(200d, pipeline: "A"));
+
+        anomalies.Should().ContainSingle();
+        anomalies[0].PipelineName.Should().Be("A");
+        anomalies[0].BaselineMean.Should().BeApproximately(100d, 0.5, "B's values must not contaminate A's baseline");
+    }
+
+    [Fact]
+    public void Detect_NullMetrics_AreSkipped()
+    {
+        var service = CreateService();
+        var snapshots = Enumerable.Range(0, 10).Select(_ => new MigrationProgressSnapshot
+        {
+            Sample = new MigrationProgressSample { PipelineName = "P" },
+            RequestUnitsPerSecond = null,
+            ThroughputRowsPerSecond = null,
+        });
+
+        Feed(service, snapshots).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Detect_LowOnTerminalStatus_IsSuppressed_ButHighIsNot()
+    {
+        var service = CreateService();
+        Feed(service, new[] { 100d, 101d, 99d, 100d, 100d }.Select(v => RuSnapshot(v)));
+
+        var low = service.Detect(RuSnapshot(5d, status: "Succeeded"));
+        low.Should().BeEmpty("ramp-down at completion should not warn");
+
+        var high = service.Detect(RuSnapshot(500d, status: "Succeeded"));
+        high.Should().ContainSingle();
+        high[0].Direction.Should().Be(AnomalyDirection.High);
+    }
+
+    [Fact]
+    public void Detect_Throughput_IsWatchedIndependently()
+    {
+        var service = CreateService();
+        var baseline = Enumerable.Repeat(50d, 6).Select(v => new MigrationProgressSnapshot
+        {
+            Sample = new MigrationProgressSample { PipelineName = "P" },
+            ThroughputRowsPerSecond = v,
+        });
+        Feed(service, baseline);
+
+        var anomalies = service.Detect(new MigrationProgressSnapshot
+        {
+            Sample = new MigrationProgressSample { PipelineName = "P" },
+            ThroughputRowsPerSecond = 500d,
+        });
+
+        anomalies.Should().ContainSingle();
+        anomalies[0].MetricName.Should().Be(AnomalyDetectionService.MetricThroughputRowsPerSecond);
+    }
+
+    [Fact]
+    public void Detect_WhenDisabled_ReturnsEmpty()
+    {
+        var service = CreateService(new AnomalyDetectionOptions { Enabled = false });
+
+        Feed(service, new[] { 100d, 100d, 100d, 100d, 100d, 99999d }.Select(v => RuSnapshot(v)))
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Detect_NullSnapshot_Throws()
+    {
+        var service = CreateService();
+
+        ((Action)(() => service.Detect(null!))).Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task DetectAsync_StreamsDetectedAnomalies()
+    {
+        var service = CreateService();
+        var snapshots = new[] { 100d, 101d, 99d, 100d, 100d, 250d }.Select(v => RuSnapshot(v));
+
+        var anomalies = new List<MigrationAnomaly>();
+        await foreach (var anomaly in service.DetectAsync(snapshots.ToAsync()))
+        {
+            anomalies.Add(anomaly);
+        }
+
+        anomalies.Should().ContainSingle();
+        anomalies[0].Direction.Should().Be(AnomalyDirection.High);
+    }
+
+    [Fact]
+    public async Task DetectAsync_NullSource_Throws()
+    {
+        var service = CreateService();
+
+        var act = async () =>
+        {
+            await foreach (var _ in service.DetectAsync(null!))
+            {
+            }
+        };
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Theory]
+    [InlineData(0, 5, 3.0, 1e-9, 0.25)]   // WindowSize <= 0
+    [InlineData(20, 1, 3.0, 1e-9, 0.25)]  // MinSamplesForBaseline < 2
+    [InlineData(3, 5, 3.0, 1e-9, 0.25)]   // WindowSize < MinSamplesForBaseline
+    [InlineData(20, 5, 0.0, 1e-9, 0.25)]  // ZScoreThreshold <= 0
+    [InlineData(20, 5, 3.0, 0.0, 0.25)]   // MinBaselineStdDev <= 0
+    [InlineData(20, 5, 3.0, 1e-9, -0.1)]  // MinRelativeChange < 0
+    public void Constructor_InvalidOptions_Throw(
+        int windowSize,
+        int minSamples,
+        double zThreshold,
+        double minStdDev,
+        double minRelative)
+    {
+        var options = new AnomalyDetectionOptions
+        {
+            WindowSize = windowSize,
+            MinSamplesForBaseline = minSamples,
+            ZScoreThreshold = zThreshold,
+            MinBaselineStdDev = minStdDev,
+            MinRelativeChange = minRelative,
+        };
+
+        ((Func<AnomalyDetectionService>)(() => CreateService(options)))
+            .Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Constructor_NullArguments_Throw()
+    {
+        ((Func<AnomalyDetectionService>)(() => new AnomalyDetectionService(null!, NullLogger<AnomalyDetectionService>.Instance)))
+            .Should().Throw<ArgumentNullException>();
+        ((Func<AnomalyDetectionService>)(() => new AnomalyDetectionService(new AnomalyDetectionOptions(), null!)))
+            .Should().Throw<ArgumentNullException>();
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/Monitoring/AzureMonitorMetricPayloadBuilderTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/Monitoring/AzureMonitorMetricPayloadBuilderTests.cs
@@ -1,0 +1,140 @@
+using System.Text.Json;
+using CosmosToSqlAssessment.Models.Monitoring;
+using CosmosToSqlAssessment.Services.Monitoring;
+
+namespace CosmosToSqlAssessment.Tests.Services.Monitoring;
+
+public class AzureMonitorMetricPayloadBuilderTests
+{
+    private static readonly DateTimeOffset Time = new(2026, 6, 18, 12, 0, 0, TimeSpan.Zero);
+
+    private static MigrationMetricPoint Point(
+        string name,
+        double value,
+        DateTimeOffset? time = null,
+        IReadOnlyDictionary<string, string>? dims = null,
+        string ns = "CosmosToSqlMigration")
+        => new()
+        {
+            Name = name,
+            Namespace = ns,
+            Value = value,
+            Timestamp = time ?? Time,
+            Dimensions = dims ?? new Dictionary<string, string>(),
+        };
+
+    [Fact]
+    public void BuildPayloads_NullOrEmpty_ReturnsEmpty()
+    {
+        var builder = new AzureMonitorMetricPayloadBuilder();
+
+        builder.BuildPayloads(null).Should().BeEmpty();
+        builder.BuildPayloads(Array.Empty<MigrationMetricPoint>()).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildPayloads_SinglePoint_ProducesDocumentedSchema()
+    {
+        var dims = new Dictionary<string, string> { ["PipelineName"] = "Migrate_Sales", ["Status"] = "InProgress" };
+        var builder = new AzureMonitorMetricPayloadBuilder();
+
+        var payloads = builder.BuildPayloads(new[] { Point("MigrationRowsMigrated", 123, dims: dims) });
+
+        payloads.Should().HaveCount(1);
+        var payload = payloads[0];
+        payload["time"].Should().Be("2026-06-18T12:00:00.000Z");
+
+        var data = (IDictionary<string, object?>)payload["data"]!;
+        var baseData = (IDictionary<string, object?>)data["baseData"]!;
+        baseData["metric"].Should().Be("MigrationRowsMigrated");
+        baseData["namespace"].Should().Be("CosmosToSqlMigration");
+
+        var dimNames = ((IEnumerable<object?>)baseData["dimNames"]!).Cast<string>().ToList();
+        dimNames.Should().ContainInOrder("PipelineName", "Status"); // ordinal-sorted
+
+        var series = (List<object?>)baseData["series"]!;
+        series.Should().HaveCount(1);
+        var s0 = (IDictionary<string, object?>)series[0]!;
+        ((IEnumerable<object?>)s0["dimValues"]!).Cast<string>().Should().ContainInOrder("Migrate_Sales", "InProgress");
+        s0["min"].Should().Be(123d);
+        s0["max"].Should().Be(123d);
+        s0["sum"].Should().Be(123d);
+        s0["count"].Should().Be(1);
+    }
+
+    [Fact]
+    public void BuildPayloads_DifferentMetricNames_ProduceSeparatePayloads()
+    {
+        var builder = new AzureMonitorMetricPayloadBuilder();
+
+        var payloads = builder.BuildPayloads(new[]
+        {
+            Point("MigrationRowsMigrated", 10),
+            Point("MigrationErrorRate", 0.5),
+        });
+
+        payloads.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void BuildPayloads_SameMetricDifferentDimValues_GroupIntoOnePayloadWithSeries()
+    {
+        var builder = new AzureMonitorMetricPayloadBuilder();
+        var a = new Dictionary<string, string> { ["PipelineName"] = "A" };
+        var b = new Dictionary<string, string> { ["PipelineName"] = "B" };
+
+        var payloads = builder.BuildPayloads(new[]
+        {
+            Point("MigrationRowsMigrated", 1, dims: a),
+            Point("MigrationRowsMigrated", 2, dims: b),
+        });
+
+        payloads.Should().HaveCount(1);
+        var baseData = (IDictionary<string, object?>)((IDictionary<string, object?>)payloads[0]["data"]!)["baseData"]!;
+        ((List<object?>)baseData["series"]!).Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void BuildPayloads_DifferentTimestamps_ProduceSeparatePayloads()
+    {
+        var builder = new AzureMonitorMetricPayloadBuilder();
+
+        var payloads = builder.BuildPayloads(new[]
+        {
+            Point("MigrationRowsMigrated", 1, time: Time),
+            Point("MigrationRowsMigrated", 2, time: Time.AddMinutes(1)),
+        });
+
+        payloads.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void BuildPayloads_EmptyDimensions_ProduceEmptyDimArrays()
+    {
+        var builder = new AzureMonitorMetricPayloadBuilder();
+
+        var payloads = builder.BuildPayloads(new[] { Point("MigrationErrorCount", 0) });
+
+        var baseData = (IDictionary<string, object?>)((IDictionary<string, object?>)payloads[0]["data"]!)["baseData"]!;
+        ((IEnumerable<object?>)baseData["dimNames"]!).Should().BeEmpty();
+        var s0 = (IDictionary<string, object?>)((List<object?>)baseData["series"]!)[0]!;
+        ((IEnumerable<object?>)s0["dimValues"]!).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildPayloadJson_ProducesValidParsableJson()
+    {
+        var dims = new Dictionary<string, string> { ["PipelineName"] = "Migrate_Sales" };
+        var builder = new AzureMonitorMetricPayloadBuilder();
+
+        var jsonList = builder.BuildPayloadJson(new[] { Point("MigrationRowsMigrated", 7, dims: dims) });
+
+        jsonList.Should().HaveCount(1);
+        using var doc = JsonDocument.Parse(jsonList[0]);
+        var root = doc.RootElement;
+        root.GetProperty("time").GetString().Should().Be("2026-06-18T12:00:00.000Z");
+        var baseData = root.GetProperty("data").GetProperty("baseData");
+        baseData.GetProperty("metric").GetString().Should().Be("MigrationRowsMigrated");
+        baseData.GetProperty("series")[0].GetProperty("count").GetInt32().Should().Be(1);
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/Monitoring/AzureMonitorMetricPublisherTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/Monitoring/AzureMonitorMetricPublisherTests.cs
@@ -1,0 +1,154 @@
+using System.Net;
+using System.Net.Http;
+using Azure.Core;
+using CosmosToSqlAssessment.Models.Monitoring;
+using CosmosToSqlAssessment.Services.Monitoring;
+
+namespace CosmosToSqlAssessment.Tests.Services.Monitoring;
+
+public class AzureMonitorMetricPublisherTests
+{
+    private sealed class StubTokenCredential : TokenCredential
+    {
+        public int Calls { get; private set; }
+
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            Calls++;
+            return new AccessToken("fake-token", DateTimeOffset.UtcNow.AddHours(1));
+        }
+
+        public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            => new(GetToken(requestContext, cancellationToken));
+    }
+
+    private sealed class CountingHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+        public List<HttpRequestMessage> Requests { get; } = new();
+        public List<string> Bodies { get; } = new();
+
+        public CountingHandler(HttpStatusCode status = HttpStatusCode.OK) => _status = status;
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            if (request.Content is not null)
+            {
+                Bodies.Add(await request.Content.ReadAsStringAsync(cancellationToken));
+            }
+            return new HttpResponseMessage(_status) { Content = new StringContent("{}") };
+        }
+    }
+
+    private static List<MigrationMetricPoint> SamplePoints() => new()
+    {
+        new MigrationMetricPoint
+        {
+            Name = "MigrationRowsMigrated",
+            Namespace = "CosmosToSqlMigration",
+            Value = 100,
+            Timestamp = new DateTimeOffset(2026, 6, 18, 12, 0, 0, TimeSpan.Zero),
+            Dimensions = new Dictionary<string, string> { ["PipelineName"] = "P" },
+        },
+    };
+
+    private static AzureMonitorMetricPublisher Create(
+        AzureMonitorMetricOptions options,
+        TokenCredential credential,
+        HttpMessageHandler handler)
+        => new(options, Mock.Of<ILogger<AzureMonitorMetricPublisher>>(), credential, new HttpClient(handler), new AzureMonitorMetricPayloadBuilder());
+
+    [Fact]
+    public async Task PublishAsync_Disabled_DoesNotCallEndpointOrCredential()
+    {
+        var credential = new StubTokenCredential();
+        var handler = new CountingHandler();
+        var publisher = Create(new AzureMonitorMetricOptions { Enabled = false }, credential, handler);
+
+        await publisher.PublishAsync(SamplePoints());
+
+        handler.Requests.Should().BeEmpty();
+        credential.Calls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task PublishAsync_EnabledButMissingConfig_DoesNotCallEndpoint()
+    {
+        var credential = new StubTokenCredential();
+        var handler = new CountingHandler();
+        var publisher = Create(new AzureMonitorMetricOptions { Enabled = true, Region = "", ResourceId = null }, credential, handler);
+
+        await publisher.PublishAsync(SamplePoints());
+
+        handler.Requests.Should().BeEmpty();
+        credential.Calls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task PublishAsync_EmptyMetrics_IsNoOp()
+    {
+        var credential = new StubTokenCredential();
+        var handler = new CountingHandler();
+        var publisher = Create(
+            new AzureMonitorMetricOptions { Enabled = true, Region = "eastus", ResourceId = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.DataFactory/factories/f" },
+            credential, handler);
+
+        await publisher.PublishAsync(Array.Empty<MigrationMetricPoint>());
+
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task PublishAsync_Configured_PostsBearerAuthorizedPayloadToRegionalEndpoint()
+    {
+        var credential = new StubTokenCredential();
+        var handler = new CountingHandler();
+        var options = new AzureMonitorMetricOptions
+        {
+            Enabled = true,
+            Region = "eastus",
+            ResourceId = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.DataFactory/factories/f",
+        };
+        var publisher = Create(options, credential, handler);
+
+        await publisher.PublishAsync(SamplePoints());
+
+        handler.Requests.Should().HaveCount(1);
+        var request = handler.Requests[0];
+        request.Method.Should().Be(HttpMethod.Post);
+        request.RequestUri!.ToString().Should().Be(
+            "https://eastus.monitoring.azure.com/subscriptions/s/resourceGroups/rg/providers/Microsoft.DataFactory/factories/f/metrics");
+        request.Headers.Authorization!.Scheme.Should().Be("Bearer");
+        request.Headers.Authorization!.Parameter.Should().Be("fake-token");
+        handler.Bodies[0].Should().Contain("MigrationRowsMigrated");
+    }
+
+    [Fact]
+    public async Task PublishAsync_HttpError_DoesNotThrow()
+    {
+        var credential = new StubTokenCredential();
+        var handler = new CountingHandler(HttpStatusCode.BadRequest);
+        var options = new AzureMonitorMetricOptions
+        {
+            Enabled = true,
+            Region = "eastus",
+            ResourceId = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.DataFactory/factories/f",
+        };
+        var publisher = Create(options, credential, handler);
+
+        var act = async () => await publisher.PublishAsync(SamplePoints());
+
+        await act.Should().NotThrowAsync();
+        handler.Requests.Should().HaveCount(1);
+    }
+
+    [Theory]
+    [InlineData("/subscriptions/s/rg")]
+    [InlineData("subscriptions/s/rg")]
+    public void BuildEndpoint_NormalizesLeadingSlash(string resourceId)
+    {
+        var endpoint = AzureMonitorMetricPublisher.BuildEndpoint("westus2", resourceId);
+        endpoint.Should().Be("https://westus2.monitoring.azure.com/subscriptions/s/rg/metrics");
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/Monitoring/AzureMonitorMigrationStatusSourceTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/Monitoring/AzureMonitorMigrationStatusSourceTests.cs
@@ -1,0 +1,184 @@
+using Azure.Monitor.Query.Models;
+using CosmosToSqlAssessment.Models.Monitoring;
+using CosmosToSqlAssessment.Services.Monitoring;
+using CosmosToSqlAssessment.Tests.Mocks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace CosmosToSqlAssessment.Tests.Services.Monitoring;
+
+public class AzureMonitorMigrationStatusSourceTests
+{
+    private static IConfiguration Config(string? workspaceId = null, string? lookback = null)
+    {
+        var values = new Dictionary<string, string?>();
+        if (workspaceId is not null)
+        {
+            values["AzureMonitor:WorkspaceId"] = workspaceId;
+        }
+
+        if (lookback is not null)
+        {
+            values["AzureMonitor:Status:LookbackMinutes"] = lookback;
+        }
+
+        return new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+    }
+
+    private static ILogger<AzureMonitorMigrationStatusSource> Logger() =>
+        Mock.Of<ILogger<AzureMonitorMigrationStatusSource>>();
+
+    private static LogsTableRow ActivityRow(
+        DateTimeOffset time,
+        string pipeline,
+        string activity,
+        string runId,
+        string status,
+        long rowsCopied,
+        long rowsRead)
+    {
+        var columns = new[]
+        {
+            MonitorQueryModelFactory.LogsTableColumn("TimeGenerated", LogsColumnType.Datetime),
+            MonitorQueryModelFactory.LogsTableColumn("PipelineName", LogsColumnType.String),
+            MonitorQueryModelFactory.LogsTableColumn("ActivityName", LogsColumnType.String),
+            MonitorQueryModelFactory.LogsTableColumn("RunId", LogsColumnType.String),
+            MonitorQueryModelFactory.LogsTableColumn("Status", LogsColumnType.String),
+            MonitorQueryModelFactory.LogsTableColumn("RowsCopied", LogsColumnType.Long),
+            MonitorQueryModelFactory.LogsTableColumn("RowsRead", LogsColumnType.Long),
+        };
+
+        return MonitorQueryModelFactory.LogsTableRow(
+            columns,
+            new object[] { time, pipeline, activity, runId, status, rowsCopied, rowsRead });
+    }
+
+    private static LogsTable ActivityTable(params LogsTableRow[] rows)
+    {
+        var columns = new[]
+        {
+            MonitorQueryModelFactory.LogsTableColumn("TimeGenerated", LogsColumnType.Datetime),
+            MonitorQueryModelFactory.LogsTableColumn("PipelineName", LogsColumnType.String),
+            MonitorQueryModelFactory.LogsTableColumn("ActivityName", LogsColumnType.String),
+            MonitorQueryModelFactory.LogsTableColumn("RunId", LogsColumnType.String),
+            MonitorQueryModelFactory.LogsTableColumn("Status", LogsColumnType.String),
+            MonitorQueryModelFactory.LogsTableColumn("RowsCopied", LogsColumnType.Long),
+            MonitorQueryModelFactory.LogsTableColumn("RowsRead", LogsColumnType.Long),
+        };
+
+        return MonitorQueryModelFactory.LogsTable("PrimaryResult", columns, rows);
+    }
+
+    [Fact]
+    public void BuildQuery_TargetsAdfActivityRunWithLookback()
+    {
+        var query = AzureMonitorMigrationStatusSource.BuildQuery(60);
+
+        query.Should().Contain("ADFActivityRun");
+        query.Should().Contain("ago(60m)");
+        query.Should().Contain("Copy");
+    }
+
+    [Fact]
+    public void MapRow_MapsAllProjectedColumns()
+    {
+        var time = DateTimeOffset.UtcNow;
+        var row = ActivityRow(time, "Migrate_Orders", "CopyOrders", "run-1", "InProgress", 500, 520);
+
+        var observation = AzureMonitorMigrationStatusSource.MapRow(row);
+
+        observation.Timestamp.Should().Be(time);
+        observation.PipelineName.Should().Be("Migrate_Orders");
+        observation.ActivityName.Should().Be("CopyOrders");
+        observation.RunId.Should().Be("run-1");
+        observation.Status.Should().Be("InProgress");
+        observation.CumulativeRowsCopied.Should().Be(500);
+        observation.CumulativeRowsRead.Should().Be(520);
+        observation.Key.Should().Be("Migrate_Orders|run-1|CopyOrders");
+    }
+
+    [Fact]
+    public async Task ReadSamplesAsync_WorkspaceNotConfigured_YieldsNothing()
+    {
+        var source = new AzureMonitorMigrationStatusSource(Config(workspaceId: null), Logger(), logsQueryClient: null);
+
+        var samples = new List<MigrationProgressSample>();
+        await foreach (var sample in source.ReadSamplesAsync(new MigrationStatusReportOptions()))
+        {
+            samples.Add(sample);
+        }
+
+        samples.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ReadSamplesAsync_ClientPresentButNoWorkspaceConfig_YieldsNothing()
+    {
+        var client = new LogsQueryClientMockBuilder().WithTable(ActivityTable()).Build();
+        var source = new AzureMonitorMigrationStatusSource(Config(workspaceId: null), Logger(), client);
+
+        var samples = new List<MigrationProgressSample>();
+        await foreach (var sample in source.ReadSamplesAsync(new MigrationStatusReportOptions()))
+        {
+            samples.Add(sample);
+        }
+
+        samples.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ReadSamplesAsync_OneShot_MapsRowsToSamplesWithFirstObservationDelta()
+    {
+        var time = DateTimeOffset.UtcNow;
+        var table = ActivityTable(
+            ActivityRow(time, "Migrate_Orders", "CopyOrders", "run-1", "InProgress", 500, 520));
+        var client = new LogsQueryClientMockBuilder().WithTable(table).Build();
+        var source = new AzureMonitorMigrationStatusSource(Config(workspaceId: "ws-id"), Logger(), client);
+
+        var samples = new List<MigrationProgressSample>();
+        await foreach (var sample in source.ReadSamplesAsync(new MigrationStatusReportOptions()))
+        {
+            samples.Add(sample);
+        }
+
+        samples.Should().ContainSingle();
+        var only = samples[0];
+        only.PipelineName.Should().Be("Migrate_Orders");
+        only.ActivityName.Should().Be("CopyOrders");
+        only.RunId.Should().Be("run-1");
+        only.Status.Should().Be("InProgress");
+        only.RowsMigrated.Should().Be(500); // first observation: delta == cumulative
+    }
+
+    [Fact]
+    public async Task ReadSamplesAsync_QueryError_YieldsNothingGracefully()
+    {
+        var client = new LogsQueryClientMockBuilder()
+            .WithError(new InvalidOperationException("kusto exploded"))
+            .Build();
+        var source = new AzureMonitorMigrationStatusSource(Config(workspaceId: "ws-id"), Logger(), client);
+
+        var samples = new List<MigrationProgressSample>();
+        await foreach (var sample in source.ReadSamplesAsync(new MigrationStatusReportOptions()))
+        {
+            samples.Add(sample);
+        }
+
+        samples.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ReadSamplesAsync_NullOptions_Throws()
+    {
+        var source = new AzureMonitorMigrationStatusSource(Config(workspaceId: "ws-id"), Logger(), logsQueryClient: null);
+
+        var act = async () =>
+        {
+            await foreach (var _ in source.ReadSamplesAsync(null!))
+            {
+            }
+        };
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/Monitoring/MigrationMonitoringServiceTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/Monitoring/MigrationMonitoringServiceTests.cs
@@ -1,0 +1,227 @@
+using CosmosToSqlAssessment.Models.Monitoring;
+using CosmosToSqlAssessment.Services.Monitoring;
+
+namespace CosmosToSqlAssessment.Tests.Services.Monitoring;
+
+public class MigrationMonitoringServiceTests
+{
+    private static readonly DateTimeOffset T0 = new(2026, 6, 18, 12, 0, 0, TimeSpan.Zero);
+
+    private static MigrationMonitoringService CreateService(
+        IMigrationMetricPublisher publisher,
+        AzureMonitorMetricOptions? options = null)
+        => new(publisher, options ?? new AzureMonitorMetricOptions(), Mock.Of<ILogger<MigrationMonitoringService>>());
+
+    private static async Task<List<MigrationProgressSnapshot>> CollectAsync(
+        MigrationMonitoringService service,
+        IEnumerable<MigrationProgressSample> samples)
+    {
+        var result = new List<MigrationProgressSnapshot>();
+        await foreach (var snapshot in service.MonitorAsync(samples.ToAsync()))
+        {
+            result.Add(snapshot);
+        }
+        return result;
+    }
+
+    [Fact]
+    public async Task MonitorAsync_EmitsFourMetricPointsPerSample()
+    {
+        var publisher = new RecordingMetricPublisher();
+        var service = CreateService(publisher);
+
+        var snapshots = await CollectAsync(service, new[]
+        {
+            new MigrationProgressSample { PipelineName = "P", RowsMigrated = 100, RowsRead = 100, RequestUnitsConsumed = 50, Timestamp = T0 },
+        });
+
+        snapshots.Should().HaveCount(1);
+        snapshots[0].Metrics.Select(m => m.Name).Should().BeEquivalentTo(new[]
+        {
+            MigrationMonitoringService.MetricRowsMigrated,
+            MigrationMonitoringService.MetricRequestUnits,
+            MigrationMonitoringService.MetricErrorCount,
+            MigrationMonitoringService.MetricErrorRate,
+        });
+        publisher.Batches.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task MonitorAsync_AccumulatesCumulativeTotalsPerKey()
+    {
+        var publisher = new RecordingMetricPublisher();
+        var service = CreateService(publisher);
+
+        var snapshots = await CollectAsync(service, new[]
+        {
+            new MigrationProgressSample { PipelineName = "P", RunId = "r1", RowsMigrated = 100, RowsRead = 110, RequestUnitsConsumed = 40, Timestamp = T0 },
+            new MigrationProgressSample { PipelineName = "P", RunId = "r1", RowsMigrated = 50, RowsRead = 60, RequestUnitsConsumed = 25, Timestamp = T0.AddMinutes(1) },
+        });
+
+        snapshots[1].CumulativeRowsMigrated.Should().Be(150);
+        snapshots[1].CumulativeRowsRead.Should().Be(170);
+        snapshots[1].CumulativeRequestUnits.Should().Be(65);
+    }
+
+    [Fact]
+    public async Task MonitorAsync_PartitionsAccumulationByPipelineRunActivity()
+    {
+        var publisher = new RecordingMetricPublisher();
+        var service = CreateService(publisher);
+
+        var snapshots = await CollectAsync(service, new[]
+        {
+            new MigrationProgressSample { PipelineName = "A", RowsMigrated = 100, Timestamp = T0 },
+            new MigrationProgressSample { PipelineName = "B", RowsMigrated = 5, Timestamp = T0 },
+            new MigrationProgressSample { PipelineName = "A", RowsMigrated = 100, Timestamp = T0.AddMinutes(1) },
+        });
+
+        snapshots[2].CumulativeRowsMigrated.Should().Be(200); // A only, not contaminated by B
+    }
+
+    [Fact]
+    public async Task MonitorAsync_WindowedErrorRate_UsesRowsReadDenominator()
+    {
+        var publisher = new RecordingMetricPublisher();
+        var service = CreateService(publisher);
+
+        var snapshots = await CollectAsync(service, new[]
+        {
+            new MigrationProgressSample { PipelineName = "P", RowsMigrated = 90, RowsRead = 100, ErrorCount = 10, Timestamp = T0 },
+        });
+
+        snapshots[0].ErrorRate.Should().BeApproximately(0.10, 1e-9);
+    }
+
+    [Fact]
+    public async Task MonitorAsync_WindowedErrorRate_FallsBackWhenRowsReadUnknown()
+    {
+        var publisher = new RecordingMetricPublisher();
+        var service = CreateService(publisher);
+
+        var snapshots = await CollectAsync(service, new[]
+        {
+            new MigrationProgressSample { PipelineName = "P", RowsMigrated = 8, ErrorCount = 2, Timestamp = T0 },
+        });
+
+        // fallback denominator = RowsMigrated + ErrorCount = 10
+        snapshots[0].ErrorRate.Should().BeApproximately(0.20, 1e-9);
+    }
+
+    [Fact]
+    public async Task MonitorAsync_PercentComplete_ComputedFromTotalRows()
+    {
+        var publisher = new RecordingMetricPublisher();
+        var service = CreateService(publisher);
+
+        var snapshots = await CollectAsync(service, new[]
+        {
+            new MigrationProgressSample { PipelineName = "P", RowsMigrated = 250, TotalRows = 1000, Timestamp = T0 },
+        });
+
+        snapshots[0].PercentComplete.Should().BeApproximately(25d, 1e-9);
+    }
+
+    [Fact]
+    public async Task MonitorAsync_PercentComplete_NullWhenTotalUnknown()
+    {
+        var publisher = new RecordingMetricPublisher();
+        var service = CreateService(publisher);
+
+        var snapshots = await CollectAsync(service, new[]
+        {
+            new MigrationProgressSample { PipelineName = "P", RowsMigrated = 10, Timestamp = T0 },
+        });
+
+        snapshots[0].PercentComplete.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task MonitorAsync_Throughput_NullOnFirstSampleThenComputed()
+    {
+        var publisher = new RecordingMetricPublisher();
+        var service = CreateService(publisher);
+
+        var snapshots = await CollectAsync(service, new[]
+        {
+            new MigrationProgressSample { PipelineName = "P", RowsMigrated = 60, RequestUnitsConsumed = 120, Timestamp = T0 },
+            new MigrationProgressSample { PipelineName = "P", RowsMigrated = 120, RequestUnitsConsumed = 600, Timestamp = T0.AddSeconds(60) },
+        });
+
+        snapshots[0].ThroughputRowsPerSecond.Should().BeNull();
+        snapshots[1].ThroughputRowsPerSecond.Should().BeApproximately(2d, 1e-9); // 120 rows / 60s
+        snapshots[1].RequestUnitsPerSecond.Should().BeApproximately(10d, 1e-9); // 600 RU / 60s
+    }
+
+    [Fact]
+    public async Task MonitorAsync_RunIdDimension_ExcludedByDefault()
+    {
+        var publisher = new RecordingMetricPublisher();
+        var service = CreateService(publisher);
+
+        await CollectAsync(service, new[]
+        {
+            new MigrationProgressSample { PipelineName = "P", RunId = "run-123", RowsMigrated = 1, Timestamp = T0 },
+        });
+
+        publisher.AllPoints.Should().NotBeEmpty();
+        publisher.AllPoints.Should().OnlyContain(p => !p.Dimensions.ContainsKey(MigrationMonitoringService.DimensionRunId));
+    }
+
+    [Fact]
+    public async Task MonitorAsync_RunIdDimension_IncludedWhenOptedIn()
+    {
+        var publisher = new RecordingMetricPublisher();
+        var service = CreateService(publisher, new AzureMonitorMetricOptions { IncludeRunIdDimension = true });
+
+        await CollectAsync(service, new[]
+        {
+            new MigrationProgressSample { PipelineName = "P", RunId = "run-123", RowsMigrated = 1, Timestamp = T0 },
+        });
+
+        publisher.AllPoints.Should().OnlyContain(p => p.Dimensions[MigrationMonitoringService.DimensionRunId] == "run-123");
+    }
+
+    [Fact]
+    public async Task MonitorAsync_PublisherFailure_DoesNotBreakStream()
+    {
+        var publisher = new ThrowingMetricPublisher();
+        var service = CreateService(publisher);
+
+        var snapshots = await CollectAsync(service, new[]
+        {
+            new MigrationProgressSample { PipelineName = "P", RowsMigrated = 1, Timestamp = T0 },
+            new MigrationProgressSample { PipelineName = "P", RowsMigrated = 2, Timestamp = T0.AddMinutes(1) },
+        });
+
+        snapshots.Should().HaveCount(2);
+        publisher.Calls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task MonitorAsync_Cancellation_StopsEnumeration()
+    {
+        var publisher = new RecordingMetricPublisher();
+        var service = CreateService(publisher);
+        using var cts = new CancellationTokenSource();
+
+        var samples = new[]
+        {
+            new MigrationProgressSample { PipelineName = "P", RowsMigrated = 1, Timestamp = T0 },
+            new MigrationProgressSample { PipelineName = "P", RowsMigrated = 2, Timestamp = T0.AddMinutes(1) },
+        };
+
+        var seen = 0;
+        Func<Task> act = async () =>
+        {
+            await foreach (var _ in service.MonitorAsync(samples.ToAsync(cts.Token), cts.Token))
+            {
+                seen++;
+                cts.Cancel();
+            }
+        };
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        seen.Should().Be(1);
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/Monitoring/MigrationStatusServiceTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/Monitoring/MigrationStatusServiceTests.cs
@@ -1,6 +1,7 @@
 using CosmosToSqlAssessment.Models.Monitoring;
 using CosmosToSqlAssessment.Services.Monitoring;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace CosmosToSqlAssessment.Tests.Services.Monitoring;
 
@@ -130,6 +131,46 @@ public class MigrationStatusServiceTests
 
         await actNullOptions.Should().ThrowAsync<ArgumentNullException>();
         await actNullWriter.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task RunAsync_WithAnomalyDetector_RendersAnomalyWarning()
+    {
+        var start = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        MigrationProgressSample TimedSample(int second, double ru) => new()
+        {
+            PipelineName = "Migrate_Orders",
+            Timestamp = start.AddSeconds(second),
+            RowsMigrated = 10,
+            RowsRead = 10,
+            RequestUnitsConsumed = ru,
+            Status = "InProgress",
+        };
+
+        // 1s spacing => RU/sec == RequestUnitsConsumed. First sample has no prior window
+        // (RU/sec null), so samples 1-5 form the baseline (~100) and sample 6 spikes to 500.
+        var samples = new[]
+        {
+            TimedSample(0, 100),
+            TimedSample(1, 100),
+            TimedSample(2, 100),
+            TimedSample(3, 100),
+            TimedSample(4, 100),
+            TimedSample(5, 100),
+            TimedSample(6, 500),
+        };
+        var source = new FakeMigrationStatusSource(samples);
+        var detector = new AnomalyDetectionService(new AnomalyDetectionOptions(), NullLogger<AnomalyDetectionService>.Instance);
+        var service = new MigrationStatusService(
+            source,
+            new AzureMonitorMetricOptions(),
+            detector,
+            Mock.Of<ILogger<MigrationStatusService>>());
+        var writer = new StringWriter();
+
+        await service.RunAsync(new MigrationStatusReportOptions(), writer);
+
+        writer.ToString().Should().Contain("⚠ anomaly");
     }
 
     [Fact]

--- a/tests/CosmosToSqlAssessment.Tests/Services/Monitoring/MigrationStatusServiceTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/Monitoring/MigrationStatusServiceTests.cs
@@ -1,0 +1,149 @@
+using CosmosToSqlAssessment.Models.Monitoring;
+using CosmosToSqlAssessment.Services.Monitoring;
+using Microsoft.Extensions.Logging;
+
+namespace CosmosToSqlAssessment.Tests.Services.Monitoring;
+
+public class MigrationStatusServiceTests
+{
+    private static MigrationStatusService CreateService(
+        IMigrationStatusSource source,
+        AzureMonitorMetricOptions? options = null) =>
+        new(source, options ?? new AzureMonitorMetricOptions(), Mock.Of<ILogger<MigrationStatusService>>());
+
+    private static MigrationProgressSample Sample(
+        string pipeline,
+        long rows,
+        string status = "InProgress",
+        long? totalRows = null,
+        double ru = 0,
+        long errors = 0) =>
+        new()
+        {
+            PipelineName = pipeline,
+            RowsMigrated = rows,
+            RowsRead = rows + errors,
+            TotalRows = totalRows,
+            RequestUnitsConsumed = ru,
+            ErrorCount = errors,
+            Status = status,
+        };
+
+    [Fact]
+    public async Task RunAsync_RendersHeaderPerUpdateLineAndSummary()
+    {
+        var source = new FakeMigrationStatusSource(new[]
+        {
+            Sample("Migrate_Orders", rows: 100, totalRows: 1000, ru: 50),
+            Sample("Migrate_Orders", rows: 150, totalRows: 1000, ru: 75),
+        });
+        var service = CreateService(source);
+        var writer = new StringWriter();
+
+        var exit = await service.RunAsync(new MigrationStatusReportOptions(), writer);
+
+        exit.Should().Be(0);
+        var text = writer.ToString();
+        text.Should().Contain("Migration status");
+        text.Should().Contain("Migrate_Orders");
+        text.Should().Contain("── Summary ──");
+        text.Should().Contain("Total rows migrated:  250");
+    }
+
+    [Fact]
+    public async Task RunAsync_ComputesCumulativeAndPercentComplete()
+    {
+        var source = new FakeMigrationStatusSource(new[]
+        {
+            Sample("P", rows: 250, totalRows: 1000),
+            Sample("P", rows: 250, totalRows: 1000),
+        });
+        var service = CreateService(source);
+        var writer = new StringWriter();
+
+        await service.RunAsync(new MigrationStatusReportOptions(), writer);
+
+        var text = writer.ToString();
+        // After two 250-row windows against a 1000 total -> 500 rows, 50%.
+        text.Should().Contain("rows=500");
+        text.Should().Contain("50.0%");
+    }
+
+    [Fact]
+    public async Task RunAsync_NoSamples_ReportsNoActiveMigration()
+    {
+        var source = new FakeMigrationStatusSource(Array.Empty<MigrationProgressSample>());
+        var service = CreateService(source);
+        var writer = new StringWriter();
+
+        var exit = await service.RunAsync(new MigrationStatusReportOptions(), writer);
+
+        exit.Should().Be(0);
+        writer.ToString().Should().Contain("No active migration progress found.");
+    }
+
+    [Fact]
+    public async Task RunAsync_DoesNotRepublishMetrics()
+    {
+        // The service derives snapshots with a null publisher; a recording publisher passed via
+        // options is never consulted. We assert behaviorally: running status twice is side-effect free.
+        var source = new FakeMigrationStatusSource(new[] { Sample("P", rows: 10) });
+        var service = CreateService(source);
+        var writer = new StringWriter();
+
+        var first = await service.RunAsync(new MigrationStatusReportOptions(), writer);
+        var second = await service.RunAsync(new MigrationStatusReportOptions(), new StringWriter());
+
+        first.Should().Be(0);
+        second.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RunAsync_WatchCancellation_StopsGracefullyAndPrintsSummary()
+    {
+        var source = new FakeMigrationStatusSource(
+            new[] { Sample("P", rows: 10) },
+            loopForeverWhenWatching: true);
+        var service = CreateService(source);
+        var writer = new StringWriter();
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+
+        var exit = await service.RunAsync(
+            new MigrationStatusReportOptions { Watch = true, PollIntervalSeconds = 1 },
+            writer,
+            cts.Token);
+
+        exit.Should().Be(0);
+        var text = writer.ToString();
+        text.Should().Contain("Watching live progress");
+        text.Should().Contain("Stopped watching.");
+        text.Should().Contain("── Summary ──");
+    }
+
+    [Fact]
+    public async Task RunAsync_NullArguments_Throw()
+    {
+        var service = CreateService(new FakeMigrationStatusSource(Array.Empty<MigrationProgressSample>()));
+
+        var actNullOptions = async () => await service.RunAsync(null!, new StringWriter());
+        var actNullWriter = async () => await service.RunAsync(new MigrationStatusReportOptions(), null!);
+
+        await actNullOptions.Should().ThrowAsync<ArgumentNullException>();
+        await actNullWriter.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_NullArguments_Throw()
+    {
+        var source = new FakeMigrationStatusSource(Array.Empty<MigrationProgressSample>());
+        var options = new AzureMonitorMetricOptions();
+        var logger = Mock.Of<ILogger<MigrationStatusService>>();
+
+        ((Func<MigrationStatusService>)(() => new MigrationStatusService(null!, options, logger)))
+            .Should().Throw<ArgumentNullException>();
+        ((Func<MigrationStatusService>)(() => new MigrationStatusService(source, null!, logger)))
+            .Should().Throw<ArgumentNullException>();
+        ((Func<MigrationStatusService>)(() => new MigrationStatusService(source, options, null!)))
+            .Should().Throw<ArgumentNullException>();
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/Monitoring/MonitoringTestHelpers.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/Monitoring/MonitoringTestHelpers.cs
@@ -1,0 +1,51 @@
+using System.Runtime.CompilerServices;
+using CosmosToSqlAssessment.Models.Monitoring;
+using CosmosToSqlAssessment.Services.Monitoring;
+
+namespace CosmosToSqlAssessment.Tests.Services.Monitoring;
+
+/// <summary>
+/// Test helpers shared by the monitoring test suite: an in-memory metric publisher and
+/// an <see cref="IAsyncEnumerable{T}"/> adapter for plain collections.
+/// </summary>
+internal static class MonitoringTestHelpers
+{
+    /// <summary>Wraps a synchronous sequence as an <see cref="IAsyncEnumerable{T}"/>.</summary>
+    public static async IAsyncEnumerable<T> ToAsync<T>(
+        this IEnumerable<T> source,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (var item in source)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.Yield();
+            yield return item;
+        }
+    }
+}
+
+/// <summary>Captures every batch of metric points published, for assertions.</summary>
+internal sealed class RecordingMetricPublisher : IMigrationMetricPublisher
+{
+    public List<IReadOnlyList<MigrationMetricPoint>> Batches { get; } = new();
+    public List<MigrationMetricPoint> AllPoints { get; } = new();
+
+    public Task PublishAsync(IReadOnlyList<MigrationMetricPoint> metrics, CancellationToken cancellationToken = default)
+    {
+        Batches.Add(metrics);
+        AllPoints.AddRange(metrics);
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>A publisher that always throws — used to prove the stream stays alive.</summary>
+internal sealed class ThrowingMetricPublisher : IMigrationMetricPublisher
+{
+    public int Calls { get; private set; }
+
+    public Task PublishAsync(IReadOnlyList<MigrationMetricPoint> metrics, CancellationToken cancellationToken = default)
+    {
+        Calls++;
+        throw new InvalidOperationException("boom");
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/Monitoring/MonitoringTestHelpers.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/Monitoring/MonitoringTestHelpers.cs
@@ -49,3 +49,39 @@ internal sealed class ThrowingMetricPublisher : IMigrationMetricPublisher
         throw new InvalidOperationException("boom");
     }
 }
+
+/// <summary>An <see cref="IMigrationStatusSource"/> that replays a fixed set of samples.</summary>
+internal sealed class FakeMigrationStatusSource : IMigrationStatusSource
+{
+    private readonly IReadOnlyList<MigrationProgressSample> _samples;
+    private readonly bool _loopForeverWhenWatching;
+
+    public FakeMigrationStatusSource(
+        IReadOnlyList<MigrationProgressSample> samples,
+        bool loopForeverWhenWatching = false)
+    {
+        _samples = samples;
+        _loopForeverWhenWatching = loopForeverWhenWatching;
+    }
+
+    public async IAsyncEnumerable<MigrationProgressSample> ReadSamplesAsync(
+        MigrationStatusReportOptions options,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (var sample in _samples)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.Yield();
+            yield return sample;
+        }
+
+        if (options.Watch && _loopForeverWhenWatching)
+        {
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await Task.Delay(10, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #133

Real-time visibility and alerting for in-flight migration executions (paired with the ADF pipelines from #70). Integrates with Azure Monitor for metric streaming and alerting, surfaces progress via the CLI, and detects anomalies during migration.

## Sub-issues
- [x] #223 Stream migration progress metrics to Azure Monitor (rows migrated, RU consumption, error rate)
- [x] #224 Generate alert rule ARM templates (threshold breaches, error spikes, stalled pipelines)
- [x] #225 CLI command `migration status` for live progress reporting
- [x] #226 Anomaly detection on RU consumption and throughput (simple statistical baseline)
- [x] #227 Document monitoring setup and customization in `docs/monitoring.md`

## Implementation approach
- **#223** New `CosmosToSqlAssessment.Services.Monitoring` + `Models.Monitoring` namespaces. `MigrationMonitoringService` consumes an `IAsyncEnumerable<MigrationProgressSample>` (streaming per #129), derives rows-migrated / RU-consumption / error-rate custom metrics, publishes them via `IMigrationMetricPublisher`, and yields enriched `MigrationProgressSnapshot`s. The default `AzureMonitorMetricPublisher` posts the documented custom-metric payload to the regional ingestion endpoint, reusing the #76 Azure Monitor credential/config surface; gated by `AzureMonitor:Metrics:Enabled` (default off) so CI/offline runs never call out. Per-pipeline/run/activity accumulation; conservative metric dimensions (RunId opt-in).
- **#224** `AlertRuleTemplateBuilder` emits a `Microsoft.Insights/metricAlerts` template (static error-rate breach via `SingleResourceMultipleMetricCriteria`, dynamic error-spike via `MultipleResourceMultipleMetricCriteria` with `skipMetricValidation`, low/no-throughput, optional RU ceiling) and a `Microsoft.Insights/scheduledQueryRules` `LogAlert` over `ADFPipelineRun`/`ADFActivityRun` as the reliable stalled-pipeline detector (`actions.actionGroups` string array, `skipQueryValidation`). `AlertRuleTemplateGenerationService` writes `Monitoring/AlertRules/{metric-alerts,stalled-pipeline-log-alert}.template.json` + README via the shared dictionary JSON serializer. Bound from `AzureMonitor:Alerts`; registered in `AddCosmosAssessment`.

## Testing
- **#223** 26 new unit tests (payload schema/grouping, streaming derivation & cumulative aggregation, error-rate semantics, throughput, RunId dimension policy, publisher disabled/misconfigured/HTTP-error guards, cancellation).
- **#224** 25 new unit tests (metric/log template JSON well-formedness, resource type/apiVersion/location, static-vs-dynamic criterion shapes, `skipMetricValidation`/`skipQueryValidation`, scope/action wiring, metric-name constants, generation writes expected files + RU warning path).
- Full suite: **812 passing**.

## Branch-protection changes
_None anticipated. ARM templates are validated for JSON well-formedness in unit tests; no live Azure deploy is required._



