### PR TITLE
Parent #132: Adaptive optimization loops and continuous learning

### DIFF
--- a/Cli/CliArgumentParser.cs
+++ b/Cli/CliArgumentParser.cs
@@ -122,6 +122,12 @@ internal static class CliArgumentParser
                 case "--agentic":
                     options.Agentic = true;
                     break;
+                case "--enable-feedback":
+                    options.EnableFeedback = true;
+                    break;
+                case "--disable-feedback":
+                    options.DisableFeedback = true;
+                    break;
                 case "--config":
                 case "-c":
                     if (i + 1 < args.Length)
@@ -170,6 +176,13 @@ internal static class CliArgumentParser
             return false;
         }
 
+        if (options.EnableFeedback && options.DisableFeedback)
+        {
+            output.WriteLine("❌ Error: Cannot specify both --enable-feedback and --disable-feedback flags.");
+            output.WriteLine("   Use one or the other; feedback collection is opt-in and disabled by default.");
+            return false;
+        }
+
         return true;
     }
 
@@ -200,6 +213,8 @@ internal static class CliArgumentParser
         output.WriteLine("  --test-connection         Test connectivity to Cosmos DB and Azure Monitor");
         output.WriteLine("  -i, --interactive         Launch interactive wizard mode for guided configuration");
         output.WriteLine("  --agentic                 Run the assessment via the multi-agent orchestration layer (equivalent output)");
+        output.WriteLine("  --enable-feedback         Opt in to anonymized continuous-learning feedback (default: off)");
+        output.WriteLine("  --disable-feedback        Explicitly opt out of feedback collection (overrides config)");
         output.WriteLine("  -c, --config <path>       Load configuration from a saved JSON file");
         output.WriteLine("  --save-config <path>      Save wizard configuration to a JSON file for reuse");
         output.WriteLine("  --resume                  Resume an interrupted interactive wizard session");

--- a/Cli/CliOptions.cs
+++ b/Cli/CliOptions.cs
@@ -18,6 +18,8 @@ internal sealed class CliOptions
     public bool TestConnection { get; set; }
     public bool Interactive { get; set; }
     public bool Agentic { get; set; }
+    public bool EnableFeedback { get; set; }
+    public bool DisableFeedback { get; set; }
     public string? ConfigFile { get; set; }
     public string? SaveConfigFile { get; set; }
     public bool ResumeSession { get; set; }

--- a/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/DependencyInjection/ServiceCollectionExtensions.cs
@@ -106,6 +106,7 @@ namespace CosmosToSqlAssessment.DependencyInjection
                 services.AddSingleton<IFeedbackTelemetrySink, NullFeedbackTelemetrySink>();
             }
             services.AddScoped<FeedbackCollectionService>();
+            services.AddScoped<RecommendationRefinementService>();
 
             // Orchestration
             services.AddScoped<AssessmentOrchestrator>();

--- a/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/DependencyInjection/ServiceCollectionExtensions.cs
@@ -10,8 +10,10 @@ using CosmosToSqlAssessment.Reporting;
 using CosmosToSqlAssessment.Services;
 using CosmosToSqlAssessment.Services.DataFactory;
 using CosmosToSqlAssessment.Services.Discovery;
+using CosmosToSqlAssessment.Services.Feedback;
 using CosmosToSqlAssessment.Services.Monitoring;
 using CosmosToSqlAssessment.SqlProject;
+using System.Net.Http;
 
 namespace CosmosToSqlAssessment.DependencyInjection
 {
@@ -87,6 +89,23 @@ namespace CosmosToSqlAssessment.DependencyInjection
                 ?? new AnomalyDetectionOptions());
             services.AddScoped<AnomalyDetectionService>();
             services.AddScoped<MigrationStatusService>();
+
+            // Continuous-learning feedback loop (parent #132). Opt-in only; default OFF. Each
+            // registration is independent of the other parents' registrations — keep them all.
+            var feedbackOptions = configuration.GetSection(FeedbackOptions.SectionName).Get<FeedbackOptions>()
+                ?? new FeedbackOptions();
+            services.AddSingleton(feedbackOptions);
+            services.AddSingleton<IFeedbackStore, LocalJsonFeedbackStore>();
+            if (!string.IsNullOrWhiteSpace(feedbackOptions.TelemetryEndpoint))
+            {
+                services.AddSingleton(new HttpClient { Timeout = TimeSpan.FromSeconds(10) });
+                services.AddSingleton<IFeedbackTelemetrySink, HttpFeedbackTelemetrySink>();
+            }
+            else
+            {
+                services.AddSingleton<IFeedbackTelemetrySink, NullFeedbackTelemetrySink>();
+            }
+            services.AddScoped<FeedbackCollectionService>();
 
             // Orchestration
             services.AddScoped<AssessmentOrchestrator>();

--- a/Models/CosmosModels.cs
+++ b/Models/CosmosModels.cs
@@ -24,6 +24,15 @@ namespace CosmosToSqlAssessment.Models
         public DataQualityAnalysis? DataQualityAnalysis { get; set; } = null;
         /// <summary>Ordered list of actionable recommendations produced by the assessment engine.</summary>
         public List<RecommendationItem> Recommendations { get; set; } = new();
+
+        /// <summary>
+        /// The result of refining (or confirming) the recommended Azure SQL platform and tier
+        /// against prior, anonymized migration outcomes from the opt-in feedback loop. Is
+        /// <see langword="null"/> when refinement was not run, and carries an attributable
+        /// "based on N prior similar migrations" rationale for inclusion in generated reports
+        /// when it is present.
+        /// </summary>
+        public RecommendationRefinement? RecommendationRefinement { get; set; } = null;
         
         // Properties for multi-database handling
         /// <summary>When true, individual Excel reports are generated per database rather than a single combined report.</summary>

--- a/Models/MigrationOutcome.cs
+++ b/Models/MigrationOutcome.cs
@@ -1,0 +1,288 @@
+using System.Text.Json.Serialization;
+
+namespace CosmosToSqlAssessment.Models;
+
+/// <summary>
+/// The terminal status of a completed (or attempted) migration, used as a coarse
+/// success metric in the continuous-learning feedback loop.
+/// </summary>
+public enum MigrationOutcomeStatus
+{
+    /// <summary>Status was not recorded.</summary>
+    Unknown = 0,
+
+    /// <summary>The migration completed and all data/workload moved successfully.</summary>
+    Succeeded = 1,
+
+    /// <summary>The migration completed but with caveats (e.g., partial data, manual fix-ups required).</summary>
+    PartiallySucceeded = 2,
+
+    /// <summary>The migration attempt failed before completion.</summary>
+    Failed = 3,
+
+    /// <summary>The migration was completed but later rolled back.</summary>
+    RolledBack = 4
+}
+
+/// <summary>
+/// Normalized, tool-owned assessment of overall migration complexity. Mirrors the
+/// free-text <see cref="MigrationComplexity.OverallComplexity"/> value but as a closed
+/// enum so it cannot smuggle arbitrary (potentially identifying) text into a persisted
+/// feedback record.
+/// </summary>
+public enum MigrationComplexityRating
+{
+    /// <summary>Complexity could not be determined from the assessment.</summary>
+    Unknown = 0,
+
+    /// <summary>Low-complexity migration.</summary>
+    Low = 1,
+
+    /// <summary>Medium-complexity migration.</summary>
+    Medium = 2,
+
+    /// <summary>High-complexity migration.</summary>
+    High = 3
+}
+
+/// <summary>
+/// Coarse size band for a workload, derived from its total data size. Used for grouping
+/// and similarity matching so that exact sizes need not be compared directly.
+/// </summary>
+public enum WorkloadSizeBucket
+{
+    /// <summary>Under 10 GB.</summary>
+    Small = 0,
+
+    /// <summary>10 GB up to (but not including) 100 GB.</summary>
+    Medium = 1,
+
+    /// <summary>100 GB up to (but not including) 1 TB.</summary>
+    Large = 2,
+
+    /// <summary>1 TB and above.</summary>
+    VeryLarge = 3
+}
+
+/// <summary>
+/// An anonymized, aggregate "fingerprint" of an assessed workload. It captures only the
+/// non-identifying, tool-derived characteristics needed to find <em>similar</em> prior
+/// migrations (so refined recommendations can be attributed to "N prior similar
+/// migrations"). It deliberately excludes any names, endpoints, identifiers, or other
+/// customer data.
+/// </summary>
+/// <remarks>
+/// Privacy-by-design: every property here is either a closed enum, an aggregate count, or
+/// an aggregate size — none of which carry per-document or per-customer detail. Cosmos
+/// account/database/container names are intentionally never included.
+/// </remarks>
+public sealed class WorkloadProfile
+{
+    /// <summary>Normalized overall migration complexity rating.</summary>
+    public MigrationComplexityRating ComplexityRating { get; set; } = MigrationComplexityRating.Unknown;
+
+    /// <summary>Number of source containers in the assessed workload.</summary>
+    public int ContainerCount { get; set; }
+
+    /// <summary>Coarse size band derived from <see cref="TotalDataSizeGb"/>.</summary>
+    public WorkloadSizeBucket SizeBucket { get; set; } = WorkloadSizeBucket.Small;
+
+    /// <summary>Aggregate count of documents across all containers (not per-document data).</summary>
+    public long TotalDocumentCount { get; set; }
+
+    /// <summary>Aggregate data size across all containers, in gigabytes.</summary>
+    public double TotalDataSizeGb { get; set; }
+
+    /// <summary>The highest provisioned request units (RU/s) observed across containers.</summary>
+    public int MaxProvisionedRUs { get; set; }
+
+    /// <summary>Count of index recommendations produced by the assessment (a complexity signal).</summary>
+    public int IndexRecommendationCount { get; set; }
+
+    /// <summary>The Azure SQL platform recommended by the assessment (tool-generated label).</summary>
+    public string RecommendedPlatform { get; set; } = string.Empty;
+
+    /// <summary>The Azure SQL service tier recommended by the assessment (tool-generated label).</summary>
+    public string RecommendedTier { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Maps a total data size in gigabytes to a coarse <see cref="WorkloadSizeBucket"/>.
+    /// </summary>
+    /// <param name="totalDataSizeGb">Aggregate workload size in gigabytes.</param>
+    /// <returns>The matching size band.</returns>
+    public static WorkloadSizeBucket BucketFor(double totalDataSizeGb)
+    {
+        if (totalDataSizeGb < 10) return WorkloadSizeBucket.Small;
+        if (totalDataSizeGb < 100) return WorkloadSizeBucket.Medium;
+        if (totalDataSizeGb < 1024) return WorkloadSizeBucket.Large;
+        return WorkloadSizeBucket.VeryLarge;
+    }
+
+    /// <summary>
+    /// Parses a free-text complexity label (e.g., "Low"/"Medium"/"High") into the closed
+    /// <see cref="MigrationComplexityRating"/> enum, returning
+    /// <see cref="MigrationComplexityRating.Unknown"/> for unrecognized values.
+    /// </summary>
+    /// <param name="complexity">The free-text complexity label to normalize.</param>
+    /// <returns>The normalized complexity rating.</returns>
+    public static MigrationComplexityRating ParseComplexity(string? complexity) =>
+        complexity?.Trim().ToLowerInvariant() switch
+        {
+            "low" => MigrationComplexityRating.Low,
+            "medium" => MigrationComplexityRating.Medium,
+            "high" => MigrationComplexityRating.High,
+            _ => MigrationComplexityRating.Unknown
+        };
+
+    /// <summary>
+    /// Derives an anonymized <see cref="WorkloadProfile"/> from a completed assessment.
+    /// Only aggregate, non-identifying characteristics are extracted.
+    /// </summary>
+    /// <param name="assessment">The assessment result to fingerprint.</param>
+    /// <returns>A workload profile suitable for similarity matching.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="assessment"/> is null.</exception>
+    public static WorkloadProfile FromAssessment(AssessmentResult assessment)
+    {
+        ArgumentNullException.ThrowIfNull(assessment);
+
+        var containers = assessment.CosmosAnalysis?.Containers ?? new List<ContainerAnalysis>();
+        var totalDocs = containers.Sum(c => c.DocumentCount);
+        var totalSizeGb = containers.Sum(c => c.SizeBytes) / (1024.0 * 1024.0 * 1024.0);
+        var maxRUs = containers.Count > 0 ? containers.Max(c => c.ProvisionedRUs) : 0;
+
+        var sql = assessment.SqlAssessment ?? new SqlMigrationAssessment();
+
+        return new WorkloadProfile
+        {
+            ComplexityRating = ParseComplexity(sql.Complexity?.OverallComplexity),
+            ContainerCount = containers.Count,
+            TotalDocumentCount = totalDocs,
+            TotalDataSizeGb = totalSizeGb,
+            SizeBucket = BucketFor(totalSizeGb),
+            MaxProvisionedRUs = maxRUs,
+            IndexRecommendationCount = sql.IndexRecommendations?.Count ?? 0,
+            RecommendedPlatform = sql.RecommendedPlatform ?? string.Empty,
+            RecommendedTier = sql.RecommendedTier ?? string.Empty
+        };
+    }
+}
+
+/// <summary>
+/// An anonymized, aggregate record of how a migration actually turned out, captured
+/// <em>only with explicit opt-in</em> and used to refine future recommendations.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Privacy contract.</b> This schema is anonymized and aggregate <em>by construction</em>:
+/// it contains no names, endpoints, identifiers (other than a random, non-correlatable
+/// <see cref="OutcomeId"/>), IP addresses, credentials, or free-text notes. Every field is
+/// either a closed enum, an aggregate count/size, a tool-generated categorical label, or a
+/// numeric metric. There is intentionally <b>no</b> property in which a caller could place
+/// customer data such as a database name or a sample document.
+/// </para>
+/// <para>
+/// The three metric families required by the feedback loop are represented explicitly:
+/// <b>success</b> (<see cref="Status"/>, <see cref="ActualMigrationDays"/>,
+/// <see cref="DataCompletenessPercent"/>), <b>performance</b> (<see cref="DeployedPlatform"/>,
+/// <see cref="DeployedTier"/>, utilization/latency, <see cref="PerformanceSatisfactory"/>),
+/// and <b>cost actual vs estimate</b> (the monthly and one-time cost pairs).
+/// </para>
+/// </remarks>
+public sealed class MigrationOutcome
+{
+    /// <summary>The schema version this record was written with.</summary>
+    public const int CurrentSchemaVersion = 1;
+
+    /// <summary>
+    /// The schema version of this record, enabling forward-compatible evolution of the
+    /// persisted feedback format.
+    /// </summary>
+    public int SchemaVersion { get; set; } = CurrentSchemaVersion;
+
+    /// <summary>
+    /// A random, non-correlatable identifier for this record (no link to any user, account,
+    /// or assessment). Used only to de-duplicate records within a store.
+    /// </summary>
+    public string OutcomeId { get; set; } = Guid.NewGuid().ToString("N");
+
+    /// <summary>The UTC instant at which this outcome was recorded.</summary>
+    public DateTimeOffset RecordedAtUtc { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>The anonymized workload fingerprint used for similarity matching.</summary>
+    public WorkloadProfile Profile { get; set; } = new();
+
+    // ---- Success metrics ----
+
+    /// <summary>The terminal status of the migration.</summary>
+    public MigrationOutcomeStatus Status { get; set; } = MigrationOutcomeStatus.Unknown;
+
+    /// <summary>The actual number of days the migration took, end to end.</summary>
+    public int ActualMigrationDays { get; set; }
+
+    /// <summary>
+    /// The percentage (0–100) of data that migrated successfully (an aggregate completeness
+    /// measure, not per-row detail).
+    /// </summary>
+    public double DataCompletenessPercent { get; set; }
+
+    // ---- Performance metrics ----
+
+    /// <summary>The Azure SQL platform actually deployed (may differ from the recommendation).</summary>
+    public string DeployedPlatform { get; set; } = string.Empty;
+
+    /// <summary>The Azure SQL service tier actually deployed (may differ from the recommendation).</summary>
+    public string DeployedTier { get; set; } = string.Empty;
+
+    /// <summary>Average post-migration resource utilization (DTU/vCore) percentage, if measured.</summary>
+    public double? AvgResourceUtilizationPercent { get; set; }
+
+    /// <summary>Peak post-migration resource utilization (DTU/vCore) percentage, if measured.</summary>
+    public double? PeakResourceUtilizationPercent { get; set; }
+
+    /// <summary>Average post-migration query latency in milliseconds, if measured.</summary>
+    public double? AvgQueryLatencyMs { get; set; }
+
+    /// <summary>
+    /// Whether the deployed sizing performed satisfactorily in production, if assessed.
+    /// This is the primary signal the refinement logic learns from.
+    /// </summary>
+    public bool? PerformanceSatisfactory { get; set; }
+
+    // ---- Cost actual vs estimate ----
+
+    /// <summary>The estimated recurring monthly Azure SQL cost (USD).</summary>
+    public decimal EstimatedMonthlyCostUsd { get; set; }
+
+    /// <summary>The actual recurring monthly Azure SQL cost (USD).</summary>
+    public decimal ActualMonthlyCostUsd { get; set; }
+
+    /// <summary>The estimated one-time migration cost (USD), e.g., Data Factory.</summary>
+    public decimal EstimatedMigrationCostUsd { get; set; }
+
+    /// <summary>The actual one-time migration cost (USD).</summary>
+    public decimal ActualMigrationCostUsd { get; set; }
+
+    // ---- Derived (not persisted) ----
+
+    /// <summary>The signed monthly cost variance (actual minus estimate), in USD.</summary>
+    [JsonIgnore]
+    public decimal MonthlyCostVarianceUsd => ActualMonthlyCostUsd - EstimatedMonthlyCostUsd;
+
+    /// <summary>
+    /// The monthly cost variance as a percentage of the estimate, or <see langword="null"/>
+    /// when the estimate is zero (undefined).
+    /// </summary>
+    [JsonIgnore]
+    public double? MonthlyCostVariancePercent =>
+        EstimatedMonthlyCostUsd == 0
+            ? null
+            : (double)((ActualMonthlyCostUsd - EstimatedMonthlyCostUsd) / EstimatedMonthlyCostUsd) * 100.0;
+
+    /// <summary>
+    /// Whether this outcome counts as a success for learning purposes (fully or partially
+    /// succeeded).
+    /// </summary>
+    [JsonIgnore]
+    public bool Succeeded =>
+        Status is MigrationOutcomeStatus.Succeeded or MigrationOutcomeStatus.PartiallySucceeded;
+}

--- a/Models/RecommendationRefinement.cs
+++ b/Models/RecommendationRefinement.cs
@@ -1,0 +1,107 @@
+namespace CosmosToSqlAssessment.Models;
+
+/// <summary>
+/// A qualitative confidence level for a refined recommendation, derived from the volume and
+/// consistency of the prior similar migrations that support it.
+/// </summary>
+public enum RefinementConfidence
+{
+    /// <summary>No refinement was produced (insufficient comparable history).</summary>
+    None = 0,
+
+    /// <summary>A small amount of comparable history supports the recommendation.</summary>
+    Low = 1,
+
+    /// <summary>A moderate amount of consistent comparable history supports the recommendation.</summary>
+    Medium = 2,
+
+    /// <summary>A substantial amount of highly consistent comparable history supports the recommendation.</summary>
+    High = 3
+}
+
+/// <summary>
+/// The result of correlating the current assessment with prior, anonymized migration outcomes to
+/// refine (or confirm) the recommended Azure SQL platform and tier. Carries an attributable
+/// rationale ("based on N prior similar migrations") for transparent inclusion in reports.
+/// </summary>
+/// <remarks>
+/// When <see cref="HasRefinement"/> is <see langword="false"/> the refined values equal the
+/// baseline and <see cref="ChangedFromBaseline"/> is <see langword="false"/>; the
+/// <see cref="Rationale"/> explains why no learning was applied (e.g., too little comparable
+/// history). When <see cref="HasRefinement"/> is <see langword="true"/> the recommendation may
+/// still equal the baseline — in which case the prior outcomes <em>confirm</em> rather than change
+/// it.
+/// </remarks>
+public sealed class RecommendationRefinement
+{
+    /// <summary>
+    /// Whether enough comparable prior history existed to apply learning. When false, the baseline
+    /// recommendation is used unchanged.
+    /// </summary>
+    public bool HasRefinement { get; set; }
+
+    /// <summary>The number of prior similar, successful migrations that informed this result.</summary>
+    public int PriorSimilarMigrationCount { get; set; }
+
+    /// <summary>The assessment's original (baseline) recommended Azure SQL platform.</summary>
+    public string BaselinePlatform { get; set; } = string.Empty;
+
+    /// <summary>The assessment's original (baseline) recommended Azure SQL tier.</summary>
+    public string BaselineTier { get; set; } = string.Empty;
+
+    /// <summary>The refined recommended Azure SQL platform (equals the baseline when not changed).</summary>
+    public string RefinedPlatform { get; set; } = string.Empty;
+
+    /// <summary>The refined recommended Azure SQL tier (equals the baseline when not changed).</summary>
+    public string RefinedTier { get; set; } = string.Empty;
+
+    /// <summary>Whether the refined recommendation differs from the baseline recommendation.</summary>
+    public bool ChangedFromBaseline { get; set; }
+
+    /// <summary>The confidence level for the refined recommendation.</summary>
+    public RefinementConfidence Confidence { get; set; } = RefinementConfidence.None;
+
+    /// <summary>
+    /// A human-readable, attributable rationale suitable for inclusion in a generated report.
+    /// </summary>
+    public string Rationale { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The observed fraction (0–1) of prior similar migrations on the refined configuration that
+    /// performed satisfactorily, or <see langword="null"/> when no refinement was produced.
+    /// </summary>
+    public double? ObservedSatisfactionRate { get; set; }
+
+    /// <summary>
+    /// The average monthly cost variance percentage (actual vs estimate) observed across the
+    /// supporting prior migrations, or <see langword="null"/> when unavailable.
+    /// </summary>
+    public double? AverageMonthlyCostVariancePercent { get; set; }
+
+    /// <summary>
+    /// Creates a "no refinement" result that defers to the baseline recommendation.
+    /// </summary>
+    /// <param name="baselinePlatform">The baseline recommended platform.</param>
+    /// <param name="baselineTier">The baseline recommended tier.</param>
+    /// <param name="priorSimilarCount">The number of comparable prior migrations found (may be 0).</param>
+    /// <param name="rationale">An explanation of why no refinement was applied.</param>
+    /// <returns>A <see cref="RecommendationRefinement"/> that mirrors the baseline.</returns>
+    public static RecommendationRefinement None(
+        string baselinePlatform,
+        string baselineTier,
+        int priorSimilarCount,
+        string rationale) => new()
+        {
+            HasRefinement = false,
+            PriorSimilarMigrationCount = priorSimilarCount,
+            BaselinePlatform = baselinePlatform,
+            BaselineTier = baselineTier,
+            RefinedPlatform = baselinePlatform,
+            RefinedTier = baselineTier,
+            ChangedFromBaseline = false,
+            Confidence = RefinementConfidence.None,
+            Rationale = rationale,
+            ObservedSatisfactionRate = null,
+            AverageMonthlyCostVariancePercent = null
+        };
+}

--- a/Orchestration/AssessmentOrchestrator.cs
+++ b/Orchestration/AssessmentOrchestrator.cs
@@ -97,6 +97,8 @@ internal sealed class AssessmentOrchestrator
             return 1;
         }
 
+        ShowFeedbackConsentNotice(options);
+
         var assessmentResult = await RunAssessmentAsync(userInputs, cancellationToken);
         await GenerateOutputsAsync(assessmentResult, userInputs.OutputDirectory, options, cancellationToken);
         await GenerateSqlProjectAsync(assessmentResult, userInputs.OutputDirectory, cancellationToken);
@@ -186,6 +188,20 @@ internal sealed class AssessmentOrchestrator
 
         Console.WriteLine();
         return true;
+    }
+
+    private void ShowFeedbackConsentNotice(CliOptions options)
+    {
+        var feedback = _services.GetRequiredService<FeedbackCollectionService>();
+        bool? cliOverride = options.EnableFeedback ? true : options.DisableFeedback ? false : (bool?)null;
+        var consent = feedback.ResolveConsent(cliOverride);
+
+        // Only surface the notice when it's relevant: feedback is active, or the user explicitly
+        // asked about it via a flag. Default runs stay quiet.
+        if (consent.IsGranted || options.EnableFeedback || options.DisableFeedback)
+        {
+            feedback.WriteConsentNotice(Console.Out, consent);
+        }
     }
 
     private async Task<AssessmentResult> RunAssessmentAsync(UserInputs userInputs, CancellationToken cancellationToken)

--- a/Orchestration/AssessmentOrchestrator.cs
+++ b/Orchestration/AssessmentOrchestrator.cs
@@ -236,6 +236,7 @@ internal sealed class AssessmentOrchestrator
             }
 
             var assessmentResult = await RunDatabaseAssessmentAsync(activeServiceProvider, userInputs, databaseName, cancellationToken);
+            await AttachRecommendationRefinementAsync(activeServiceProvider, assessmentResult, cancellationToken);
             assessmentResults.Add(assessmentResult);
 
             Console.WriteLine($"✅ Completed assessment for database: {databaseName}");
@@ -265,6 +266,46 @@ internal sealed class AssessmentOrchestrator
         };
 
         return combinedResult;
+    }
+
+    /// <summary>
+    /// Attaches a recommendation refinement to <paramref name="assessmentResult"/> by correlating
+    /// the assessment with prior, anonymized migration outcomes from the opt-in feedback loop.
+    /// Refinement is best-effort: any failure (other than cancellation) is logged and swallowed so
+    /// that it can never break an otherwise successful assessment. Applied per database only — never
+    /// to a synthetic combined multi-database result, whose merged recommendation has no meaningful
+    /// baseline tier to refine against.
+    /// </summary>
+    /// <param name="provider">The active service provider for the database being assessed.</param>
+    /// <param name="assessmentResult">The assessment result to enrich with a refinement.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>A task that completes once refinement has been attempted.</returns>
+    private async Task AttachRecommendationRefinementAsync(
+        IServiceProvider provider,
+        AssessmentResult assessmentResult,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var refiner = provider.GetRequiredService<RecommendationRefinementService>();
+            var refinement = await refiner.RefineAsync(assessmentResult, cancellationToken);
+            assessmentResult.RecommendationRefinement = refinement;
+
+            if (refinement.HasRefinement)
+            {
+                Console.WriteLine(refinement.ChangedFromBaseline
+                    ? $"   🔁 Recommendation refined from {refinement.PriorSimilarMigrationCount} prior similar migration(s): {refinement.RefinedPlatform} / {refinement.RefinedTier}"
+                    : $"   ✅ Recommendation confirmed by {refinement.PriorSimilarMigrationCount} prior similar migration(s)");
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Recommendation refinement skipped due to an error; continuing with the baseline recommendation");
+        }
     }
 
     private async Task<AssessmentResult> RunDatabaseAssessmentAsync(

--- a/Reporting/ReportGenerationService.cs
+++ b/Reporting/ReportGenerationService.cs
@@ -1344,6 +1344,9 @@ namespace CosmosToSqlAssessment.Reporting
                 AddMigrationRecommendationsExplanation(body, assessmentResult);
                 AddEmptyLine(body);
 
+                // Level 1 Header: Recommendations Based on Prior Migrations (opt-in feedback loop)
+                AddPriorMigrationsRationale(body, assessmentResult);
+
                     cancellationToken.ThrowIfCancellationRequested();
 
                     // Level 1 Header: Data Factory Estimates
@@ -1980,6 +1983,47 @@ namespace CosmosToSqlAssessment.Reporting
                 
                 AddWordParagraph(body, explanation);
             }
+        }
+
+        /// <summary>
+        /// Adds the "Recommendations Based on Prior Migrations" section, surfacing the attributable
+        /// rationale produced by the opt-in feedback loop. The section is rendered only when a
+        /// refinement was produced (<see cref="RecommendationRefinement.HasRefinement"/> is
+        /// <see langword="true"/>), so default runs without opt-in feedback show nothing extra.
+        /// </summary>
+        /// <param name="body">The Word document body to append to.</param>
+        /// <param name="assessmentResult">The assessment whose refinement should be rendered.</param>
+        private void AddPriorMigrationsRationale(Body body, AssessmentResult assessmentResult)
+        {
+            var refinement = assessmentResult.RecommendationRefinement;
+            if (refinement is not { HasRefinement: true })
+            {
+                return;
+            }
+
+            AddWordHeading(body, "Recommendations Based on Prior Migrations", 1);
+
+            AddWordParagraph(body, $"• Prior similar migrations analyzed: {refinement.PriorSimilarMigrationCount}");
+            AddWordParagraph(body, $"• Confidence: {refinement.Confidence}");
+            AddWordParagraph(body, refinement.ChangedFromBaseline
+                ? $"• Refined recommendation: {refinement.RefinedPlatform} / {refinement.RefinedTier} (baseline was {refinement.BaselinePlatform} / {refinement.BaselineTier})"
+                : $"• Recommendation confirmed: {refinement.RefinedPlatform} / {refinement.RefinedTier}");
+
+            if (refinement.ObservedSatisfactionRate.HasValue)
+            {
+                var satisfaction = (refinement.ObservedSatisfactionRate.Value * 100).ToString("0.#", System.Globalization.CultureInfo.InvariantCulture);
+                AddWordParagraph(body, $"• Observed performance-satisfaction rate: {satisfaction}%");
+            }
+
+            if (refinement.AverageMonthlyCostVariancePercent.HasValue)
+            {
+                var variance = refinement.AverageMonthlyCostVariancePercent.Value.ToString("+0.0;-0.0;0.0", System.Globalization.CultureInfo.InvariantCulture);
+                AddWordParagraph(body, $"• Average monthly cost variance (actual vs estimate): {variance}%");
+            }
+
+            AddEmptyLine(body);
+            AddWordParagraph(body, refinement.Rationale);
+            AddEmptyLine(body);
         }
 
         /// <summary>

--- a/Services/Feedback/HttpFeedbackTelemetrySink.cs
+++ b/Services/Feedback/HttpFeedbackTelemetrySink.cs
@@ -1,0 +1,70 @@
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace CosmosToSqlAssessment.Services.Feedback;
+
+/// <summary>
+/// An <see cref="IFeedbackTelemetrySink"/> that POSTs a coarsened payload as JSON to the configured
+/// <see cref="FeedbackOptions.TelemetryEndpoint"/>. Transport failures are logged and swallowed so
+/// that local feedback collection always succeeds regardless of network conditions.
+/// </summary>
+public sealed class HttpFeedbackTelemetrySink : IFeedbackTelemetrySink
+{
+    private readonly HttpClient _httpClient;
+    private readonly FeedbackOptions _options;
+    private readonly ILogger<HttpFeedbackTelemetrySink> _logger;
+
+    /// <summary>
+    /// Creates a new <see cref="HttpFeedbackTelemetrySink"/>.
+    /// </summary>
+    /// <param name="httpClient">The HTTP client used to transmit telemetry.</param>
+    /// <param name="options">Feedback options supplying the telemetry endpoint.</param>
+    /// <param name="logger">Logger for diagnostic output.</param>
+    public HttpFeedbackTelemetrySink(
+        HttpClient httpClient,
+        FeedbackOptions options,
+        ILogger<HttpFeedbackTelemetrySink> logger)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task SendAsync(CoarsenedOutcome payload, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+
+        if (string.IsNullOrWhiteSpace(_options.TelemetryEndpoint))
+        {
+            return;
+        }
+
+        try
+        {
+            var json = JsonSerializer.Serialize(payload);
+            using var content = new StringContent(json, Encoding.UTF8, "application/json");
+            using var response = await _httpClient
+                .PostAsync(_options.TelemetryEndpoint, content, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Feedback telemetry endpoint returned {StatusCode}; continuing.",
+                    (int)response.StatusCode);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Transmission is best-effort; never fail local collection because of telemetry.
+            _logger.LogWarning(ex, "Failed to transmit coarsened feedback telemetry; continuing.");
+        }
+    }
+}

--- a/Services/Feedback/IFeedbackStore.cs
+++ b/Services/Feedback/IFeedbackStore.cs
@@ -1,0 +1,33 @@
+using CosmosToSqlAssessment.Models;
+
+namespace CosmosToSqlAssessment.Services.Feedback;
+
+/// <summary>
+/// Abstraction over the durable store for anonymized <see cref="MigrationOutcome"/> records
+/// that power the continuous-learning feedback loop. Implementations must never persist any
+/// data beyond what is present on the supplied (already anonymized) outcome.
+/// </summary>
+public interface IFeedbackStore
+{
+    /// <summary>
+    /// A human-readable description of where outcomes are stored (e.g., a file path), suitable
+    /// for display in consent notices.
+    /// </summary>
+    string Location { get; }
+
+    /// <summary>
+    /// Appends a single anonymized outcome to the store.
+    /// </summary>
+    /// <param name="outcome">The anonymized outcome to persist.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>A task that completes when the record has been written.</returns>
+    Task AppendAsync(MigrationOutcome outcome, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Streams all previously recorded outcomes. A missing/empty store yields an empty sequence;
+    /// individual malformed records are skipped rather than aborting the stream.
+    /// </summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>An asynchronous stream of stored outcomes.</returns>
+    IAsyncEnumerable<MigrationOutcome> ReadAllAsync(CancellationToken cancellationToken = default);
+}

--- a/Services/Feedback/IFeedbackTelemetrySink.cs
+++ b/Services/Feedback/IFeedbackTelemetrySink.cs
@@ -1,0 +1,142 @@
+using CosmosToSqlAssessment.Models;
+
+namespace CosmosToSqlAssessment.Services.Feedback;
+
+/// <summary>
+/// A telemetry-safe, <em>coarsened</em> projection of a <see cref="MigrationOutcome"/> intended for
+/// the optional remote telemetry endpoint. Exact aggregate counts and costs are replaced with
+/// bucketed labels to further reduce any re-identification risk when data leaves the local machine.
+/// </summary>
+/// <remarks>
+/// This type intentionally carries only enums and bucketed string labels — never raw counts, sizes,
+/// costs, names, or identifiers.
+/// </remarks>
+public sealed class CoarsenedOutcome
+{
+    /// <summary>The schema version of the originating outcome.</summary>
+    public int SchemaVersion { get; set; } = MigrationOutcome.CurrentSchemaVersion;
+
+    /// <summary>Normalized workload complexity.</summary>
+    public MigrationComplexityRating ComplexityRating { get; set; }
+
+    /// <summary>Coarse workload size band.</summary>
+    public WorkloadSizeBucket SizeBucket { get; set; }
+
+    /// <summary>Bucketed number of source containers.</summary>
+    public string ContainerCountBucket { get; set; } = string.Empty;
+
+    /// <summary>The recommended Azure SQL platform (tool-generated label).</summary>
+    public string RecommendedPlatform { get; set; } = string.Empty;
+
+    /// <summary>The recommended Azure SQL tier (tool-generated label).</summary>
+    public string RecommendedTier { get; set; } = string.Empty;
+
+    /// <summary>The deployed Azure SQL platform (tool-generated label).</summary>
+    public string DeployedPlatform { get; set; } = string.Empty;
+
+    /// <summary>The deployed Azure SQL tier (tool-generated label).</summary>
+    public string DeployedTier { get; set; } = string.Empty;
+
+    /// <summary>The terminal migration status.</summary>
+    public MigrationOutcomeStatus Status { get; set; }
+
+    /// <summary>Whether the deployed sizing performed satisfactorily, if assessed.</summary>
+    public bool? PerformanceSatisfactory { get; set; }
+
+    /// <summary>Bucketed monthly cost variance (estimate accuracy band).</summary>
+    public string MonthlyCostVarianceBucket { get; set; } = string.Empty;
+
+    /// <summary>Bucketed actual migration duration.</summary>
+    public string MigrationDaysBucket { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Projects a full <see cref="MigrationOutcome"/> into its telemetry-safe, coarsened form.
+    /// </summary>
+    /// <param name="outcome">The outcome to coarsen.</param>
+    /// <returns>A bucketed, telemetry-safe projection.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="outcome"/> is null.</exception>
+    public static CoarsenedOutcome From(MigrationOutcome outcome)
+    {
+        ArgumentNullException.ThrowIfNull(outcome);
+        var profile = outcome.Profile ?? new WorkloadProfile();
+
+        return new CoarsenedOutcome
+        {
+            SchemaVersion = outcome.SchemaVersion,
+            ComplexityRating = profile.ComplexityRating,
+            SizeBucket = profile.SizeBucket,
+            ContainerCountBucket = BucketContainerCount(profile.ContainerCount),
+            RecommendedPlatform = profile.RecommendedPlatform,
+            RecommendedTier = profile.RecommendedTier,
+            DeployedPlatform = outcome.DeployedPlatform,
+            DeployedTier = outcome.DeployedTier,
+            Status = outcome.Status,
+            PerformanceSatisfactory = outcome.PerformanceSatisfactory,
+            MonthlyCostVarianceBucket = BucketCostVariance(outcome.MonthlyCostVariancePercent),
+            MigrationDaysBucket = BucketDays(outcome.ActualMigrationDays)
+        };
+    }
+
+    /// <summary>Maps a container count to a coarse band.</summary>
+    /// <param name="count">The exact container count.</param>
+    /// <returns>A bucket label.</returns>
+    public static string BucketContainerCount(int count) => count switch
+    {
+        <= 1 => "1",
+        <= 5 => "2-5",
+        <= 20 => "6-20",
+        <= 100 => "21-100",
+        _ => "100+"
+    };
+
+    /// <summary>Maps a monthly cost variance percentage to an estimate-accuracy band.</summary>
+    /// <param name="variancePercent">The monthly cost variance percent, or null if undefined.</param>
+    /// <returns>A bucket label.</returns>
+    public static string BucketCostVariance(double? variancePercent) => variancePercent switch
+    {
+        null => "Unknown",
+        < -10 => "UnderEstimate",
+        <= 10 => "OnTarget",
+        <= 50 => "OverEstimate",
+        _ => "WellOverEstimate"
+    };
+
+    /// <summary>Maps an actual migration duration in days to a coarse band.</summary>
+    /// <param name="days">The actual migration duration in days.</param>
+    /// <returns>A bucket label.</returns>
+    public static string BucketDays(int days) => days switch
+    {
+        <= 5 => "0-5",
+        <= 15 => "6-15",
+        <= 30 => "16-30",
+        _ => "30+"
+    };
+}
+
+/// <summary>
+/// Optional transport that forwards a <see cref="CoarsenedOutcome"/> to a configured remote
+/// telemetry endpoint. Only invoked when feedback consent is granted <em>and</em> a telemetry
+/// endpoint is configured.
+/// </summary>
+public interface IFeedbackTelemetrySink
+{
+    /// <summary>
+    /// Sends a coarsened outcome to the remote endpoint. Implementations must not throw on
+    /// transport errors (local collection must always succeed regardless).
+    /// </summary>
+    /// <param name="payload">The coarsened, telemetry-safe payload.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>A task that completes when the send attempt finishes.</returns>
+    Task SendAsync(CoarsenedOutcome payload, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// A no-op <see cref="IFeedbackTelemetrySink"/> used when no remote telemetry endpoint is
+/// configured. Nothing leaves the local machine.
+/// </summary>
+public sealed class NullFeedbackTelemetrySink : IFeedbackTelemetrySink
+{
+    /// <inheritdoc />
+    public Task SendAsync(CoarsenedOutcome payload, CancellationToken cancellationToken = default) =>
+        Task.CompletedTask;
+}

--- a/Services/Feedback/LocalJsonFeedbackStore.cs
+++ b/Services/Feedback/LocalJsonFeedbackStore.cs
@@ -1,0 +1,134 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using CosmosToSqlAssessment.Models;
+using Microsoft.Extensions.Logging;
+
+namespace CosmosToSqlAssessment.Services.Feedback;
+
+/// <summary>
+/// A local, append-only, JSON-lines (<c>.jsonl</c>) implementation of <see cref="IFeedbackStore"/>.
+/// Each anonymized <see cref="MigrationOutcome"/> is serialized to a single line. This is the
+/// default, fully-offline storage mechanism for the feedback loop.
+/// </summary>
+/// <remarks>
+/// Writes are serialized with a process-local semaphore and use an append-mode
+/// <see cref="FileStream"/> with <see cref="FileShare.Read"/>; reads open the file with
+/// <see cref="FileShare.ReadWrite"/> and stream line-by-line without buffering the whole file.
+/// Malformed or truncated lines (e.g., from an interrupted write) are skipped and logged
+/// without echoing their raw content.
+/// </remarks>
+public sealed class LocalJsonFeedbackStore : IFeedbackStore
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = false
+    };
+
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+    private readonly ILogger<LocalJsonFeedbackStore> _logger;
+
+    /// <inheritdoc />
+    public string Location { get; }
+
+    /// <summary>
+    /// Creates a new <see cref="LocalJsonFeedbackStore"/>.
+    /// </summary>
+    /// <param name="options">Feedback options; <see cref="FeedbackOptions.StorePath"/> overrides the default path.</param>
+    /// <param name="logger">Logger for diagnostic output.</param>
+    public LocalJsonFeedbackStore(FeedbackOptions options, ILogger<LocalJsonFeedbackStore> logger)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        Location = string.IsNullOrWhiteSpace(options.StorePath) ? GetDefaultPath() : options.StorePath!;
+    }
+
+    /// <summary>
+    /// Computes the default per-user store path under the local application-data folder.
+    /// </summary>
+    /// <returns>The absolute default store path.</returns>
+    public static string GetDefaultPath()
+    {
+        var baseDir = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (string.IsNullOrEmpty(baseDir))
+        {
+            baseDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        }
+
+        return Path.Combine(baseDir, "CosmosToSqlAssessment", "feedback", "migration-outcomes.jsonl");
+    }
+
+    /// <inheritdoc />
+    public async Task AppendAsync(MigrationOutcome outcome, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(outcome);
+
+        var directory = Path.GetDirectoryName(Location);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        // Serialized to a single physical line; JSON encodes any control characters, so the
+        // record can never span multiple lines and corrupt the JSON-lines format.
+        var line = JsonSerializer.Serialize(outcome, SerializerOptions);
+
+        await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await using var stream = new FileStream(
+                Location, FileMode.Append, FileAccess.Write, FileShare.Read);
+            await using var writer = new StreamWriter(stream);
+            await writer.WriteLineAsync(line.AsMemory(), cancellationToken).ConfigureAwait(false);
+            await writer.FlushAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<MigrationOutcome> ReadAllAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(Location))
+        {
+            yield break;
+        }
+
+        await using var stream = new FileStream(
+            Location, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var reader = new StreamReader(stream);
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false);
+            if (line is null)
+            {
+                yield break;
+            }
+
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            MigrationOutcome? outcome = null;
+            try
+            {
+                outcome = JsonSerializer.Deserialize<MigrationOutcome>(line, SerializerOptions);
+            }
+            catch (JsonException)
+            {
+                _logger.LogWarning("Skipping a malformed feedback record in {Location}.", Location);
+            }
+
+            if (outcome is not null)
+            {
+                yield return outcome;
+            }
+        }
+    }
+}

--- a/Services/FeedbackCollectionService.cs
+++ b/Services/FeedbackCollectionService.cs
@@ -1,0 +1,268 @@
+using CosmosToSqlAssessment.Models;
+using CosmosToSqlAssessment.Services.Feedback;
+using Microsoft.Extensions.Logging;
+
+namespace CosmosToSqlAssessment.Services;
+
+/// <summary>
+/// Strongly-typed configuration for the continuous-learning feedback loop, bound from the
+/// <c>FeedbackLoop</c> configuration section. Feedback is <b>off by default</b>.
+/// </summary>
+public sealed class FeedbackOptions
+{
+    /// <summary>The configuration section name these options bind from.</summary>
+    public const string SectionName = "FeedbackLoop";
+
+    /// <summary>
+    /// Environment variable that, when set to <c>1</c>/<c>true</c>, unconditionally disables
+    /// feedback collection (an absolute opt-out, mirroring <c>DOTNET_CLI_TELEMETRY_OPTOUT</c>).
+    /// </summary>
+    public const string OptOutEnvironmentVariable = "COSMOS2SQL_FEEDBACK_OPTOUT";
+
+    /// <summary>
+    /// Environment variable that, when set to <c>1</c>/<c>true</c>, opts in to feedback collection
+    /// — but only when neither the command line nor configuration has expressed a preference.
+    /// </summary>
+    public const string OptInEnvironmentVariable = "COSMOS2SQL_FEEDBACK_OPTIN";
+
+    /// <summary>
+    /// Whether feedback collection is enabled via configuration. <see langword="null"/> means
+    /// "not configured" (so lower-precedence sources decide); the effective default is disabled.
+    /// </summary>
+    public bool? Enabled { get; set; }
+
+    /// <summary>
+    /// Optional override for the local outcome store path. When null/empty the per-user default
+    /// (<see cref="LocalJsonFeedbackStore.GetDefaultPath"/>) is used.
+    /// </summary>
+    public string? StorePath { get; set; }
+
+    /// <summary>
+    /// Optional remote telemetry endpoint. When set (and consent is granted), a coarsened payload
+    /// is POSTed to this URL in addition to the local record. When null/empty, nothing ever leaves
+    /// the local machine.
+    /// </summary>
+    public string? TelemetryEndpoint { get; set; }
+}
+
+/// <summary>
+/// Identifies which input decided the effective feedback consent, for transparent diagnostics.
+/// </summary>
+public enum FeedbackConsentSource
+{
+    /// <summary>No source expressed a preference; the privacy-preserving default (disabled) applies.</summary>
+    Default = 0,
+
+    /// <summary>Consent was decided by the <c>FeedbackLoop:Enabled</c> configuration value.</summary>
+    Configuration = 1,
+
+    /// <summary>Consent was granted by the opt-in environment variable.</summary>
+    EnvironmentOptIn = 2,
+
+    /// <summary>Consent was denied by the absolute opt-out environment variable.</summary>
+    EnvironmentOptOut = 3,
+
+    /// <summary>Consent was decided by an explicit command-line flag.</summary>
+    CommandLine = 4
+}
+
+/// <summary>
+/// The resolved feedback consent decision and the source that determined it.
+/// </summary>
+public sealed class FeedbackConsent
+{
+    /// <summary>Whether feedback collection (and any transmission) is permitted.</summary>
+    public bool IsGranted { get; }
+
+    /// <summary>The input that determined <see cref="IsGranted"/>.</summary>
+    public FeedbackConsentSource Source { get; }
+
+    /// <summary>
+    /// Creates a new <see cref="FeedbackConsent"/>.
+    /// </summary>
+    /// <param name="isGranted">Whether consent is granted.</param>
+    /// <param name="source">The deciding source.</param>
+    public FeedbackConsent(bool isGranted, FeedbackConsentSource source)
+    {
+        IsGranted = isGranted;
+        Source = source;
+    }
+
+    /// <summary>
+    /// Resolves the effective consent from all inputs using a privacy-first precedence:
+    /// environment opt-out (absolute) → command-line flag → explicit configuration → environment
+    /// opt-in → default (disabled). Environment opt-in only applies when configuration is silent.
+    /// </summary>
+    /// <param name="commandLineOptIn">Explicit CLI preference, or null when no flag was supplied.</param>
+    /// <param name="configEnabled">Explicit configuration preference, or null when not configured.</param>
+    /// <param name="envOptOut">Whether the absolute opt-out environment variable is set.</param>
+    /// <param name="envOptIn">Whether the opt-in environment variable is set.</param>
+    /// <returns>The resolved consent decision.</returns>
+    public static FeedbackConsent Resolve(bool? commandLineOptIn, bool? configEnabled, bool envOptOut, bool envOptIn)
+    {
+        if (envOptOut)
+        {
+            return new FeedbackConsent(false, FeedbackConsentSource.EnvironmentOptOut);
+        }
+
+        if (commandLineOptIn.HasValue)
+        {
+            return new FeedbackConsent(commandLineOptIn.Value, FeedbackConsentSource.CommandLine);
+        }
+
+        if (configEnabled.HasValue)
+        {
+            return new FeedbackConsent(configEnabled.Value, FeedbackConsentSource.Configuration);
+        }
+
+        if (envOptIn)
+        {
+            return new FeedbackConsent(true, FeedbackConsentSource.EnvironmentOptIn);
+        }
+
+        return new FeedbackConsent(false, FeedbackConsentSource.Default);
+    }
+}
+
+/// <summary>
+/// Coordinates the <b>opt-in</b> collection of anonymized migration outcomes. Collection and any
+/// remote transmission are gated behind an explicit consent decision that defaults to disabled.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Consent gates <em>writing</em> new outcomes and any telemetry transmission. Reading previously
+/// stored local outcomes (<see cref="GetOutcomesAsync"/>) is not gated: it is the user's own,
+/// already-stored, local data used to refine the user's own recommendations. To purge it, delete
+/// the file at <see cref="StoreLocation"/>.
+/// </para>
+/// </remarks>
+public sealed class FeedbackCollectionService
+{
+    private readonly IFeedbackStore _store;
+    private readonly IFeedbackTelemetrySink _telemetrySink;
+    private readonly FeedbackOptions _options;
+    private readonly ILogger<FeedbackCollectionService> _logger;
+
+    /// <summary>
+    /// Creates a new <see cref="FeedbackCollectionService"/>.
+    /// </summary>
+    /// <param name="store">The local outcome store.</param>
+    /// <param name="telemetrySink">The optional remote telemetry sink.</param>
+    /// <param name="options">The feedback options.</param>
+    /// <param name="logger">Logger for diagnostic output.</param>
+    public FeedbackCollectionService(
+        IFeedbackStore store,
+        IFeedbackTelemetrySink telemetrySink,
+        FeedbackOptions options,
+        ILogger<FeedbackCollectionService> logger)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _telemetrySink = telemetrySink ?? throw new ArgumentNullException(nameof(telemetrySink));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>The location where outcomes are stored (for display in consent notices).</summary>
+    public string StoreLocation => _store.Location;
+
+    /// <summary>Whether a remote telemetry endpoint is configured.</summary>
+    public bool HasTelemetryEndpoint => !string.IsNullOrWhiteSpace(_options.TelemetryEndpoint);
+
+    /// <summary>
+    /// Resolves the effective feedback consent, combining the optional command-line preference with
+    /// configuration and environment variables.
+    /// </summary>
+    /// <param name="commandLineOptIn">Explicit CLI preference, or null when no flag was supplied.</param>
+    /// <returns>The resolved consent decision.</returns>
+    public FeedbackConsent ResolveConsent(bool? commandLineOptIn = null)
+    {
+        var envOptOut = IsEnvironmentFlagSet(FeedbackOptions.OptOutEnvironmentVariable);
+        var envOptIn = IsEnvironmentFlagSet(FeedbackOptions.OptInEnvironmentVariable);
+        return FeedbackConsent.Resolve(commandLineOptIn, _options.Enabled, envOptOut, envOptIn);
+    }
+
+    /// <summary>
+    /// Records an anonymized migration outcome, but only when consent is granted. When disabled,
+    /// this is a no-op that returns <see langword="false"/> and persists nothing.
+    /// </summary>
+    /// <param name="outcome">The anonymized outcome to record.</param>
+    /// <param name="commandLineOptIn">Explicit CLI preference, or null when no flag was supplied.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns><see langword="true"/> if the outcome was recorded; otherwise <see langword="false"/>.</returns>
+    public async Task<bool> RecordOutcomeAsync(
+        MigrationOutcome outcome,
+        bool? commandLineOptIn = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(outcome);
+
+        var consent = ResolveConsent(commandLineOptIn);
+        if (!consent.IsGranted)
+        {
+            _logger.LogInformation(
+                "Feedback collection is disabled (consent source: {Source}); outcome not recorded.",
+                consent.Source);
+            return false;
+        }
+
+        await _store.AppendAsync(outcome, cancellationToken).ConfigureAwait(false);
+        _logger.LogInformation("Recorded an anonymized migration outcome to {Location}.", _store.Location);
+
+        if (HasTelemetryEndpoint)
+        {
+            var coarsened = CoarsenedOutcome.From(outcome);
+            await _telemetrySink.SendAsync(coarsened, cancellationToken).ConfigureAwait(false);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Streams previously recorded local outcomes (the user's own data) for use in recommendation
+    /// refinement. Not gated on consent; see the class remarks.
+    /// </summary>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>An asynchronous stream of stored outcomes.</returns>
+    public IAsyncEnumerable<MigrationOutcome> GetOutcomesAsync(CancellationToken cancellationToken = default) =>
+        _store.ReadAllAsync(cancellationToken);
+
+    /// <summary>
+    /// Writes a transparent consent notice describing exactly what is and isn't collected, where it
+    /// is stored, and how to opt out.
+    /// </summary>
+    /// <param name="output">The writer to emit the notice to.</param>
+    /// <param name="consent">The resolved consent decision to describe.</param>
+    public void WriteConsentNotice(TextWriter output, FeedbackConsent consent)
+    {
+        ArgumentNullException.ThrowIfNull(output);
+        ArgumentNullException.ThrowIfNull(consent);
+
+        output.WriteLine();
+        output.WriteLine("🔒 Continuous-learning feedback");
+        if (consent.IsGranted)
+        {
+            output.WriteLine($"   • Status: ENABLED (source: {consent.Source})");
+            output.WriteLine($"   • Stored locally at: {StoreLocation}");
+            output.WriteLine(HasTelemetryEndpoint
+                ? "   • A coarsened (bucketed) summary is also sent to the configured telemetry endpoint."
+                : "   • Data stays on this machine (no telemetry endpoint configured).");
+            output.WriteLine("   • Collected: anonymized, aggregate metrics only (sizes, counts, complexity,");
+            output.WriteLine("     recommended/deployed platform & tier, success/cost/performance outcomes).");
+            output.WriteLine("   • NOT collected: account/database/container names, documents, credentials, or any PII.");
+            output.WriteLine($"   • Opt out anytime: set {FeedbackOptions.OptOutEnvironmentVariable}=1 or pass --disable-feedback.");
+        }
+        else
+        {
+            output.WriteLine($"   • Status: DISABLED (source: {consent.Source}) — nothing is collected.");
+            output.WriteLine("   • Opt in with --enable-feedback or FeedbackLoop:Enabled=true to help improve recommendations.");
+        }
+        output.WriteLine();
+    }
+
+    private static bool IsEnvironmentFlagSet(string name)
+    {
+        var value = Environment.GetEnvironmentVariable(name);
+        return value is not null &&
+               (value == "1" || value.Equals("true", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/Services/RecommendationRefinementService.cs
+++ b/Services/RecommendationRefinementService.cs
@@ -1,0 +1,475 @@
+using CosmosToSqlAssessment.Models;
+
+namespace CosmosToSqlAssessment.Services;
+
+/// <summary>
+/// Computes a bounded similarity score between two anonymized <see cref="WorkloadProfile"/>
+/// fingerprints. The score weights normalized workload complexity and size most heavily, with
+/// smaller contributions from container count and provisioned throughput.
+/// </summary>
+public static class WorkloadSimilarity
+{
+    /// <summary>
+    /// The minimum <see cref="Score"/> at which two workloads are considered comparable for the
+    /// purpose of recommendation refinement.
+    /// </summary>
+    public const double DefaultThreshold = 0.6;
+
+    private const double ComplexityWeight = 0.35;
+    private const double SizeWeight = 0.35;
+    private const double ContainerWeight = 0.15;
+    private const double ThroughputWeight = 0.15;
+
+    /// <summary>
+    /// Computes a similarity score in the range [0, 1] between two workload profiles, where 1 is
+    /// identical along every weighted dimension.
+    /// </summary>
+    /// <param name="a">The first workload profile.</param>
+    /// <param name="b">The second workload profile.</param>
+    /// <returns>A similarity score between 0 and 1.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when either profile is null.</exception>
+    public static double Score(WorkloadProfile a, WorkloadProfile b)
+    {
+        ArgumentNullException.ThrowIfNull(a);
+        ArgumentNullException.ThrowIfNull(b);
+
+        var complexity = ComplexityCloseness(a.ComplexityRating, b.ComplexityRating);
+        var size = OrdinalCloseness((int)a.SizeBucket, (int)b.SizeBucket);
+        var containers = CountCloseness(a.ContainerCount, b.ContainerCount, treatZeroAsUnknown: false);
+        var throughput = CountCloseness(a.MaxProvisionedRUs, b.MaxProvisionedRUs, treatZeroAsUnknown: true);
+
+        return (ComplexityWeight * complexity)
+            + (SizeWeight * size)
+            + (ContainerWeight * containers)
+            + (ThroughputWeight * throughput);
+    }
+
+    /// <summary>
+    /// Determines whether two workload profiles are comparable at the given threshold.
+    /// </summary>
+    /// <param name="a">The first workload profile.</param>
+    /// <param name="b">The second workload profile.</param>
+    /// <param name="threshold">The minimum score for comparability (defaults to <see cref="DefaultThreshold"/>).</param>
+    /// <returns><see langword="true"/> when the profiles are comparable; otherwise <see langword="false"/>.</returns>
+    public static bool AreComparable(WorkloadProfile a, WorkloadProfile b, double threshold = DefaultThreshold) =>
+        Score(a, b) >= threshold;
+
+    private static double ComplexityCloseness(MigrationComplexityRating a, MigrationComplexityRating b)
+    {
+        // An unknown rating carries no signal, so treat it as neutral rather than dissimilar.
+        if (a == MigrationComplexityRating.Unknown || b == MigrationComplexityRating.Unknown)
+        {
+            return 0.5;
+        }
+
+        return OrdinalCloseness((int)a, (int)b);
+    }
+
+    private static double OrdinalCloseness(int a, int b)
+    {
+        var diff = Math.Abs(a - b);
+        return diff switch
+        {
+            0 => 1.0,
+            1 => 0.5,
+            _ => 0.0
+        };
+    }
+
+    private static double CountCloseness(long a, long b, bool treatZeroAsUnknown)
+    {
+        if (a == b)
+        {
+            return 1.0;
+        }
+
+        if (a == 0 || b == 0)
+        {
+            // Zero may mean "unknown" (e.g., serverless throughput) — stay neutral instead of
+            // penalizing — or, for a genuine count, a real mismatch.
+            return treatZeroAsUnknown ? 0.5 : 0.0;
+        }
+
+        var min = Math.Min(a, b);
+        var max = Math.Max(a, b);
+        return (double)min / max;
+    }
+}
+
+/// <summary>
+/// A single labeled scenario used to evaluate refinement accuracy: an assessment, the prior
+/// migration history available at the time, and the ground-truth configuration that is known to
+/// perform satisfactorily for that workload.
+/// </summary>
+public sealed class RefinementScenario
+{
+    /// <summary>
+    /// Creates a new <see cref="RefinementScenario"/>.
+    /// </summary>
+    /// <param name="assessment">The assessment whose baseline recommendation is being evaluated.</param>
+    /// <param name="history">The prior migration outcomes available when refining.</param>
+    /// <param name="expectedPlatform">The ground-truth satisfactory platform for this workload.</param>
+    /// <param name="expectedTier">The ground-truth satisfactory tier for this workload.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="assessment"/> or <paramref name="history"/> is null.</exception>
+    public RefinementScenario(
+        AssessmentResult assessment,
+        IReadOnlyList<MigrationOutcome> history,
+        string expectedPlatform,
+        string expectedTier)
+    {
+        Assessment = assessment ?? throw new ArgumentNullException(nameof(assessment));
+        History = history ?? throw new ArgumentNullException(nameof(history));
+        ExpectedPlatform = expectedPlatform ?? string.Empty;
+        ExpectedTier = expectedTier ?? string.Empty;
+    }
+
+    /// <summary>The assessment whose recommendation is being evaluated.</summary>
+    public AssessmentResult Assessment { get; }
+
+    /// <summary>The prior migration outcomes available when refining.</summary>
+    public IReadOnlyList<MigrationOutcome> History { get; }
+
+    /// <summary>The ground-truth satisfactory platform for this workload.</summary>
+    public string ExpectedPlatform { get; }
+
+    /// <summary>The ground-truth satisfactory tier for this workload.</summary>
+    public string ExpectedTier { get; }
+}
+
+/// <summary>
+/// The aggregate result of an A/B comparison between the static baseline recommendation and the
+/// learning-refined recommendation across a labeled set of <see cref="RefinementScenario"/>s.
+/// Correctness is measured on the full <c>(platform, tier)</c> pair.
+/// </summary>
+public sealed class RefinementAbComparison
+{
+    /// <summary>Creates a new <see cref="RefinementAbComparison"/>.</summary>
+    /// <param name="scenarioCount">The total number of scenarios evaluated.</param>
+    /// <param name="baselineCorrect">The number of scenarios the baseline recommendation got right.</param>
+    /// <param name="refinedCorrect">The number of scenarios the refined recommendation got right.</param>
+    /// <param name="baselineTierOnlyCorrect">Secondary diagnostic: baseline correct on tier alone.</param>
+    /// <param name="refinedTierOnlyCorrect">Secondary diagnostic: refined correct on tier alone.</param>
+    public RefinementAbComparison(
+        int scenarioCount,
+        int baselineCorrect,
+        int refinedCorrect,
+        int baselineTierOnlyCorrect,
+        int refinedTierOnlyCorrect)
+    {
+        ScenarioCount = scenarioCount;
+        BaselineCorrect = baselineCorrect;
+        RefinedCorrect = refinedCorrect;
+        BaselineTierOnlyCorrect = baselineTierOnlyCorrect;
+        RefinedTierOnlyCorrect = refinedTierOnlyCorrect;
+    }
+
+    /// <summary>The total number of scenarios evaluated.</summary>
+    public int ScenarioCount { get; }
+
+    /// <summary>The number of scenarios the baseline got right on the full (platform, tier) pair.</summary>
+    public int BaselineCorrect { get; }
+
+    /// <summary>The number of scenarios the refined recommendation got right on the full (platform, tier) pair.</summary>
+    public int RefinedCorrect { get; }
+
+    /// <summary>Secondary diagnostic: baseline scenarios correct on tier alone.</summary>
+    public int BaselineTierOnlyCorrect { get; }
+
+    /// <summary>Secondary diagnostic: refined scenarios correct on tier alone.</summary>
+    public int RefinedTierOnlyCorrect { get; }
+
+    /// <summary>The fraction (0–1) of scenarios the baseline got right on the full pair.</summary>
+    public double BaselineAccuracy => ScenarioCount == 0 ? 0.0 : (double)BaselineCorrect / ScenarioCount;
+
+    /// <summary>The fraction (0–1) of scenarios the refined recommendation got right on the full pair.</summary>
+    public double RefinedAccuracy => ScenarioCount == 0 ? 0.0 : (double)RefinedCorrect / ScenarioCount;
+
+    /// <summary>Whether the refined recommendation is strictly more accurate than the baseline.</summary>
+    public bool RefinedImprovesOverBaseline => RefinedAccuracy > BaselineAccuracy;
+}
+
+/// <summary>
+/// Correlates the current assessment with prior, anonymized <see cref="MigrationOutcome"/>s to
+/// refine (or confirm) the recommended Azure SQL platform and tier, producing an attributable
+/// <see cref="RecommendationRefinement"/>.
+/// </summary>
+/// <remarks>
+/// The core <see cref="Refine(AssessmentResult, IReadOnlyList{MigrationOutcome})"/> is pure and
+/// deterministic. Candidate configurations are ranked by the Wilson lower bound of their observed
+/// satisfaction rate so that small samples cannot outrank larger, consistently-satisfactory ones,
+/// and ties deterministically favor the baseline to avoid unnecessary churn.
+/// </remarks>
+public sealed class RecommendationRefinementService
+{
+    /// <summary>The minimum number of comparable prior migrations required to attempt refinement.</summary>
+    public const int MinimumSimilarSamples = 3;
+
+    /// <summary>The minimum number of samples a single configuration needs to be eligible as the refined choice.</summary>
+    public const int MinimumCandidateSamples = 3;
+
+    // z for a 95% confidence interval, used by the Wilson lower-bound ranking.
+    private const double WilsonZ = 1.96;
+
+    private readonly FeedbackCollectionService _feedback;
+
+    /// <summary>
+    /// Creates a new <see cref="RecommendationRefinementService"/>.
+    /// </summary>
+    /// <param name="feedback">The feedback service used to read prior local outcomes.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="feedback"/> is null.</exception>
+    public RecommendationRefinementService(FeedbackCollectionService feedback)
+    {
+        _feedback = feedback ?? throw new ArgumentNullException(nameof(feedback));
+    }
+
+    /// <summary>
+    /// Refines the assessment's recommendation using prior outcomes read from the local feedback
+    /// store. Reading is not consent-gated (it is the user's own data); see
+    /// <see cref="FeedbackCollectionService"/>.
+    /// </summary>
+    /// <param name="assessment">The assessment to refine.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation.</param>
+    /// <returns>The refinement result (which may defer to the baseline).</returns>
+    public async Task<RecommendationRefinement> RefineAsync(
+        AssessmentResult assessment,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(assessment);
+
+        var prior = new List<MigrationOutcome>();
+        await foreach (var outcome in _feedback.GetOutcomesAsync(cancellationToken).ConfigureAwait(false))
+        {
+            prior.Add(outcome);
+        }
+
+        return Refine(assessment, prior);
+    }
+
+    /// <summary>
+    /// Refines the assessment's recommendation against an explicit set of prior outcomes. Pure and
+    /// deterministic — identical inputs always yield an identical result.
+    /// </summary>
+    /// <param name="assessment">The assessment to refine.</param>
+    /// <param name="prior">The prior migration outcomes to learn from.</param>
+    /// <returns>The refinement result (which may defer to or confirm the baseline).</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="assessment"/> or <paramref name="prior"/> is null.</exception>
+    public RecommendationRefinement Refine(AssessmentResult assessment, IReadOnlyList<MigrationOutcome> prior)
+    {
+        ArgumentNullException.ThrowIfNull(assessment);
+        ArgumentNullException.ThrowIfNull(prior);
+
+        var sql = assessment.SqlAssessment ?? new SqlMigrationAssessment();
+        var baselinePlatform = sql.RecommendedPlatform ?? string.Empty;
+        var baselineTier = sql.RecommendedTier ?? string.Empty;
+
+        var current = WorkloadProfile.FromAssessment(assessment);
+
+        // Comparable history: similar, successful, and with a known performance signal to learn from.
+        var similar = prior
+            .Where(o => o is { Succeeded: true, Profile: not null }
+                        && o.PerformanceSatisfactory.HasValue
+                        && WorkloadSimilarity.AreComparable(current, o.Profile))
+            .ToList();
+
+        if (similar.Count < MinimumSimilarSamples)
+        {
+            var reason = prior.Count == 0
+                ? "No prior migration outcomes are available yet; using the baseline recommendation."
+                : $"Only {similar.Count} comparable prior migration(s) found (need at least {MinimumSimilarSamples}); using the baseline recommendation.";
+            return RecommendationRefinement.None(baselinePlatform, baselineTier, similar.Count, reason);
+        }
+
+        var candidates = similar
+            .GroupBy(o => new ConfigKey(o.DeployedPlatform ?? string.Empty, o.DeployedTier ?? string.Empty))
+            .Select(g => BuildCandidate(g.Key, g.ToList(), baselinePlatform, baselineTier))
+            .Where(c => c.Count >= MinimumCandidateSamples)
+            .ToList();
+
+        if (candidates.Count == 0)
+        {
+            var reason = $"Found {similar.Count} comparable migration(s), but no single deployed configuration had at least {MinimumCandidateSamples} samples; using the baseline recommendation.";
+            return RecommendationRefinement.None(baselinePlatform, baselineTier, similar.Count, reason);
+        }
+
+        // Rank by Wilson lower bound (penalizes small samples), then prefer the baseline on a tie,
+        // then larger samples, then a stable ordinal ordering for full determinism.
+        var best = candidates
+            .OrderByDescending(c => c.WilsonScore)
+            .ThenByDescending(c => c.IsBaseline)
+            .ThenByDescending(c => c.Count)
+            .ThenBy(c => c.Platform, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(c => c.Tier, StringComparer.OrdinalIgnoreCase)
+            .First();
+
+        var changed = !ConfigEquals(best.Platform, best.Tier, baselinePlatform, baselineTier);
+        var confidence = DetermineConfidence(best.Count, best.SatisfactionRate);
+
+        return new RecommendationRefinement
+        {
+            HasRefinement = true,
+            PriorSimilarMigrationCount = similar.Count,
+            BaselinePlatform = baselinePlatform,
+            BaselineTier = baselineTier,
+            RefinedPlatform = best.Platform,
+            RefinedTier = best.Tier,
+            ChangedFromBaseline = changed,
+            Confidence = confidence,
+            ObservedSatisfactionRate = best.SatisfactionRate,
+            AverageMonthlyCostVariancePercent = best.AverageCostVariancePercent,
+            Rationale = BuildRationale(best, similar.Count, changed, baselinePlatform, baselineTier)
+        };
+    }
+
+    /// <summary>
+    /// Evaluates an A/B comparison of baseline vs refined recommendation accuracy across a labeled
+    /// set of scenarios. Correctness is measured on the full <c>(platform, tier)</c> pair.
+    /// </summary>
+    /// <param name="scenarios">The labeled scenarios to evaluate (must be non-empty).</param>
+    /// <returns>The aggregate comparison.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="scenarios"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="scenarios"/> is empty.</exception>
+    public RefinementAbComparison EvaluateAccuracy(IEnumerable<RefinementScenario> scenarios)
+    {
+        ArgumentNullException.ThrowIfNull(scenarios);
+
+        var list = scenarios.ToList();
+        if (list.Count == 0)
+        {
+            throw new ArgumentException("At least one scenario is required to evaluate accuracy.", nameof(scenarios));
+        }
+
+        int baselineCorrect = 0, refinedCorrect = 0, baselineTierOnly = 0, refinedTierOnly = 0;
+
+        foreach (var scenario in list)
+        {
+            var sql = scenario.Assessment.SqlAssessment ?? new SqlMigrationAssessment();
+            var refinement = Refine(scenario.Assessment, scenario.History);
+
+            if (ConfigEquals(sql.RecommendedPlatform, sql.RecommendedTier, scenario.ExpectedPlatform, scenario.ExpectedTier))
+            {
+                baselineCorrect++;
+            }
+
+            if (ConfigEquals(refinement.RefinedPlatform, refinement.RefinedTier, scenario.ExpectedPlatform, scenario.ExpectedTier))
+            {
+                refinedCorrect++;
+            }
+
+            if (string.Equals(sql.RecommendedTier ?? string.Empty, scenario.ExpectedTier, StringComparison.OrdinalIgnoreCase))
+            {
+                baselineTierOnly++;
+            }
+
+            if (string.Equals(refinement.RefinedTier, scenario.ExpectedTier, StringComparison.OrdinalIgnoreCase))
+            {
+                refinedTierOnly++;
+            }
+        }
+
+        return new RefinementAbComparison(list.Count, baselineCorrect, refinedCorrect, baselineTierOnly, refinedTierOnly);
+    }
+
+    private Candidate BuildCandidate(ConfigKey key, IReadOnlyList<MigrationOutcome> outcomes, string baselinePlatform, string baselineTier)
+    {
+        var satisfied = outcomes.Count(o => o.PerformanceSatisfactory == true);
+        var satisfactionRate = (double)satisfied / outcomes.Count;
+
+        var variances = outcomes
+            .Select(o => o.MonthlyCostVariancePercent)
+            .Where(v => v.HasValue)
+            .Select(v => v!.Value)
+            .ToList();
+        double? avgVariance = variances.Count > 0 ? variances.Average() : null;
+
+        return new Candidate(
+            key.Platform,
+            key.Tier,
+            outcomes.Count,
+            satisfied,
+            satisfactionRate,
+            WilsonLowerBound(satisfied, outcomes.Count),
+            avgVariance,
+            ConfigEquals(key.Platform, key.Tier, baselinePlatform, baselineTier));
+    }
+
+    private static RefinementConfidence DetermineConfidence(int count, double satisfactionRate)
+    {
+        if (count >= 8 && satisfactionRate >= 0.8)
+        {
+            return RefinementConfidence.High;
+        }
+
+        if (count >= 5 && satisfactionRate >= 0.6)
+        {
+            return RefinementConfidence.Medium;
+        }
+
+        return RefinementConfidence.Low;
+    }
+
+    private static string BuildRationale(Candidate best, int similarCount, bool changed, string baselinePlatform, string baselineTier)
+    {
+        var config = DescribeConfig(best.Platform, best.Tier);
+        var satisfactionText = $"{best.SatisfactionRate:P0}";
+        var lead = changed
+            ? $"Based on {similarCount} prior similar migration(s), {config} met performance expectations {satisfactionText} of the time, refining the baseline recommendation of {DescribeConfig(baselinePlatform, baselineTier)}."
+            : $"Based on {similarCount} prior similar migration(s), prior outcomes support the baseline recommendation of {config}, which met performance expectations {satisfactionText} of the time.";
+
+        if (best.AverageCostVariancePercent is { } variance)
+        {
+            var direction = variance > 0 ? "above" : "below";
+            lead += $" On average, actual monthly cost ran {Math.Abs(variance):0.#}% {direction} estimate for these migrations.";
+        }
+
+        return lead;
+    }
+
+    private static string DescribeConfig(string platform, string tier)
+    {
+        var hasPlatform = !string.IsNullOrWhiteSpace(platform);
+        var hasTier = !string.IsNullOrWhiteSpace(tier);
+        if (hasPlatform && hasTier)
+        {
+            return $"{platform} ({tier})";
+        }
+
+        if (hasPlatform)
+        {
+            return platform;
+        }
+
+        return hasTier ? tier : "the deployed configuration";
+    }
+
+    private static bool ConfigEquals(string? platformA, string? tierA, string? platformB, string? tierB) =>
+        string.Equals(platformA ?? string.Empty, platformB ?? string.Empty, StringComparison.OrdinalIgnoreCase)
+        && string.Equals(tierA ?? string.Empty, tierB ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+
+    private static double WilsonLowerBound(int positives, int total)
+    {
+        if (total == 0)
+        {
+            return 0.0;
+        }
+
+        var n = (double)total;
+        var phat = positives / n;
+        var z = WilsonZ;
+        var denominator = 1 + (z * z / n);
+        var centre = phat + (z * z / (2 * n));
+        var margin = z * Math.Sqrt((phat * (1 - phat) + (z * z / (4 * n))) / n);
+        return (centre - margin) / denominator;
+    }
+
+    private readonly record struct ConfigKey(string Platform, string Tier);
+
+    private sealed record Candidate(
+        string Platform,
+        string Tier,
+        int Count,
+        int Satisfied,
+        double SatisfactionRate,
+        double WilsonScore,
+        double? AverageCostVariancePercent,
+        bool IsBaseline);
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ The application follows enterprise-grade patterns with:
 - **[Configuration Guide](configuration.md)** - Detailed configuration options
 - **[Usage Guide](usage.md)** - How to run assessments and interpret results
 - **[Real-Time Monitoring and Alerting](monitoring.md)** - Stream migration progress metrics, generate alert-rule ARM templates, the `migration status` CLI, and RU/throughput anomaly detection (parent #133)
+- **[Continuous-Learning Feedback Loop](feedback-loop.md)** - Opt‑in privacy guide: what is/isn't collected, consent, opt in/out, and how refined recommendations are attributed (parent #132)
 - **[SQL Project Generation](sql-project-generation.md)** - Generate SQL Database Projects from assessments
 - **[Transformation Logic](transformation-logic.md)** - Data transformation stored procedures and implementation
 - **[Architecture Overview](architecture.md)** - Technical architecture and design patterns

--- a/docs/feedback-loop.md
+++ b/docs/feedback-loop.md
@@ -1,0 +1,231 @@
+# Continuous-Learning Feedback Loop — Privacy & Opt‑In Guide
+
+The assessment tool can **optionally** learn from the outcomes of past migrations to refine
+future recommendations. When enabled, it records **anonymized, aggregate** metrics about a
+completed migration, correlates them with the original assessment inputs, and surfaces a
+*"based on N prior similar migrations"* rationale in the generated reports.
+
+This document is the authoritative privacy statement for that feature: what is and is not
+collected, how consent works, how to opt in and out, where data lives, and how to delete it.
+
+---
+
+## TL;DR
+
+- **Off by default.** Nothing is collected unless you explicitly opt in.
+- **No PII, no customer data.** No account/database/container names, no documents, no
+  credentials, no endpoints, no connection strings, no free‑text — by construction.
+- **Local first.** Data is stored only on your machine unless you deliberately configure a
+  remote telemetry endpoint.
+- **You stay in control.** Opt out at any time; delete the local file at any time.
+
+---
+
+## Privacy by design
+
+The feedback schema is designed so that leaking identifying information is *structurally*
+impossible, not merely discouraged:
+
+- **Data minimization.** Only the aggregate signals needed to compare workloads and learn from
+  outcomes are recorded (sizes, counts, complexity, recommended/deployed platform & tier,
+  and success/cost/performance outcomes).
+- **No free‑text fields.** Every string property is constrained to a fixed, tool‑generated
+  value set (e.g. `"Azure SQL Database"`, `"General Purpose"`). There is no place to put a
+  name, comment, or identifier — and a reflection‑based unit test enforces that no
+  unapproved string field is ever added to the schema.
+- **Categorical / bucketed values.** Where exact numbers could be sensitive, the optional
+  telemetry payload is *coarsened* into buckets (see below).
+- **Non‑correlatable record id.** Each record carries a fresh random `OutcomeId` (a GUID) that
+  is not derived from, and cannot be linked back to, any account, tenant, or user.
+
+---
+
+## What **is** collected
+
+When you opt in and record a migration outcome, the local record (`MigrationOutcome`) contains
+only the following anonymized, aggregate fields:
+
+| Category | Fields | Example |
+| --- | --- | --- |
+| **Schema / record** | `SchemaVersion`, `OutcomeId` (random GUID), `RecordedAtUtc` | `1`, `a1b2…`, `2026-01-01T00:00:00Z` |
+| **Workload profile** (similarity fingerprint) | `ComplexityRating`, `ContainerCount`, `SizeBucket`, `TotalDocumentCount`, `TotalDataSizeGb`, `MaxProvisionedRUs`, `IndexRecommendationCount`, `RecommendedPlatform`, `RecommendedTier` | `Medium`, `3`, `Medium`, `500000`, `4.7`, `4000`, `5`, `Azure SQL Database`, `General Purpose` |
+| **Success** | `Status`, `ActualMigrationDays`, `DataCompletenessPercent` | `Succeeded`, `4`, `100` |
+| **Performance** | `DeployedPlatform`, `DeployedTier`, `AvgResourceUtilizationPercent`, `PeakResourceUtilizationPercent`, `AvgQueryLatencyMs`, `PerformanceSatisfactory` | `Azure SQL Database`, `General Purpose`, `42`, `78`, `12`, `true` |
+| **Cost (actual vs estimate)** | `EstimatedMonthlyCostUsd`, `ActualMonthlyCostUsd`, `EstimatedMigrationCostUsd`, `ActualMigrationCostUsd` | `1200`, `1100`, `5000`, `5200` |
+
+All platform/tier strings come from the tool's own recommendation value set; the rating/status
+fields are enums.
+
+### Optional remote telemetry (coarsened)
+
+If — and only if — you configure a `FeedbackLoop:TelemetryEndpoint`, an additional **coarsened**
+summary (`CoarsenedOutcome`) is POSTed there alongside the local write. It is *more* aggregated
+than the local record: exact counts and dollar amounts are replaced with **buckets**.
+
+| Field | What it is |
+| --- | --- |
+| `SchemaVersion` | Schema version integer |
+| `ComplexityRating`, `SizeBucket` | Workload complexity & size bucket |
+| `ContainerCountBucket` | Bucketed container count (a range, not an exact number) |
+| `RecommendedPlatform` / `RecommendedTier` | Tool‑generated labels |
+| `DeployedPlatform` / `DeployedTier` | Tool‑generated labels |
+| `Status`, `PerformanceSatisfactory` | Outcome status and a boolean |
+| `MonthlyCostVarianceBucket` | Bucketed cost variance (a range, not a dollar amount) |
+| `MigrationDaysBucket` | Bucketed migration duration (a range) |
+
+No telemetry endpoint is configured by default, so **nothing leaves your machine** unless you
+add one yourself.
+
+---
+
+## What is **NOT** collected
+
+The following are **never** recorded or transmitted, in either the local or telemetry payload:
+
+- Cosmos DB **account, database, or container names**
+- **Document data**, field values, sample data, or query text
+- **Credentials**, connection strings, keys, tokens, or endpoints/URLs
+- **IP addresses**, hostnames, usernames, tenant or subscription identifiers
+- Any **free‑text** notes or comments
+- Any other **personally identifiable information (PII)** or customer data
+
+---
+
+## How consent works
+
+Consent is **default‑OFF**. The effective decision is resolved from several inputs using a
+**privacy‑first precedence** (highest wins):
+
+1. **Environment opt‑out** — `COSMOS2SQL_FEEDBACK_OPTOUT=1` *(absolute; always wins)*
+2. **Command line** — `--enable-feedback` / `--disable-feedback`
+3. **Configuration** — `FeedbackLoop:Enabled` (`true` / `false`)
+4. **Environment opt‑in** — `COSMOS2SQL_FEEDBACK_OPTIN=1` *(only applies when nothing above expresses a preference)*
+5. **Default** — disabled (nothing is collected)
+
+The absolute opt‑out mirrors the convention used by `DOTNET_CLI_TELEMETRY_OPTOUT`: setting it
+guarantees collection is off, regardless of any other setting.
+
+On every run the tool prints a transparent consent notice stating the current status, where
+data is stored, exactly what is and isn't collected, and how to change your choice.
+
+---
+
+## How to opt **in**
+
+Pick whichever fits your workflow:
+
+- **Per run (CLI):**
+  ```bash
+  CosmosToSqlAssessment --enable-feedback
+  ```
+- **Persistent (configuration)** in `appsettings.json` (or environment‑specific overrides):
+  ```json
+  {
+    "FeedbackLoop": {
+      "Enabled": true
+    }
+  }
+  ```
+- **Environment variable:**
+  ```bash
+  # Windows (PowerShell)
+  $env:COSMOS2SQL_FEEDBACK_OPTIN = "1"
+  # Linux / macOS
+  export COSMOS2SQL_FEEDBACK_OPTIN=1
+  ```
+
+## How to opt **out**
+
+Opt‑out always wins. Any of these disables collection:
+
+- **Per run (CLI):** `--disable-feedback`
+- **Configuration:** `"FeedbackLoop": { "Enabled": false }`
+- **Absolute environment opt‑out:**
+  ```bash
+  # Windows (PowerShell)
+  $env:COSMOS2SQL_FEEDBACK_OPTOUT = "1"
+  # Linux / macOS
+  export COSMOS2SQL_FEEDBACK_OPTOUT=1
+  ```
+
+> Passing both `--enable-feedback` and `--disable-feedback` in the same invocation is rejected
+> as a configuration error.
+
+---
+
+## Where your data is stored
+
+By default, outcomes are appended to a per‑user, local **JSON‑lines** file:
+
+| OS | Default location |
+| --- | --- |
+| Windows | `%LOCALAPPDATA%\CosmosToSqlAssessment\feedback\migration-outcomes.jsonl` |
+| Linux / macOS | `$XDG_DATA_HOME` (or `~/.local/share`) `/CosmosToSqlAssessment/feedback/migration-outcomes.jsonl` |
+
+You can override the path with `FeedbackLoop:StorePath`. The exact location is shown in the
+consent notice printed at runtime.
+
+### Deleting / purging your data
+
+The data is yours and stays on your machine. To delete it, simply remove the file:
+
+```bash
+# Windows (PowerShell)
+Remove-Item "$env:LOCALAPPDATA\CosmosToSqlAssessment\feedback\migration-outcomes.jsonl"
+# Linux / macOS
+rm ~/.local/share/CosmosToSqlAssessment/feedback/migration-outcomes.jsonl
+```
+
+There is no central server, no account, and nothing to request deletion from — unless you
+explicitly configured a `TelemetryEndpoint`, in which case data retention/deletion at that
+endpoint is governed by whoever operates it.
+
+> **Reading is not consent‑gated.** Refinement reads your *own* previously stored local
+> outcomes to improve your *own* recommendations even when collection is currently disabled.
+> Opt‑out stops *new* writes and any transmission; deleting the file removes the history.
+
+---
+
+## How refined recommendations are attributed
+
+When enough comparable history exists, the report includes a
+**"Recommendations Based on Prior Migrations"** section. The tool:
+
+1. Builds a `WorkloadProfile` "fingerprint" for the current assessment.
+2. Finds prior **successful** outcomes whose profiles are sufficiently *similar* (a weighted
+   similarity score over complexity, size, container count, and provisioned RUs).
+3. Requires a minimum number of comparable samples before it will adjust anything — otherwise
+   it defers to the baseline and says so.
+4. Ranks the candidate platform/tier configurations by a conservative lower‑bound of their
+   observed satisfaction rate, and reports whether prior outcomes **confirm** or **refine** the
+   baseline, along with a confidence level.
+
+The rendered rationale always states the sample size it is based on, e.g.:
+
+> *"Based on 6 prior similar migrations, Azure SQL Managed Instance (Business Critical)
+> performed satisfactorily."*
+
+This keeps every learned recommendation **transparent and attributable** — you can always see
+how many prior migrations informed it and how confident the tool is.
+
+---
+
+## Summary of settings
+
+| Setting | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `--enable-feedback` | CLI flag | — | Opt in for this run |
+| `--disable-feedback` | CLI flag | — | Opt out for this run |
+| `FeedbackLoop:Enabled` | config (bool?) | unset → off | Persistent opt in/out |
+| `FeedbackLoop:StorePath` | config (string) | per‑user path | Override local store location |
+| `FeedbackLoop:TelemetryEndpoint` | config (string) | unset | If set, also POST a coarsened summary |
+| `COSMOS2SQL_FEEDBACK_OPTOUT` | env var | unset | `1`/`true` → absolute opt out (always wins) |
+| `COSMOS2SQL_FEEDBACK_OPTIN` | env var | unset | `1`/`true` → opt in when nothing else decides |
+
+---
+
+## Related documentation
+
+- [Configuration](configuration.md)
+- [Usage](usage.md)
+- [Architecture](architecture.md)

--- a/tests/CosmosToSqlAssessment.Tests/Cli/CliArgumentParserTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Cli/CliArgumentParserTests.cs
@@ -151,6 +151,75 @@ public class CliArgumentParserTests
         options.Agentic.Should().BeTrue();
     }
 
+    // ---- Parse: feedback opt-in flags (#219) -------------------------------
+
+    [Fact]
+    public void Parse_EnableFeedbackFlag_SetsEnableFeedback()
+    {
+        var options = CliArgumentParser.Parse(new[] { "--enable-feedback" }, new StringWriter());
+
+        options.Should().NotBeNull();
+        options!.EnableFeedback.Should().BeTrue();
+        options.DisableFeedback.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parse_DisableFeedbackFlag_SetsDisableFeedback()
+    {
+        var options = CliArgumentParser.Parse(new[] { "--disable-feedback" }, new StringWriter());
+
+        options.Should().NotBeNull();
+        options!.DisableFeedback.Should().BeTrue();
+        options.EnableFeedback.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parse_DefaultOptions_FeedbackFlagsAreFalse()
+    {
+        var options = CliArgumentParser.Parse(Array.Empty<string>(), new StringWriter());
+
+        options!.EnableFeedback.Should().BeFalse();
+        options.DisableFeedback.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_BothFeedbackFlags_ReturnsFalseAndWritesError()
+    {
+        var output = new StringWriter();
+        var options = new CliOptions { EnableFeedback = true, DisableFeedback = true };
+
+        var result = CliArgumentParser.Validate(options, output);
+
+        result.Should().BeFalse();
+        var text = output.ToString();
+        text.Should().Contain("Cannot specify both --enable-feedback and --disable-feedback");
+    }
+
+    [Fact]
+    public void Parse_EnableFeedbackWithSiblingFlags_KeepsAllFlags()
+    {
+        var options = CliArgumentParser.Parse(
+            new[] { "--skip-auto-discovery", "--interactive", "--agentic", "--enable-feedback" }, new StringWriter());
+
+        options.Should().NotBeNull();
+        options!.SkipAutoDiscovery.Should().BeTrue();
+        options.Interactive.Should().BeTrue();
+        options.Agentic.Should().BeTrue();
+        options.EnableFeedback.Should().BeTrue();
+    }
+
+    [Fact]
+    public void DisplayHelp_IncludesFeedbackFlags()
+    {
+        var output = new StringWriter();
+
+        CliArgumentParser.Parse(new[] { "--help" }, output);
+
+        var text = output.ToString();
+        text.Should().Contain("--enable-feedback");
+        text.Should().Contain("--disable-feedback");
+    }
+
     // ---- Parse: value-taking flags -----------------------------------------
 
     [Theory]

--- a/tests/CosmosToSqlAssessment.Tests/Models/MigrationOutcomeTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Models/MigrationOutcomeTests.cs
@@ -1,0 +1,227 @@
+using System.Reflection;
+using System.Text.Json;
+using CosmosToSqlAssessment.Tests.Infrastructure;
+
+namespace CosmosToSqlAssessment.Tests.Models;
+
+/// <summary>
+/// Tests for the anonymized <see cref="MigrationOutcome"/> / <see cref="WorkloadProfile"/>
+/// feedback schema (parent #132, sub-issue #218).
+/// </summary>
+public class MigrationOutcomeTests
+{
+    [Fact]
+    public void MigrationOutcome_Defaults_AreSafeAndVersioned()
+    {
+        var outcome = new MigrationOutcome();
+
+        outcome.SchemaVersion.Should().Be(MigrationOutcome.CurrentSchemaVersion);
+        outcome.OutcomeId.Should().NotBeNullOrEmpty();
+        outcome.OutcomeId.Should().HaveLength(32, "the id is a non-correlatable Guid 'N' format");
+        outcome.Profile.Should().NotBeNull();
+        outcome.Status.Should().Be(MigrationOutcomeStatus.Unknown);
+        outcome.RecordedAtUtc.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromMinutes(1));
+    }
+
+    [Fact]
+    public void OutcomeId_IsUniquePerInstance()
+    {
+        var a = new MigrationOutcome();
+        var b = new MigrationOutcome();
+
+        a.OutcomeId.Should().NotBe(b.OutcomeId);
+    }
+
+    [Fact]
+    public void MonthlyCostVariance_ComputesSignedDifference()
+    {
+        var outcome = new MigrationOutcome
+        {
+            EstimatedMonthlyCostUsd = 100m,
+            ActualMonthlyCostUsd = 130m
+        };
+
+        outcome.MonthlyCostVarianceUsd.Should().Be(30m);
+        outcome.MonthlyCostVariancePercent.Should().BeApproximately(30.0, 0.0001);
+    }
+
+    [Fact]
+    public void MonthlyCostVariancePercent_IsNull_WhenEstimateIsZero()
+    {
+        var outcome = new MigrationOutcome
+        {
+            EstimatedMonthlyCostUsd = 0m,
+            ActualMonthlyCostUsd = 50m
+        };
+
+        outcome.MonthlyCostVariancePercent.Should().BeNull();
+        outcome.MonthlyCostVarianceUsd.Should().Be(50m);
+    }
+
+    [Theory]
+    [InlineData(MigrationOutcomeStatus.Succeeded, true)]
+    [InlineData(MigrationOutcomeStatus.PartiallySucceeded, true)]
+    [InlineData(MigrationOutcomeStatus.Failed, false)]
+    [InlineData(MigrationOutcomeStatus.RolledBack, false)]
+    [InlineData(MigrationOutcomeStatus.Unknown, false)]
+    public void Succeeded_ReflectsStatus(MigrationOutcomeStatus status, bool expected)
+    {
+        new MigrationOutcome { Status = status }.Succeeded.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(0.0, WorkloadSizeBucket.Small)]
+    [InlineData(9.99, WorkloadSizeBucket.Small)]
+    [InlineData(10.0, WorkloadSizeBucket.Medium)]
+    [InlineData(99.99, WorkloadSizeBucket.Medium)]
+    [InlineData(100.0, WorkloadSizeBucket.Large)]
+    [InlineData(1023.0, WorkloadSizeBucket.Large)]
+    [InlineData(1024.0, WorkloadSizeBucket.VeryLarge)]
+    [InlineData(50000.0, WorkloadSizeBucket.VeryLarge)]
+    public void BucketFor_MapsSizeBoundaries(double gb, WorkloadSizeBucket expected)
+    {
+        WorkloadProfile.BucketFor(gb).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("Low", MigrationComplexityRating.Low)]
+    [InlineData("medium", MigrationComplexityRating.Medium)]
+    [InlineData("HIGH", MigrationComplexityRating.High)]
+    [InlineData("  Medium  ", MigrationComplexityRating.Medium)]
+    [InlineData("", MigrationComplexityRating.Unknown)]
+    [InlineData(null, MigrationComplexityRating.Unknown)]
+    [InlineData("nonsense", MigrationComplexityRating.Unknown)]
+    public void ParseComplexity_NormalizesLabels(string? input, MigrationComplexityRating expected)
+    {
+        WorkloadProfile.ParseComplexity(input).Should().Be(expected);
+    }
+
+    [Fact]
+    public void FromAssessment_ProjectsAggregateFingerprint()
+    {
+        var assessment = TestDataFactory.CreateSampleAssessmentResult();
+
+        var profile = WorkloadProfile.FromAssessment(assessment);
+
+        profile.ComplexityRating.Should().Be(MigrationComplexityRating.Medium);
+        profile.ContainerCount.Should().Be(1);
+        profile.TotalDocumentCount.Should().Be(500000);
+        profile.TotalDataSizeGb.Should().BeApproximately(5_000_000_000 / (1024.0 * 1024.0 * 1024.0), 0.01);
+        profile.SizeBucket.Should().Be(WorkloadSizeBucket.Small);
+        profile.MaxProvisionedRUs.Should().Be(400);
+        profile.IndexRecommendationCount.Should().Be(1);
+        profile.RecommendedPlatform.Should().Be("Azure SQL Database");
+        profile.RecommendedTier.Should().Be("General Purpose");
+    }
+
+    [Fact]
+    public void FromAssessment_Null_Throws()
+    {
+        Action act = () => WorkloadProfile.FromAssessment(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void FromAssessment_HandlesEmptyAssessment()
+    {
+        var profile = WorkloadProfile.FromAssessment(new AssessmentResult());
+
+        profile.ContainerCount.Should().Be(0);
+        profile.MaxProvisionedRUs.Should().Be(0);
+        profile.TotalDocumentCount.Should().Be(0);
+        profile.ComplexityRating.Should().Be(MigrationComplexityRating.Unknown);
+    }
+
+    /// <summary>
+    /// Privacy contract: the only string-typed (free-text-capable) properties allowed in the
+    /// persisted feedback graph are a fixed allow-list of tool-generated categorical labels.
+    /// Any newly added string property forces a conscious privacy decision (update this list),
+    /// preventing accidental introduction of a name/notes/identifier field.
+    /// </summary>
+    [Fact]
+    public void Schema_ExposesNoUnapprovedStringFields()
+    {
+        var allowed = new HashSet<string>
+        {
+            // MigrationOutcome
+            "OutcomeId",
+            "DeployedPlatform",
+            "DeployedTier",
+            // WorkloadProfile
+            "RecommendedPlatform",
+            "RecommendedTier"
+        };
+
+        var stringProps = CollectStringProperties(typeof(MigrationOutcome))
+            .Concat(CollectStringProperties(typeof(WorkloadProfile)))
+            .Select(p => p.Name)
+            .Distinct()
+            .ToList();
+
+        stringProps.Should().OnlyContain(name => allowed.Contains(name),
+            "the feedback schema must not introduce free-text / identifying string fields without an explicit privacy decision");
+    }
+
+    [Fact]
+    public void Schema_DoesNotPersistDerivedProperties()
+    {
+        var outcome = new MigrationOutcome
+        {
+            EstimatedMonthlyCostUsd = 100m,
+            ActualMonthlyCostUsd = 150m,
+            Status = MigrationOutcomeStatus.Succeeded
+        };
+
+        var json = JsonSerializer.Serialize(outcome);
+
+        json.Should().Contain("SchemaVersion");
+        json.Should().NotContain("MonthlyCostVarianceUsd");
+        json.Should().NotContain("MonthlyCostVariancePercent");
+        json.Should().NotContain("Succeeded");
+    }
+
+    [Fact]
+    public void Schema_RoundTripsThroughJson()
+    {
+        var original = new MigrationOutcome
+        {
+            Status = MigrationOutcomeStatus.PartiallySucceeded,
+            ActualMigrationDays = 7,
+            DataCompletenessPercent = 99.5,
+            DeployedPlatform = "Azure SQL Managed Instance",
+            DeployedTier = "Business Critical",
+            AvgResourceUtilizationPercent = 62.0,
+            PerformanceSatisfactory = true,
+            EstimatedMonthlyCostUsd = 1000m,
+            ActualMonthlyCostUsd = 1250m,
+            Profile = new WorkloadProfile
+            {
+                ComplexityRating = MigrationComplexityRating.High,
+                ContainerCount = 12,
+                SizeBucket = WorkloadSizeBucket.Large,
+                TotalDocumentCount = 42_000_000,
+                TotalDataSizeGb = 250.0,
+                MaxProvisionedRUs = 40000,
+                IndexRecommendationCount = 9,
+                RecommendedPlatform = "Azure SQL Managed Instance",
+                RecommendedTier = "General Purpose"
+            }
+        };
+
+        var json = JsonSerializer.Serialize(original);
+        var restored = JsonSerializer.Deserialize<MigrationOutcome>(json)!;
+
+        restored.Status.Should().Be(original.Status);
+        restored.ActualMigrationDays.Should().Be(7);
+        restored.DeployedTier.Should().Be("Business Critical");
+        restored.PerformanceSatisfactory.Should().BeTrue();
+        restored.Profile.ComplexityRating.Should().Be(MigrationComplexityRating.High);
+        restored.Profile.SizeBucket.Should().Be(WorkloadSizeBucket.Large);
+        restored.Profile.MaxProvisionedRUs.Should().Be(40000);
+        restored.MonthlyCostVarianceUsd.Should().Be(250m);
+    }
+
+    private static IEnumerable<PropertyInfo> CollectStringProperties(Type type) =>
+        type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.PropertyType == typeof(string));
+}

--- a/tests/CosmosToSqlAssessment.Tests/Reporting/PriorMigrationsRationaleReportTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Reporting/PriorMigrationsRationaleReportTests.cs
@@ -1,0 +1,160 @@
+using CosmosToSqlAssessment.Tests.Infrastructure;
+using DocumentFormat.OpenXml.Packaging;
+
+namespace CosmosToSqlAssessment.Tests.Reporting;
+
+/// <summary>
+/// Tests for the "Recommendations Based on Prior Migrations" Word report section (issue #221),
+/// which surfaces the attributable rationale produced by the opt-in feedback loop.
+/// </summary>
+public class PriorMigrationsRationaleReportTests : TestBase, IDisposable
+{
+    private readonly ReportGenerationService _service;
+    private readonly string _tempDirectory;
+
+    public PriorMigrationsRationaleReportTests()
+    {
+        var logger = CreateMockLogger<ReportGenerationService>();
+        _service = new ReportGenerationService(MockConfiguration.Object, logger.Object);
+        _tempDirectory = Path.Combine(Path.GetTempPath(), $"CosmosToSqlTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    [Fact]
+    public void AssessmentResult_RecommendationRefinement_RoundTrips()
+    {
+        var refinement = new RecommendationRefinement
+        {
+            HasRefinement = true,
+            PriorSimilarMigrationCount = 4,
+            RefinedPlatform = "Azure SQL Managed Instance",
+            RefinedTier = "Business Critical"
+        };
+
+        var result = new AssessmentResult { RecommendationRefinement = refinement };
+
+        result.RecommendationRefinement.Should().BeSameAs(refinement);
+        result.RecommendationRefinement!.HasRefinement.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GenerateAssessmentReportAsync_WithRefinement_WordContainsRationaleSection()
+    {
+        // Arrange
+        var assessmentResult = TestDataFactory.CreateSampleAssessmentResult();
+        assessmentResult.RecommendationRefinement = new RecommendationRefinement
+        {
+            HasRefinement = true,
+            ChangedFromBaseline = true,
+            PriorSimilarMigrationCount = 6,
+            BaselinePlatform = "Azure SQL Database",
+            BaselineTier = "General Purpose",
+            RefinedPlatform = "Azure SQL Managed Instance",
+            RefinedTier = "Business Critical",
+            Confidence = RefinementConfidence.High,
+            ObservedSatisfactionRate = 0.9,
+            AverageMonthlyCostVariancePercent = -5.0,
+            Rationale = "Based on 6 prior similar migrations, Azure SQL Managed Instance (Business Critical) performed satisfactorily."
+        };
+
+        // Act
+        var (_, wordPath, _) = await _service.GenerateAssessmentReportAsync(assessmentResult, _tempDirectory);
+
+        // Assert
+        var text = ReadWordBodyText(wordPath);
+        text.Should().Contain("Recommendations Based on Prior Migrations");
+        text.Should().Contain("Prior similar migrations analyzed: 6");
+        text.Should().Contain("Confidence: High");
+        text.Should().Contain("Azure SQL Managed Instance");
+        text.Should().Contain("baseline was Azure SQL Database");
+        text.Should().Contain("90%");
+        text.Should().Contain("-5.0%");
+        text.Should().Contain("Based on 6 prior similar migrations");
+    }
+
+    [Fact]
+    public async Task GenerateAssessmentReportAsync_WithConfirmingRefinement_OmitsBaselineComparison()
+    {
+        // Arrange – refinement confirms the baseline (no change)
+        var assessmentResult = TestDataFactory.CreateSampleAssessmentResult();
+        assessmentResult.RecommendationRefinement = new RecommendationRefinement
+        {
+            HasRefinement = true,
+            ChangedFromBaseline = false,
+            PriorSimilarMigrationCount = 3,
+            BaselinePlatform = "Azure SQL Database",
+            BaselineTier = "General Purpose",
+            RefinedPlatform = "Azure SQL Database",
+            RefinedTier = "General Purpose",
+            Confidence = RefinementConfidence.Medium,
+            Rationale = "Based on 3 prior similar migrations, the baseline recommendation is confirmed."
+        };
+
+        // Act
+        var (_, wordPath, _) = await _service.GenerateAssessmentReportAsync(assessmentResult, _tempDirectory);
+
+        // Assert
+        var text = ReadWordBodyText(wordPath);
+        text.Should().Contain("Recommendations Based on Prior Migrations");
+        text.Should().Contain("Recommendation confirmed");
+        text.Should().NotContain("baseline was");
+        // Null performance/cost values must be omitted, never rendered as zero.
+        text.Should().NotContain("Observed performance-satisfaction rate");
+        text.Should().NotContain("Average monthly cost variance");
+    }
+
+    [Fact]
+    public async Task GenerateAssessmentReportAsync_WithoutRefinement_OmitsRationaleSection()
+    {
+        // Arrange – no refinement attached (default run, feedback loop off)
+        var assessmentResult = TestDataFactory.CreateSampleAssessmentResult();
+        assessmentResult.RecommendationRefinement = null;
+
+        // Act
+        var (_, wordPath, _) = await _service.GenerateAssessmentReportAsync(assessmentResult, _tempDirectory);
+
+        // Assert
+        var text = ReadWordBodyText(wordPath);
+        text.Should().NotContain("Recommendations Based on Prior Migrations");
+    }
+
+    [Fact]
+    public async Task GenerateAssessmentReportAsync_WithNoRefinementResult_OmitsRationaleSection()
+    {
+        // Arrange – a "None" refinement (insufficient comparable history) must not render the section
+        var assessmentResult = TestDataFactory.CreateSampleAssessmentResult();
+        assessmentResult.RecommendationRefinement = RecommendationRefinement.None(
+            "Azure SQL Database", "General Purpose", priorSimilarCount: 1,
+            rationale: "Insufficient comparable history.");
+
+        // Act
+        var (_, wordPath, _) = await _service.GenerateAssessmentReportAsync(assessmentResult, _tempDirectory);
+
+        // Assert
+        var text = ReadWordBodyText(wordPath);
+        text.Should().NotContain("Recommendations Based on Prior Migrations");
+    }
+
+    private static string ReadWordBodyText(string wordPath)
+    {
+        File.Exists(wordPath).Should().BeTrue();
+        using var document = WordprocessingDocument.Open(wordPath, false);
+        return document.MainDocumentPart?.Document?.Body?.InnerText ?? string.Empty;
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDirectory))
+            {
+                Directory.Delete(_tempDirectory, true);
+            }
+        }
+        catch
+        {
+            // Ignore cleanup errors in tests
+        }
+        GC.SuppressFinalize(this);
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/Feedback/CoarsenedOutcomeTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/Feedback/CoarsenedOutcomeTests.cs
@@ -1,0 +1,93 @@
+using CosmosToSqlAssessment.Services.Feedback;
+
+namespace CosmosToSqlAssessment.Tests.Services.Feedback;
+
+public class CoarsenedOutcomeTests
+{
+    [Theory]
+    [InlineData(0, "1")]
+    [InlineData(1, "1")]
+    [InlineData(2, "2-5")]
+    [InlineData(5, "2-5")]
+    [InlineData(6, "6-20")]
+    [InlineData(20, "6-20")]
+    [InlineData(21, "21-100")]
+    [InlineData(100, "21-100")]
+    [InlineData(101, "100+")]
+    public void BucketContainerCount_MapsBoundaries(int count, string expected)
+    {
+        CoarsenedOutcome.BucketContainerCount(count).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null, "Unknown")]
+    [InlineData(-25.0, "UnderEstimate")]
+    [InlineData(-10.0, "OnTarget")]
+    [InlineData(0.0, "OnTarget")]
+    [InlineData(10.0, "OnTarget")]
+    [InlineData(25.0, "OverEstimate")]
+    [InlineData(50.0, "OverEstimate")]
+    [InlineData(75.0, "WellOverEstimate")]
+    public void BucketCostVariance_MapsBoundaries(double? variance, string expected)
+    {
+        CoarsenedOutcome.BucketCostVariance(variance).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(0, "0-5")]
+    [InlineData(5, "0-5")]
+    [InlineData(6, "6-15")]
+    [InlineData(15, "6-15")]
+    [InlineData(16, "16-30")]
+    [InlineData(30, "16-30")]
+    [InlineData(31, "30+")]
+    public void BucketDays_MapsBoundaries(int days, string expected)
+    {
+        CoarsenedOutcome.BucketDays(days).Should().Be(expected);
+    }
+
+    [Fact]
+    public void From_ProjectsOnlyAnonymizedAggregateFields()
+    {
+        var outcome = new MigrationOutcome
+        {
+            Profile = new WorkloadProfile
+            {
+                ComplexityRating = MigrationComplexityRating.High,
+                SizeBucket = WorkloadSizeBucket.Large,
+                ContainerCount = 12,
+                RecommendedPlatform = "Azure SQL Database",
+                RecommendedTier = "General Purpose"
+            },
+            DeployedPlatform = "Azure SQL Managed Instance",
+            DeployedTier = "Business Critical",
+            Status = MigrationOutcomeStatus.Succeeded,
+            PerformanceSatisfactory = true,
+            EstimatedMonthlyCostUsd = 100m,
+            ActualMonthlyCostUsd = 130m,
+            ActualMigrationDays = 9
+        };
+
+        var coarsened = CoarsenedOutcome.From(outcome);
+
+        coarsened.ComplexityRating.Should().Be(MigrationComplexityRating.High);
+        coarsened.SizeBucket.Should().Be(WorkloadSizeBucket.Large);
+        coarsened.ContainerCountBucket.Should().Be("6-20");
+        coarsened.RecommendedPlatform.Should().Be("Azure SQL Database");
+        coarsened.RecommendedTier.Should().Be("General Purpose");
+        coarsened.DeployedPlatform.Should().Be("Azure SQL Managed Instance");
+        coarsened.DeployedTier.Should().Be("Business Critical");
+        coarsened.Status.Should().Be(MigrationOutcomeStatus.Succeeded);
+        coarsened.PerformanceSatisfactory.Should().BeTrue();
+        coarsened.MonthlyCostVarianceBucket.Should().Be("OverEstimate");
+        coarsened.MigrationDaysBucket.Should().Be("6-15");
+    }
+
+    [Fact]
+    public void From_NullOutcome_Throws()
+    {
+        var act = () => CoarsenedOutcome.From(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/Feedback/FeedbackCollectionServiceTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/Feedback/FeedbackCollectionServiceTests.cs
@@ -1,0 +1,173 @@
+using System.Runtime.CompilerServices;
+using CosmosToSqlAssessment.Services;
+using CosmosToSqlAssessment.Services.Feedback;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CosmosToSqlAssessment.Tests.Services.Feedback;
+
+public class FeedbackCollectionServiceTests
+{
+    private static FeedbackCollectionService CreateService(
+        FeedbackOptions options,
+        Mock<IFeedbackStore>? store = null,
+        Mock<IFeedbackTelemetrySink>? sink = null)
+    {
+        store ??= new Mock<IFeedbackStore>();
+        store.SetupGet(s => s.Location).Returns("test-location.jsonl");
+        sink ??= new Mock<IFeedbackTelemetrySink>();
+        return new FeedbackCollectionService(
+            store.Object, sink.Object, options, NullLogger<FeedbackCollectionService>.Instance);
+    }
+
+    [Fact]
+    public async Task RecordOutcomeAsync_ConsentDenied_DoesNotPersistAndReturnsFalse()
+    {
+        var store = new Mock<IFeedbackStore>();
+        var sink = new Mock<IFeedbackTelemetrySink>();
+        var service = CreateService(new FeedbackOptions(), store, sink);
+
+        var recorded = await service.RecordOutcomeAsync(new MigrationOutcome());
+
+        recorded.Should().BeFalse();
+        store.Verify(s => s.AppendAsync(It.IsAny<MigrationOutcome>(), It.IsAny<CancellationToken>()), Times.Never);
+        sink.Verify(s => s.SendAsync(It.IsAny<CoarsenedOutcome>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RecordOutcomeAsync_ConsentGrantedViaCli_PersistsLocally()
+    {
+        var store = new Mock<IFeedbackStore>();
+        var sink = new Mock<IFeedbackTelemetrySink>();
+        var service = CreateService(new FeedbackOptions(), store, sink);
+
+        var recorded = await service.RecordOutcomeAsync(new MigrationOutcome(), commandLineOptIn: true);
+
+        recorded.Should().BeTrue();
+        store.Verify(s => s.AppendAsync(It.IsAny<MigrationOutcome>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RecordOutcomeAsync_ConsentGrantedViaConfig_PersistsLocally()
+    {
+        var store = new Mock<IFeedbackStore>();
+        var service = CreateService(new FeedbackOptions { Enabled = true }, store);
+
+        var recorded = await service.RecordOutcomeAsync(new MigrationOutcome());
+
+        recorded.Should().BeTrue();
+        store.Verify(s => s.AppendAsync(It.IsAny<MigrationOutcome>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RecordOutcomeAsync_NoTelemetryEndpoint_DoesNotTransmit()
+    {
+        var sink = new Mock<IFeedbackTelemetrySink>();
+        var service = CreateService(new FeedbackOptions { Enabled = true }, sink: sink);
+
+        await service.RecordOutcomeAsync(new MigrationOutcome());
+
+        sink.Verify(s => s.SendAsync(It.IsAny<CoarsenedOutcome>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RecordOutcomeAsync_WithTelemetryEndpoint_TransmitsCoarsenedPayload()
+    {
+        var sink = new Mock<IFeedbackTelemetrySink>();
+        var options = new FeedbackOptions { Enabled = true, TelemetryEndpoint = "https://example.test/ingest" };
+        var service = CreateService(options, sink: sink);
+
+        await service.RecordOutcomeAsync(new MigrationOutcome());
+
+        sink.Verify(s => s.SendAsync(It.IsAny<CoarsenedOutcome>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RecordOutcomeAsync_NullOutcome_Throws()
+    {
+        var service = CreateService(new FeedbackOptions { Enabled = true });
+
+        var act = () => service.RecordOutcomeAsync(null!);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task GetOutcomesAsync_DelegatesToStore()
+    {
+        var stored = new[]
+        {
+            new MigrationOutcome { OutcomeId = "x1" },
+            new MigrationOutcome { OutcomeId = "x2" }
+        };
+        var store = new Mock<IFeedbackStore>();
+        store.Setup(s => s.ReadAllAsync(It.IsAny<CancellationToken>())).Returns(ToAsync(stored));
+        var service = CreateService(new FeedbackOptions(), store);
+
+        var collected = new List<MigrationOutcome>();
+        await foreach (var outcome in service.GetOutcomesAsync())
+        {
+            collected.Add(outcome);
+        }
+
+        collected.Select(o => o.OutcomeId).Should().Equal("x1", "x2");
+    }
+
+    [Fact]
+    public void ResolveConsent_NoInputs_DefaultsToDisabled()
+    {
+        var service = CreateService(new FeedbackOptions());
+
+        var consent = service.ResolveConsent();
+
+        consent.IsGranted.Should().BeFalse();
+        consent.Source.Should().Be(FeedbackConsentSource.Default);
+    }
+
+    [Fact]
+    public void HasTelemetryEndpoint_ReflectsConfiguration()
+    {
+        CreateService(new FeedbackOptions()).HasTelemetryEndpoint.Should().BeFalse();
+        CreateService(new FeedbackOptions { TelemetryEndpoint = "https://x.test" }).HasTelemetryEndpoint.Should().BeTrue();
+    }
+
+    [Fact]
+    public void WriteConsentNotice_Granted_DescribesCollectionAndOptOut()
+    {
+        var service = CreateService(new FeedbackOptions());
+        var writer = new StringWriter();
+
+        service.WriteConsentNotice(writer, new FeedbackConsent(true, FeedbackConsentSource.CommandLine));
+
+        var text = writer.ToString();
+        text.Should().Contain("ENABLED");
+        text.Should().Contain("test-location.jsonl");
+        text.Should().Contain("NOT collected");
+        text.Should().Contain("--disable-feedback");
+    }
+
+    [Fact]
+    public void WriteConsentNotice_Denied_DescribesOptIn()
+    {
+        var service = CreateService(new FeedbackOptions());
+        var writer = new StringWriter();
+
+        service.WriteConsentNotice(writer, new FeedbackConsent(false, FeedbackConsentSource.Default));
+
+        var text = writer.ToString();
+        text.Should().Contain("DISABLED");
+        text.Should().Contain("--enable-feedback");
+    }
+
+    private static async IAsyncEnumerable<MigrationOutcome> ToAsync(
+        IEnumerable<MigrationOutcome> items,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (var item in items)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return item;
+        }
+
+        await Task.CompletedTask;
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/Feedback/FeedbackConsentTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/Feedback/FeedbackConsentTests.cs
@@ -1,0 +1,55 @@
+using CosmosToSqlAssessment.Services;
+
+namespace CosmosToSqlAssessment.Tests.Services.Feedback;
+
+public class FeedbackConsentTests
+{
+    [Fact]
+    public void Resolve_NoInputs_DefaultsToDisabled()
+    {
+        var consent = FeedbackConsent.Resolve(commandLineOptIn: null, configEnabled: null, envOptOut: false, envOptIn: false);
+
+        consent.IsGranted.Should().BeFalse();
+        consent.Source.Should().Be(FeedbackConsentSource.Default);
+    }
+
+    [Fact]
+    public void Resolve_EnvOptOut_OverridesEverything()
+    {
+        var consent = FeedbackConsent.Resolve(commandLineOptIn: true, configEnabled: true, envOptOut: true, envOptIn: true);
+
+        consent.IsGranted.Should().BeFalse();
+        consent.Source.Should().Be(FeedbackConsentSource.EnvironmentOptOut);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Resolve_CommandLine_TakesPrecedenceOverConfigAndEnvOptIn(bool cliValue)
+    {
+        var consent = FeedbackConsent.Resolve(commandLineOptIn: cliValue, configEnabled: !cliValue, envOptOut: false, envOptIn: true);
+
+        consent.IsGranted.Should().Be(cliValue);
+        consent.Source.Should().Be(FeedbackConsentSource.CommandLine);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Resolve_Configuration_TakesPrecedenceOverEnvOptIn(bool configValue)
+    {
+        var consent = FeedbackConsent.Resolve(commandLineOptIn: null, configEnabled: configValue, envOptOut: false, envOptIn: true);
+
+        consent.IsGranted.Should().Be(configValue);
+        consent.Source.Should().Be(FeedbackConsentSource.Configuration);
+    }
+
+    [Fact]
+    public void Resolve_EnvOptIn_AppliesOnlyWhenHigherSourcesSilent()
+    {
+        var consent = FeedbackConsent.Resolve(commandLineOptIn: null, configEnabled: null, envOptOut: false, envOptIn: true);
+
+        consent.IsGranted.Should().BeTrue();
+        consent.Source.Should().Be(FeedbackConsentSource.EnvironmentOptIn);
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/Feedback/HttpFeedbackTelemetrySinkTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/Feedback/HttpFeedbackTelemetrySinkTests.cs
@@ -1,0 +1,104 @@
+using System.Net;
+using System.Net.Http;
+using CosmosToSqlAssessment.Services;
+using CosmosToSqlAssessment.Services.Feedback;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CosmosToSqlAssessment.Tests.Services.Feedback;
+
+public class HttpFeedbackTelemetrySinkTests
+{
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _responder;
+
+        public StubHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responder)
+        {
+            _responder = responder;
+        }
+
+        public int CallCount { get; private set; }
+
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            LastRequest = request;
+            return _responder(request, cancellationToken);
+        }
+    }
+
+    private static CoarsenedOutcome SamplePayload() =>
+        CoarsenedOutcome.From(new MigrationOutcome { Status = MigrationOutcomeStatus.Succeeded });
+
+    [Fact]
+    public async Task SendAsync_PostsJsonToConfiguredEndpoint()
+    {
+        var handler = new StubHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+        using var client = new HttpClient(handler);
+        var options = new FeedbackOptions { TelemetryEndpoint = "https://example.test/ingest" };
+        var sink = new HttpFeedbackTelemetrySink(client, options, NullLogger<HttpFeedbackTelemetrySink>.Instance);
+
+        await sink.SendAsync(SamplePayload());
+
+        handler.CallCount.Should().Be(1);
+        handler.LastRequest!.Method.Should().Be(HttpMethod.Post);
+        handler.LastRequest.RequestUri!.ToString().Should().Be("https://example.test/ingest");
+        handler.LastRequest.Content!.Headers.ContentType!.MediaType.Should().Be("application/json");
+    }
+
+    [Fact]
+    public async Task SendAsync_NoEndpointConfigured_DoesNotCallHttp()
+    {
+        var handler = new StubHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+        using var client = new HttpClient(handler);
+        var sink = new HttpFeedbackTelemetrySink(client, new FeedbackOptions(), NullLogger<HttpFeedbackTelemetrySink>.Instance);
+
+        await sink.SendAsync(SamplePayload());
+
+        handler.CallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task SendAsync_TransportFailure_IsSwallowed()
+    {
+        var handler = new StubHandler((_, _) => throw new HttpRequestException("boom"));
+        using var client = new HttpClient(handler);
+        var options = new FeedbackOptions { TelemetryEndpoint = "https://example.test/ingest" };
+        var sink = new HttpFeedbackTelemetrySink(client, options, NullLogger<HttpFeedbackTelemetrySink>.Instance);
+
+        var act = () => sink.SendAsync(SamplePayload());
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task SendAsync_NonSuccessStatus_DoesNotThrow()
+    {
+        var handler = new StubHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError)));
+        using var client = new HttpClient(handler);
+        var options = new FeedbackOptions { TelemetryEndpoint = "https://example.test/ingest" };
+        var sink = new HttpFeedbackTelemetrySink(client, options, NullLogger<HttpFeedbackTelemetrySink>.Instance);
+
+        var act = () => sink.SendAsync(SamplePayload());
+
+        await act.Should().NotThrowAsync();
+        handler.CallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SendAsync_Cancellation_Rethrows()
+    {
+        var handler = new StubHandler((_, ct) => Task.FromCanceled<HttpResponseMessage>(ct));
+        using var client = new HttpClient(handler);
+        var options = new FeedbackOptions { TelemetryEndpoint = "https://example.test/ingest" };
+        var sink = new HttpFeedbackTelemetrySink(client, options, NullLogger<HttpFeedbackTelemetrySink>.Instance);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var act = () => sink.SendAsync(SamplePayload(), cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/Feedback/LocalJsonFeedbackStoreTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/Feedback/LocalJsonFeedbackStoreTests.cs
@@ -1,0 +1,119 @@
+using CosmosToSqlAssessment.Services;
+using CosmosToSqlAssessment.Services.Feedback;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CosmosToSqlAssessment.Tests.Services.Feedback;
+
+public class LocalJsonFeedbackStoreTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _storePath;
+
+    public LocalJsonFeedbackStoreTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "cosmos2sql-feedback-tests", Guid.NewGuid().ToString("N"));
+        _storePath = Path.Combine(_tempDir, "outcomes.jsonl");
+    }
+
+    private LocalJsonFeedbackStore CreateStore() =>
+        new(new FeedbackOptions { StorePath = _storePath }, NullLogger<LocalJsonFeedbackStore>.Instance);
+
+    [Fact]
+    public void Location_UsesConfiguredStorePath()
+    {
+        CreateStore().Location.Should().Be(_storePath);
+    }
+
+    [Fact]
+    public void GetDefaultPath_ReturnsAbsolutePathUnderAppData()
+    {
+        var path = LocalJsonFeedbackStore.GetDefaultPath();
+
+        Path.IsPathRooted(path).Should().BeTrue();
+        path.Should().EndWith(Path.Combine("CosmosToSqlAssessment", "feedback", "migration-outcomes.jsonl"));
+    }
+
+    [Fact]
+    public async Task ReadAllAsync_MissingFile_YieldsEmpty()
+    {
+        var store = CreateStore();
+
+        var outcomes = await CollectAsync(store);
+
+        outcomes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task AppendAsync_ThenReadAll_RoundTripsRecords()
+    {
+        var store = CreateStore();
+        var first = new MigrationOutcome { OutcomeId = "a1", Status = MigrationOutcomeStatus.Succeeded, ActualMigrationDays = 4 };
+        var second = new MigrationOutcome { OutcomeId = "b2", Status = MigrationOutcomeStatus.Failed, ActualMigrationDays = 12 };
+
+        await store.AppendAsync(first);
+        await store.AppendAsync(second);
+        var outcomes = await CollectAsync(store);
+
+        outcomes.Should().HaveCount(2);
+        outcomes[0].OutcomeId.Should().Be("a1");
+        outcomes[0].Status.Should().Be(MigrationOutcomeStatus.Succeeded);
+        outcomes[1].OutcomeId.Should().Be("b2");
+        outcomes[1].ActualMigrationDays.Should().Be(12);
+    }
+
+    [Fact]
+    public async Task ReadAllAsync_SkipsMalformedAndBlankLines()
+    {
+        var store = CreateStore();
+        await store.AppendAsync(new MigrationOutcome { OutcomeId = "good1" });
+
+        // Inject a malformed line and a blank line, then a valid record.
+        await File.AppendAllTextAsync(_storePath, "this is not json" + Environment.NewLine);
+        await File.AppendAllTextAsync(_storePath, Environment.NewLine);
+        await store.AppendAsync(new MigrationOutcome { OutcomeId = "good2" });
+
+        var outcomes = await CollectAsync(store);
+
+        outcomes.Should().HaveCount(2);
+        outcomes.Select(o => o.OutcomeId).Should().Equal("good1", "good2");
+    }
+
+    [Fact]
+    public async Task AppendAsync_ConcurrentWrites_PersistAllRecords()
+    {
+        var store = CreateStore();
+
+        var tasks = Enumerable.Range(0, 25)
+            .Select(i => store.AppendAsync(new MigrationOutcome { OutcomeId = $"c{i}" }));
+        await Task.WhenAll(tasks);
+
+        var outcomes = await CollectAsync(store);
+        outcomes.Should().HaveCount(25);
+    }
+
+    private static async Task<List<MigrationOutcome>> CollectAsync(IFeedbackStore store)
+    {
+        var list = new List<MigrationOutcome>();
+        await foreach (var outcome in store.ReadAllAsync())
+        {
+            list.Add(outcome);
+        }
+
+        return list;
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/Feedback/RecommendationRefinementAbComparisonTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/Feedback/RecommendationRefinementAbComparisonTests.cs
@@ -1,0 +1,152 @@
+using CosmosToSqlAssessment.Services;
+
+namespace CosmosToSqlAssessment.Tests.Services.Feedback;
+
+/// <summary>
+/// A/B comparison proving the learning-refined recommendation is measurably more accurate than the
+/// static baseline across a labeled, non-circular fixture (acceptance criterion for #220).
+/// </summary>
+public class RecommendationRefinementAbComparisonTests
+{
+    private const string SqlDb = "Azure SQL Database";
+    private const string ManagedInstance = "Azure SQL Managed Instance";
+
+    private static RecommendationRefinementService CreateService()
+    {
+        var feedback = new FeedbackCollectionService(
+            new Mock<CosmosToSqlAssessment.Services.Feedback.IFeedbackStore>().Object,
+            new CosmosToSqlAssessment.Services.Feedback.NullFeedbackTelemetrySink(),
+            new FeedbackOptions(),
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<FeedbackCollectionService>.Instance);
+        return new RecommendationRefinementService(feedback);
+    }
+
+    private static AssessmentResult Assessment(string complexity, double sizeGb, int containers, int maxRu, string platform, string tier)
+    {
+        long totalBytes = (long)(sizeGb * 1024 * 1024 * 1024);
+        var list = new List<ContainerAnalysis>();
+        for (int i = 0; i < containers; i++)
+        {
+            list.Add(new ContainerAnalysis
+            {
+                DocumentCount = 1000,
+                SizeBytes = i == 0 ? totalBytes : 0,
+                ProvisionedRUs = i == 0 ? maxRu : 0
+            });
+        }
+
+        return new AssessmentResult
+        {
+            CosmosAnalysis = new CosmosDbAnalysis { Containers = list },
+            SqlAssessment = new SqlMigrationAssessment
+            {
+                RecommendedPlatform = platform,
+                RecommendedTier = tier,
+                Complexity = new MigrationComplexity { OverallComplexity = complexity }
+            }
+        };
+    }
+
+    private static WorkloadProfile ProfileFor(AssessmentResult assessment) => WorkloadProfile.FromAssessment(assessment);
+
+    private static List<MigrationOutcome> History(WorkloadProfile profile, string platform, string tier, bool satisfactory, int count)
+    {
+        var list = new List<MigrationOutcome>(count);
+        for (int i = 0; i < count; i++)
+        {
+            list.Add(new MigrationOutcome
+            {
+                Profile = profile,
+                Status = MigrationOutcomeStatus.Succeeded,
+                DeployedPlatform = platform,
+                DeployedTier = tier,
+                PerformanceSatisfactory = satisfactory,
+                EstimatedMonthlyCostUsd = 100m,
+                ActualMonthlyCostUsd = 100m
+            });
+        }
+
+        return list;
+    }
+
+    [Fact]
+    public void EvaluateAccuracy_RefinedBeatsBaseline_OnLabeledFixture()
+    {
+        var service = CreateService();
+        var scenarios = new List<RefinementScenario>();
+
+        // Scenario 1 — refinement helps (platform AND tier change). Baseline GP is wrong; history
+        // shows MI/Business Critical performed well for this large/high workload.
+        var a1 = Assessment("High", 200, 10, 1000, SqlDb, "General Purpose");
+        var h1 = new List<MigrationOutcome>();
+        h1.AddRange(History(ProfileFor(a1), ManagedInstance, "Business Critical", satisfactory: true, count: 6));
+        h1.AddRange(History(ProfileFor(a1), SqlDb, "General Purpose", satisfactory: false, count: 4));
+        scenarios.Add(new RefinementScenario(a1, h1, ManagedInstance, "Business Critical"));
+
+        // Scenario 2 — baseline already correct; history confirms it.
+        var a2 = Assessment("Low", 5, 3, 200, SqlDb, "General Purpose");
+        var h2 = History(ProfileFor(a2), SqlDb, "General Purpose", satisfactory: true, count: 5);
+        scenarios.Add(new RefinementScenario(a2, h2, SqlDb, "General Purpose"));
+
+        // Scenario 3 — no comparable history; refinement abstains and defers to the (correct) baseline.
+        var a3 = Assessment("Medium", 50, 5, 400, SqlDb, "Hyperscale");
+        var h3 = new List<MigrationOutcome>();
+        scenarios.Add(new RefinementScenario(a3, h3, SqlDb, "Hyperscale"));
+
+        // Scenario 4 — refinement helps (tier change). Baseline GP wrong; history favors Hyperscale.
+        var a4 = Assessment("High", 1500, 12, 4000, SqlDb, "General Purpose");
+        var h4 = History(ProfileFor(a4), SqlDb, "Hyperscale", satisfactory: true, count: 5);
+        scenarios.Add(new RefinementScenario(a4, h4, SqlDb, "Hyperscale"));
+
+        // Scenario 5 — noise resistance. A single high-satisfaction Business Critical sample is below
+        // the per-candidate floor and must not beat the larger, reliable General Purpose group.
+        var a5 = Assessment("Medium", 200, 8, 800, SqlDb, "General Purpose");
+        var h5 = new List<MigrationOutcome>();
+        h5.AddRange(History(ProfileFor(a5), SqlDb, "Business Critical", satisfactory: true, count: 1));
+        h5.AddRange(History(ProfileFor(a5), SqlDb, "General Purpose", satisfactory: true, count: 4));
+        scenarios.Add(new RefinementScenario(a5, h5, SqlDb, "General Purpose"));
+
+        // --- Per-scenario decision assertions (not just aggregate accuracy) ---
+        var r1 = service.Refine(a1, h1);
+        r1.ChangedFromBaseline.Should().BeTrue();
+        r1.RefinedPlatform.Should().Be(ManagedInstance);
+        r1.RefinedTier.Should().Be("Business Critical");
+
+        var r2 = service.Refine(a2, h2);
+        r2.HasRefinement.Should().BeTrue();
+        r2.ChangedFromBaseline.Should().BeFalse();
+        r2.RefinedTier.Should().Be("General Purpose");
+
+        var r3 = service.Refine(a3, h3);
+        r3.HasRefinement.Should().BeFalse();
+        r3.RefinedTier.Should().Be("Hyperscale");
+
+        var r4 = service.Refine(a4, h4);
+        r4.ChangedFromBaseline.Should().BeTrue();
+        r4.RefinedTier.Should().Be("Hyperscale");
+
+        var r5 = service.Refine(a5, h5);
+        r5.RefinedTier.Should().Be("General Purpose");
+
+        // --- Aggregate A/B comparison on the full (platform, tier) pair ---
+        var comparison = service.EvaluateAccuracy(scenarios);
+
+        comparison.ScenarioCount.Should().Be(5);
+        comparison.BaselineCorrect.Should().Be(3);  // scenarios 2, 3, 5
+        comparison.RefinedCorrect.Should().Be(5);   // all
+        comparison.BaselineAccuracy.Should().BeApproximately(0.6, 1e-9);
+        comparison.RefinedAccuracy.Should().Be(1.0);
+        comparison.RefinedImprovesOverBaseline.Should().BeTrue();
+        comparison.RefinedTierOnlyCorrect.Should().BeGreaterThanOrEqualTo(comparison.BaselineTierOnlyCorrect);
+    }
+
+    [Fact]
+    public void EvaluateAccuracy_EmptyScenarioSet_Throws()
+    {
+        var service = CreateService();
+
+        var act = () => service.EvaluateAccuracy(new List<RefinementScenario>());
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/Feedback/RecommendationRefinementServiceTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/Feedback/RecommendationRefinementServiceTests.cs
@@ -1,0 +1,330 @@
+using CosmosToSqlAssessment.Services;
+using CosmosToSqlAssessment.Services.Feedback;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CosmosToSqlAssessment.Tests.Services.Feedback;
+
+public class RecommendationRefinementServiceTests
+{
+    private const string Platform = "Azure SQL Database";
+
+    private static RecommendationRefinementService CreateService(IFeedbackStore? store = null)
+    {
+        store ??= new Mock<IFeedbackStore>().Object;
+        var feedback = new FeedbackCollectionService(
+            store,
+            new NullFeedbackTelemetrySink(),
+            new FeedbackOptions(),
+            NullLogger<FeedbackCollectionService>.Instance);
+        return new RecommendationRefinementService(feedback);
+    }
+
+    // Builds an assessment whose derived WorkloadProfile is High complexity, Large size,
+    // 10 containers, 1000 max RU — matching ComparableProfile() below.
+    private static AssessmentResult Assessment(string platform, string tier)
+    {
+        const double sizeGb = 200; // 10 GB ≤ Large < 1024 GB
+        long totalBytes = (long)(sizeGb * 1024 * 1024 * 1024);
+
+        var containers = new List<ContainerAnalysis>();
+        for (int i = 0; i < 10; i++)
+        {
+            containers.Add(new ContainerAnalysis
+            {
+                DocumentCount = 1000,
+                SizeBytes = i == 0 ? totalBytes : 0,
+                ProvisionedRUs = i == 0 ? 1000 : 0
+            });
+        }
+
+        return new AssessmentResult
+        {
+            CosmosAnalysis = new CosmosDbAnalysis { Containers = containers },
+            SqlAssessment = new SqlMigrationAssessment
+            {
+                RecommendedPlatform = platform,
+                RecommendedTier = tier,
+                Complexity = new MigrationComplexity { OverallComplexity = "High" }
+            }
+        };
+    }
+
+    private static WorkloadProfile ComparableProfile() => new()
+    {
+        ComplexityRating = MigrationComplexityRating.High,
+        SizeBucket = WorkloadSizeBucket.Large,
+        ContainerCount = 10,
+        MaxProvisionedRUs = 1000
+    };
+
+    private static MigrationOutcome Outcome(
+        string platform,
+        string tier,
+        bool satisfactory,
+        decimal estimatedMonthly = 100m,
+        decimal actualMonthly = 100m,
+        WorkloadProfile? profile = null) => new()
+    {
+        Profile = profile ?? ComparableProfile(),
+        Status = MigrationOutcomeStatus.Succeeded,
+        DeployedPlatform = platform,
+        DeployedTier = tier,
+        PerformanceSatisfactory = satisfactory,
+        EstimatedMonthlyCostUsd = estimatedMonthly,
+        ActualMonthlyCostUsd = actualMonthly
+    };
+
+    private static List<MigrationOutcome> Repeat(MigrationOutcome template, int count)
+    {
+        var list = new List<MigrationOutcome>(count);
+        for (int i = 0; i < count; i++)
+        {
+            list.Add(Outcome(
+                template.DeployedPlatform,
+                template.DeployedTier,
+                template.PerformanceSatisfactory!.Value,
+                template.EstimatedMonthlyCostUsd,
+                template.ActualMonthlyCostUsd,
+                template.Profile));
+        }
+
+        return list;
+    }
+
+    [Fact]
+    public void Refine_NoHistory_DefersToBaseline()
+    {
+        var service = CreateService();
+
+        var result = service.Refine(Assessment(Platform, "General Purpose"), new List<MigrationOutcome>());
+
+        result.HasRefinement.Should().BeFalse();
+        result.ChangedFromBaseline.Should().BeFalse();
+        result.RefinedTier.Should().Be("General Purpose");
+        result.PriorSimilarMigrationCount.Should().Be(0);
+        result.Rationale.Should().Contain("No prior migration outcomes");
+    }
+
+    [Fact]
+    public void Refine_FewerThanMinimumSimilar_DefersToBaseline()
+    {
+        var service = CreateService();
+        var prior = Repeat(Outcome(Platform, "General Purpose", satisfactory: true), 2);
+
+        var result = service.Refine(Assessment(Platform, "General Purpose"), prior);
+
+        result.HasRefinement.Should().BeFalse();
+        result.PriorSimilarMigrationCount.Should().Be(2);
+        result.Rationale.Should().Contain("comparable prior migration");
+    }
+
+    [Fact]
+    public void Refine_NoConfigMeetsCandidateFloor_DefersToBaseline()
+    {
+        var service = CreateService();
+        // Four similar outcomes but each on a distinct config (count 1 per config).
+        var prior = new List<MigrationOutcome>
+        {
+            Outcome(Platform, "General Purpose", true),
+            Outcome(Platform, "Business Critical", true),
+            Outcome(Platform, "Hyperscale", true),
+            Outcome("Azure SQL Managed Instance", "General Purpose", true)
+        };
+
+        var result = service.Refine(Assessment(Platform, "General Purpose"), prior);
+
+        result.HasRefinement.Should().BeFalse();
+        result.PriorSimilarMigrationCount.Should().Be(4);
+        result.Rationale.Should().Contain("no single deployed configuration");
+    }
+
+    [Fact]
+    public void Refine_HistorySupportsBaseline_ConfirmsWithoutChange()
+    {
+        var service = CreateService();
+        var prior = Repeat(Outcome(Platform, "General Purpose", satisfactory: true), 5);
+
+        var result = service.Refine(Assessment(Platform, "General Purpose"), prior);
+
+        result.HasRefinement.Should().BeTrue();
+        result.ChangedFromBaseline.Should().BeFalse();
+        result.RefinedTier.Should().Be("General Purpose");
+        result.Rationale.Should().Contain("support the baseline");
+    }
+
+    [Fact]
+    public void Refine_HistoryFavorsDifferentConfig_RefinesRecommendation()
+    {
+        var service = CreateService();
+        var prior = new List<MigrationOutcome>();
+        prior.AddRange(Repeat(Outcome("Azure SQL Managed Instance", "Business Critical", satisfactory: true), 6));
+        prior.AddRange(Repeat(Outcome(Platform, "General Purpose", satisfactory: false), 4));
+
+        var result = service.Refine(Assessment(Platform, "General Purpose"), prior);
+
+        result.HasRefinement.Should().BeTrue();
+        result.ChangedFromBaseline.Should().BeTrue();
+        result.RefinedPlatform.Should().Be("Azure SQL Managed Instance");
+        result.RefinedTier.Should().Be("Business Critical");
+        result.Rationale.Should().Contain("refining the baseline");
+    }
+
+    [Fact]
+    public void Refine_SmallHighSatisfactionGroup_DoesNotBeatLargerReliableGroup()
+    {
+        var service = CreateService();
+        var prior = new List<MigrationOutcome>();
+        // Tiny perfect group (3/3) vs larger reliable group (7/8). Wilson lower bound favors the larger.
+        prior.AddRange(Repeat(Outcome(Platform, "Business Critical", satisfactory: true), 3));
+        prior.AddRange(Repeat(Outcome(Platform, "General Purpose", satisfactory: true), 7));
+        prior.Add(Outcome(Platform, "General Purpose", satisfactory: false));
+
+        // Baseline is intentionally neither, so a tie-break can't mask the ranking.
+        var result = service.Refine(Assessment(Platform, "Hyperscale"), prior);
+
+        result.HasRefinement.Should().BeTrue();
+        result.RefinedTier.Should().Be("General Purpose");
+    }
+
+    [Fact]
+    public void Refine_TieBetweenConfigs_FavorsBaseline()
+    {
+        var service = CreateService();
+        var prior = new List<MigrationOutcome>();
+        prior.AddRange(Repeat(Outcome(Platform, "General Purpose", satisfactory: true), 4));
+        prior.AddRange(Repeat(Outcome(Platform, "Business Critical", satisfactory: true), 4));
+
+        var result = service.Refine(Assessment(Platform, "General Purpose"), prior);
+
+        result.HasRefinement.Should().BeTrue();
+        result.ChangedFromBaseline.Should().BeFalse();
+        result.RefinedTier.Should().Be("General Purpose");
+    }
+
+    [Fact]
+    public void Refine_LargeConsistentHistory_YieldsHighConfidence()
+    {
+        var service = CreateService();
+        var prior = Repeat(Outcome(Platform, "General Purpose", satisfactory: true), 8);
+
+        var result = service.Refine(Assessment(Platform, "General Purpose"), prior);
+
+        result.Confidence.Should().Be(RefinementConfidence.High);
+        result.ObservedSatisfactionRate.Should().Be(1.0);
+    }
+
+    [Fact]
+    public void Refine_ModerateHistory_YieldsMediumConfidence()
+    {
+        var service = CreateService();
+        var prior = new List<MigrationOutcome>();
+        prior.AddRange(Repeat(Outcome(Platform, "General Purpose", satisfactory: true), 4));
+        prior.Add(Outcome(Platform, "General Purpose", satisfactory: false));
+
+        var result = service.Refine(Assessment(Platform, "General Purpose"), prior);
+
+        result.Confidence.Should().Be(RefinementConfidence.Medium);
+    }
+
+    [Fact]
+    public void Refine_MinimalHistory_YieldsLowConfidence()
+    {
+        var service = CreateService();
+        var prior = new List<MigrationOutcome>
+        {
+            Outcome(Platform, "General Purpose", true),
+            Outcome(Platform, "General Purpose", true),
+            Outcome(Platform, "General Purpose", false)
+        };
+
+        var result = service.Refine(Assessment(Platform, "General Purpose"), prior);
+
+        result.HasRefinement.Should().BeTrue();
+        result.Confidence.Should().Be(RefinementConfidence.Low);
+    }
+
+    [Fact]
+    public void Refine_ExcludesFailedAndUnassessedOutcomes()
+    {
+        var service = CreateService();
+        var prior = new List<MigrationOutcome>
+        {
+            // Failed migration — excluded even though deployed config is present.
+            new()
+            {
+                Profile = ComparableProfile(),
+                Status = MigrationOutcomeStatus.Failed,
+                DeployedPlatform = Platform,
+                DeployedTier = "General Purpose",
+                PerformanceSatisfactory = true
+            },
+            // No performance signal — excluded.
+            new()
+            {
+                Profile = ComparableProfile(),
+                Status = MigrationOutcomeStatus.Succeeded,
+                DeployedPlatform = Platform,
+                DeployedTier = "General Purpose",
+                PerformanceSatisfactory = null
+            }
+        };
+
+        var result = service.Refine(Assessment(Platform, "General Purpose"), prior);
+
+        result.HasRefinement.Should().BeFalse();
+        result.PriorSimilarMigrationCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void Refine_IncludesCostVarianceInRationale()
+    {
+        var service = CreateService();
+        var prior = Repeat(Outcome(Platform, "General Purpose", satisfactory: true, estimatedMonthly: 100m, actualMonthly: 130m), 5);
+
+        var result = service.Refine(Assessment(Platform, "General Purpose"), prior);
+
+        result.AverageMonthlyCostVariancePercent.Should().BeApproximately(30.0, 1e-6);
+        result.Rationale.Should().Contain("above estimate");
+    }
+
+    [Fact]
+    public async Task RefineAsync_ReadsOutcomesFromStore()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "cosmos2sql-refine-tests", Guid.NewGuid().ToString("N"));
+        var storePath = Path.Combine(tempDir, "outcomes.jsonl");
+        try
+        {
+            var store = new LocalJsonFeedbackStore(
+                new FeedbackOptions { StorePath = storePath }, NullLogger<LocalJsonFeedbackStore>.Instance);
+            foreach (var outcome in Repeat(Outcome(Platform, "General Purpose", satisfactory: true), 5))
+            {
+                await store.AppendAsync(outcome);
+            }
+
+            var service = CreateService(store);
+
+            var result = await service.RefineAsync(Assessment(Platform, "General Purpose"));
+
+            result.HasRefinement.Should().BeTrue();
+            result.PriorSimilarMigrationCount.Should().Be(5);
+            result.RefinedTier.Should().Be("General Purpose");
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task RefineAsync_NullAssessment_Throws()
+    {
+        var service = CreateService();
+
+        var act = () => service.RefineAsync(null!);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/Feedback/WorkloadSimilarityTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/Feedback/WorkloadSimilarityTests.cs
@@ -1,0 +1,90 @@
+using CosmosToSqlAssessment.Services;
+
+namespace CosmosToSqlAssessment.Tests.Services.Feedback;
+
+public class WorkloadSimilarityTests
+{
+    private static WorkloadProfile Profile(
+        MigrationComplexityRating complexity,
+        WorkloadSizeBucket size,
+        int containers,
+        int maxRu) => new()
+    {
+        ComplexityRating = complexity,
+        SizeBucket = size,
+        ContainerCount = containers,
+        MaxProvisionedRUs = maxRu
+    };
+
+    [Fact]
+    public void Score_IdenticalProfiles_IsOne()
+    {
+        var p = Profile(MigrationComplexityRating.High, WorkloadSizeBucket.Large, 10, 1000);
+
+        WorkloadSimilarity.Score(p, p).Should().Be(1.0);
+    }
+
+    [Fact]
+    public void Score_SameComplexityAndSize_ExceedsThresholdRegardlessOfCounts()
+    {
+        var a = Profile(MigrationComplexityRating.High, WorkloadSizeBucket.Large, 10, 1000);
+        var b = Profile(MigrationComplexityRating.High, WorkloadSizeBucket.Large, 1, 1);
+
+        // 0.35 (complexity) + 0.35 (size) alone clear the 0.6 threshold.
+        WorkloadSimilarity.Score(a, b).Should().BeGreaterThanOrEqualTo(0.6);
+        WorkloadSimilarity.AreComparable(a, b).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Score_DifferentComplexityAndSize_IsNotComparable()
+    {
+        var a = Profile(MigrationComplexityRating.High, WorkloadSizeBucket.Large, 10, 1000);
+        var b = Profile(MigrationComplexityRating.Low, WorkloadSizeBucket.Small, 1, 50);
+
+        WorkloadSimilarity.AreComparable(a, b).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Score_AdjacentComplexity_StaysComparable()
+    {
+        var a = Profile(MigrationComplexityRating.High, WorkloadSizeBucket.Large, 10, 1000);
+        var b = Profile(MigrationComplexityRating.Medium, WorkloadSizeBucket.Large, 10, 1000);
+
+        WorkloadSimilarity.AreComparable(a, b).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Score_UnknownComplexity_IsTreatedAsNeutral()
+    {
+        var a = Profile(MigrationComplexityRating.High, WorkloadSizeBucket.Large, 10, 1000);
+        var b = Profile(MigrationComplexityRating.Unknown, WorkloadSizeBucket.Large, 10, 1000);
+
+        // 0.35*0.5 (neutral complexity) + 0.35 (size) + 0.15 + 0.15 = 0.825
+        WorkloadSimilarity.Score(a, b).Should().BeApproximately(0.825, 1e-9);
+    }
+
+    [Fact]
+    public void Score_ZeroProvisionedRus_TreatedAsUnknownNotPenalized()
+    {
+        var a = Profile(MigrationComplexityRating.High, WorkloadSizeBucket.Large, 10, 1000);
+        var withRu = Profile(MigrationComplexityRating.High, WorkloadSizeBucket.Large, 10, 1000);
+        var zeroRu = Profile(MigrationComplexityRating.High, WorkloadSizeBucket.Large, 10, 0);
+
+        var fullScore = WorkloadSimilarity.Score(a, withRu);
+        var zeroScore = WorkloadSimilarity.Score(a, zeroRu);
+
+        // Unknown RU costs only half of the throughput weight (0.15 * 0.5 = 0.075), not all of it.
+        fullScore.Should().Be(1.0);
+        zeroScore.Should().BeApproximately(0.925, 1e-9);
+    }
+
+    [Fact]
+    public void Score_NullProfile_Throws()
+    {
+        var p = Profile(MigrationComplexityRating.High, WorkloadSizeBucket.Large, 10, 1000);
+
+        var act = () => WorkloadSimilarity.Score(p, null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
Closes #132Enables the tool to learn from past migration outcomes and refine future recommendations. Collects **anonymized, aggregate** post-migration metrics **only when the user opts in**, correlates them with the original assessment inputs, and surfaces "based on N prior similar migrations" rationale in the generated reports.## Sub-issues- [x] #218 Define migration outcome schema (success metrics, performance metrics, cost actual vs estimate)- [x] #219 Build opt-in feedback collection mechanism (local file or optional telemetry endpoint)- [x] #220 Implement recommendation refinement logic (correlate outcomes with assessment inputs)- [x] #221 Surface "based on prior migrations" rationale in generated reports- [x] #222 Document opt-in / opt-out and privacy implications## Implementation approach- **#218 — `Models/MigrationOutcome.cs`**: anonymized/aggregate schema. `MigrationOutcome` (success / performance / cost-actual-vs-estimate metrics) + `WorkloadProfile` similarity fingerprint + `MigrationOutcomeStatus` / `MigrationComplexityRating` / `WorkloadSizeBucket` enums. No PII, no free-text fields (the only string properties are a fixed allow-list of tool-generated labels, enforced by a reflection test). Derived properties are `[JsonIgnore]`; explicit serialized `SchemaVersion` for forward-compat.- **#219 — opt-in collection layer**: `FeedbackCollectionService` + `LocalJsonFeedbackStore` (append-only JSONL) + optional coarsened `HttpFeedbackTelemetrySink`. Consent is default-OFF with precedence env opt-out (absolute) > `--enable-feedback`/`--disable-feedback` > `FeedbackLoop:Enabled` config > `COSMOS2SQL_FEEDBACK_OPTIN` > deny. DI registrations kept alongside siblings; orchestrator prints a transparent consent notice.## Testing- **#218**: `tests/.../Models/MigrationOutcomeTests.cs` — defaults, derived cost variance (incl. divide-by-zero → null), `Succeeded` mapping, `BucketFor` boundaries, `ParseComplexity`, `FromAssessment` projection, JSON round-trip, and the no-unapproved-string-fields privacy contract. Full suite: **747 passing** (717 baseline + 30 new).
- **#220 — `RecommendationRefinementService`**: `WorkloadSimilarity` scoring + `Refine` (Wilson-lower-bound ranking, per-candidate sample floor, baseline-favoring tie-breaks, confirm-vs-refine rationale) + `RefineAsync` over `GetOutcomesAsync`. `RecommendationRefinement` model. A/B via `EvaluateAccuracy` on the full (platform, tier) pair. Scoped DI registration.- **#219**: `tests/.../Services/Feedback/*` — consent-resolution matrix, JSONL store round-trip/concurrency/malformed-line resilience, coarsening bucket boundaries, service no-op-when-denied / records-when-granted / telemetry-only-when-endpoint, HTTP sink via stub handler, and CLI flag parse/validate/help. Full suite: **808 passing**.
- **#220**: `tests/.../Services/Feedback/{WorkloadSimilarity,RecommendationRefinementService,RecommendationRefinementAbComparison}Tests` — similarity boundaries; Refine no-history/insufficient/per-candidate-floor/confirm/refine/Wilson-ranking/tie-break/confidence/exclusions/cost-rationale; RefineAsync over a real store; and a non-circular A/B fixture proving **refined accuracy 1.0 > baseline 0.6**. Full suite: **831 passing**.## Branch-protection changesNone anticipated.## Privacy / acceptance guardrails- Feedback collection is **opt-in only**, default OFF, with a clear consent flow.- **No PII or customer data** collected — schema is anonymized/aggregate by construction.- Refined recommendations include rationale ("based on N prior similar migrations").- A/B comparison demonstrating refined > baseline provided via tests.- Privacy policy section added to `docs/feedback-loop.md`.

