### PR TITLE
Parent #69: Add incremental migration support with change feed

### DIFF
--- a/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/DependencyInjection/ServiceCollectionExtensions.cs
@@ -57,6 +57,7 @@ namespace CosmosToSqlAssessment.DependencyInjection
             // Cosmos analysis; consumed by the orchestrator after the core assessment.
             services.AddScoped<ChangeFeedAvailabilityAnalyzer>();
             services.AddScoped<IncrementalSyncEstimator>();
+            services.AddScoped<CutoverWindowCalculator>();
 
             // SQL Project services
             services.AddScoped<SqlDatabaseProjectService>();

--- a/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/DependencyInjection/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using CosmosToSqlAssessment.Services.DataFactory;
 using CosmosToSqlAssessment.Services.Discovery;
 using CosmosToSqlAssessment.Services.Feedback;
 using CosmosToSqlAssessment.Services.Monitoring;
+using CosmosToSqlAssessment.Services.Migration;
 using CosmosToSqlAssessment.SqlProject;
 using System.Net.Http;
 
@@ -51,6 +52,10 @@ namespace CosmosToSqlAssessment.DependencyInjection
             services.AddScoped<DataFactoryEstimateService>();
             services.AddScoped<DataQualityAnalysisService>();
             services.AddScoped<ReportGenerationService>();
+
+            // Incremental change-feed migration analysis (parent #69). Pure services over the collected
+            // Cosmos analysis; consumed by the orchestrator after the core assessment.
+            services.AddScoped<ChangeFeedAvailabilityAnalyzer>();
 
             // SQL Project services
             services.AddScoped<SqlDatabaseProjectService>();

--- a/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/DependencyInjection/ServiceCollectionExtensions.cs
@@ -58,6 +58,7 @@ namespace CosmosToSqlAssessment.DependencyInjection
             services.AddScoped<ChangeFeedAvailabilityAnalyzer>();
             services.AddScoped<IncrementalSyncEstimator>();
             services.AddScoped<CutoverWindowCalculator>();
+            services.AddScoped<PhasedMigrationPlanGenerator>();
 
             // SQL Project services
             services.AddScoped<SqlDatabaseProjectService>();

--- a/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/DependencyInjection/ServiceCollectionExtensions.cs
@@ -59,6 +59,7 @@ namespace CosmosToSqlAssessment.DependencyInjection
             services.AddScoped<IncrementalSyncEstimator>();
             services.AddScoped<CutoverWindowCalculator>();
             services.AddScoped<PhasedMigrationPlanGenerator>();
+            services.AddScoped<TimeBasedPartitioningAnalyzer>();
 
             // SQL Project services
             services.AddScoped<SqlDatabaseProjectService>();

--- a/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/DependencyInjection/ServiceCollectionExtensions.cs
@@ -56,6 +56,7 @@ namespace CosmosToSqlAssessment.DependencyInjection
             // Incremental change-feed migration analysis (parent #69). Pure services over the collected
             // Cosmos analysis; consumed by the orchestrator after the core assessment.
             services.AddScoped<ChangeFeedAvailabilityAnalyzer>();
+            services.AddScoped<IncrementalSyncEstimator>();
 
             // SQL Project services
             services.AddScoped<SqlDatabaseProjectService>();

--- a/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/DependencyInjection/ServiceCollectionExtensions.cs
@@ -60,6 +60,7 @@ namespace CosmosToSqlAssessment.DependencyInjection
             services.AddScoped<CutoverWindowCalculator>();
             services.AddScoped<PhasedMigrationPlanGenerator>();
             services.AddScoped<TimeBasedPartitioningAnalyzer>();
+            services.AddScoped<ChangeFeedProcessorGuidanceGenerator>();
 
             // SQL Project services
             services.AddScoped<SqlDatabaseProjectService>();

--- a/Models/CosmosModels.cs
+++ b/Models/CosmosModels.cs
@@ -22,6 +22,8 @@ namespace CosmosToSqlAssessment.Models
         public DataFactoryEstimate DataFactoryEstimate { get; set; } = new();
         /// <summary>Optional data-quality analysis results; null when the analysis was skipped or unavailable.</summary>
         public DataQualityAnalysis? DataQualityAnalysis { get; set; } = null;
+        /// <summary>Optional incremental (change-feed) migration analysis; null when the analysis was skipped or unavailable.</summary>
+        public Migration.IncrementalMigrationAnalysis? IncrementalMigration { get; set; } = null;
         /// <summary>Ordered list of actionable recommendations produced by the assessment engine.</summary>
         public List<RecommendationItem> Recommendations { get; set; } = new();
 
@@ -103,6 +105,29 @@ namespace CosmosToSqlAssessment.Models
         public ContainerIndexingPolicy IndexingPolicy { get; set; } = new();
         /// <summary>Container-scoped performance metrics collected during the analysis window.</summary>
         public ContainerPerformanceMetrics Performance { get; set; } = new();
+
+        /// <summary>
+        /// Raw container <c>DefaultTimeToLive</c>: <c>null</c> = TTL disabled, <c>-1</c> = enabled with no
+        /// container default (item-level TTL only), <c>&gt;0</c> = default expiration in seconds. Used by the
+        /// change feed availability analysis (#134) to reason about server-side TTL deletes.
+        /// </summary>
+        public int? DefaultTimeToLiveSeconds { get; set; }
+
+        /// <summary>Custom TTL property path when the container expires items by a property other than <c>_ts</c>.</summary>
+        public string? TimeToLivePropertyPath { get; set; }
+
+        /// <summary>
+        /// Full set of partition-key paths. Contains more than one entry for hierarchical (sub-)partition
+        /// keys; falls back to the single <see cref="PartitionKey"/> path for classic keys.
+        /// </summary>
+        public List<string> PartitionKeyPaths { get; set; } = new();
+
+        /// <summary>
+        /// Approximate number of feed ranges (physical partitions), captured during live analysis via
+        /// <c>GetFeedRangesAsync</c>. Drives change feed processor lease sizing (#140) and incremental-sync
+        /// parallelism (#135). <c>0</c> when the value could not be read.
+        /// </summary>
+        public int FeedRangeCount { get; set; }
     }
 
     /// <summary>

--- a/Models/Migration/ChangeFeedModels.cs
+++ b/Models/Migration/ChangeFeedModels.cs
@@ -1,0 +1,161 @@
+namespace CosmosToSqlAssessment.Models.Migration
+{
+    /// <summary>
+    /// The Azure Cosmos DB change feed read mode used to drive incremental synchronization.
+    /// </summary>
+    public enum ChangeFeedMode
+    {
+        /// <summary>
+        /// Latest-version (formerly "incremental") mode. Emits the most recent version of each
+        /// created or updated item. Always available on the SQL (Core) API. Does <b>not</b> emit
+        /// delete or intermediate-version events.
+        /// </summary>
+        LatestVersion,
+
+        /// <summary>
+        /// All-versions-and-deletes (formerly "full fidelity") mode. Emits every version of an item
+        /// plus delete tombstones, but only within the container's configured retention window.
+        /// Requires an explicit container <c>ChangeFeedPolicy</c> retention configuration that is not
+        /// readable through the public .NET SDK metadata.
+        /// </summary>
+        AllVersionsAndDeletes
+    }
+
+    /// <summary>
+    /// Describes how confidently a given change feed mode's availability can be determined from the
+    /// metadata the assessment tool can read.
+    /// </summary>
+    public enum ChangeFeedModeAvailability
+    {
+        /// <summary>The mode is guaranteed available for the container (e.g. latest-version on the SQL API).</summary>
+        Available,
+
+        /// <summary>
+        /// Availability cannot be determined from the public SDK metadata and must be verified manually
+        /// against the account/container configuration (e.g. all-versions-and-deletes retention).
+        /// </summary>
+        RequiresManualVerification
+    }
+
+    /// <summary>
+    /// Per-container assessment of change feed readiness for incremental migration. Derived purely from
+    /// the already-collected <see cref="ContainerAnalysis"/>; it performs no live Cosmos DB calls.
+    /// </summary>
+    public sealed class ContainerChangeFeedReadiness
+    {
+        /// <summary>Name of the Cosmos DB container this readiness record describes.</summary>
+        public string ContainerName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Whether the latest-version change feed is available. Always <c>true</c> for SQL (Core) API
+        /// containers; included explicitly so reports can state it unambiguously.
+        /// </summary>
+        public bool LatestVersionChangeFeedAvailable { get; set; } = true;
+
+        /// <summary>
+        /// Detectability of all-versions-and-deletes mode. The public SDK does not expose the
+        /// container <c>ChangeFeedPolicy</c>/retention, so this is
+        /// <see cref="ChangeFeedModeAvailability.RequiresManualVerification"/>.
+        /// </summary>
+        public ChangeFeedModeAvailability AllVersionsAndDeletesAvailability { get; set; }
+            = ChangeFeedModeAvailability.RequiresManualVerification;
+
+        /// <summary>
+        /// Whether time-to-live (TTL) is enabled on the container at all
+        /// (<c>DefaultTimeToLive</c> has a value, whether <c>-1</c> or a positive default).
+        /// </summary>
+        public bool TimeToLiveEnabled { get; set; }
+
+        /// <summary>
+        /// Whether a positive default TTL expiration is active (<c>DefaultTimeToLive &gt; 0</c>), meaning
+        /// items expire automatically after the default number of seconds unless overridden per item.
+        /// </summary>
+        public bool DefaultTtlExpirationEnabled { get; set; }
+
+        /// <summary>
+        /// Whether only item-level TTL is possible (<c>DefaultTimeToLive == -1</c>): TTL is enabled but
+        /// no container default applies, so individual items may still set their own expiration.
+        /// </summary>
+        public bool ItemLevelTtlPossible { get; set; }
+
+        /// <summary>
+        /// Raw <c>DefaultTimeToLive</c> value preserved for downstream reasoning:
+        /// <c>null</c> = TTL disabled, <c>-1</c> = enabled with no default, <c>&gt;0</c> = default seconds.
+        /// </summary>
+        public int? DefaultTimeToLiveSeconds { get; set; }
+
+        /// <summary>The custom TTL property path, when the container expires items by a property other than <c>_ts</c>.</summary>
+        public string? TimeToLivePropertyPath { get; set; }
+
+        /// <summary>The container's partition-key path(s). Contains more than one entry for hierarchical (sub-)partition keys.</summary>
+        public IReadOnlyList<string> PartitionKeyPaths { get; set; } = new List<string>();
+
+        /// <summary>Number of partition-key paths (1 for a classic single-level key, &gt;1 for hierarchical keys).</summary>
+        public int PartitionKeyPathCount { get; set; }
+
+        /// <summary>Whether the container uses a hierarchical (multi-level) partition key.</summary>
+        public bool IsHierarchicalPartitionKey { get; set; }
+
+        /// <summary>
+        /// Approximate number of feed ranges (physical partitions) for the container, captured during
+        /// live analysis via <c>GetFeedRangesAsync</c>. Feeds change feed processor lease sizing and the
+        /// incremental-sync parallelism estimate. <c>0</c> when the value could not be read.
+        /// </summary>
+        public int FeedRangeCount { get; set; }
+
+        /// <summary>
+        /// Whether deletes propagate to the SQL target through the recommended latest-version feed.
+        /// Always <c>false</c>: the latest-version change feed never emits delete events.
+        /// </summary>
+        public bool DeletePropagationSupportedByLatestVersion { get; set; }
+
+        /// <summary>
+        /// Whether the container has a known source of server-side deletes (TTL expiration) that the
+        /// latest-version change feed will not surface.
+        /// </summary>
+        public bool KnownServerSideTtlDeletes { get; set; }
+
+        /// <summary>
+        /// Whether delete handling must be validated/designed externally before cutover (always <c>true</c>:
+        /// even without TTL, application hard deletes are invisible to the latest-version change feed).
+        /// </summary>
+        public bool RequiresDeleteHandlingValidation { get; set; } = true;
+
+        /// <summary>The change feed mode recommended for this container's incremental sync.</summary>
+        public ChangeFeedMode RecommendedMode { get; set; } = ChangeFeedMode.LatestVersion;
+
+        /// <summary>Actionable warnings about change feed limitations for this container (e.g. TTL delete gaps).</summary>
+        public List<string> Warnings { get; set; } = new();
+
+        /// <summary>Informational notes about change feed behavior for this container.</summary>
+        public List<string> Notes { get; set; } = new();
+    }
+
+    /// <summary>
+    /// Database-level aggregation of per-container change feed readiness used to ground the incremental
+    /// migration plan, sync estimates, and cutover/runbook documentation.
+    /// </summary>
+    public sealed class ChangeFeedAvailabilityAnalysis
+    {
+        /// <summary>Per-container change feed readiness records.</summary>
+        public List<ContainerChangeFeedReadiness> Containers { get; set; } = new();
+
+        /// <summary>
+        /// Whether every container supports latest-version change feed incremental sync of creates/updates.
+        /// True for SQL (Core) API databases; surfaced explicitly for report clarity.
+        /// </summary>
+        public bool AllContainersSupportLatestVersionIncrementalSync { get; set; } = true;
+
+        /// <summary>Whether any container has a known server-side delete source (TTL expiration).</summary>
+        public bool AnyContainerHasKnownServerSideDeletes { get; set; }
+
+        /// <summary>
+        /// Whether delete propagation requires an external validation/design step. Always <c>true</c>
+        /// because the latest-version change feed never emits hard deletes.
+        /// </summary>
+        public bool DeletePropagationRequiresExternalValidation { get; set; } = true;
+
+        /// <summary>Database-wide warnings about change feed limitations and verification requirements.</summary>
+        public List<string> GlobalWarnings { get; set; } = new();
+    }
+}

--- a/Models/Migration/ChangeFeedProcessorModels.cs
+++ b/Models/Migration/ChangeFeedProcessorModels.cs
@@ -1,0 +1,146 @@
+namespace CosmosToSqlAssessment.Models.Migration
+{
+    /// <summary>
+    /// Checkpointing strategy recommended for a Change Feed Processor (CFP) worker (#140 of parent #69).
+    /// The change feed processor delivers changes <b>at least once</b>, so downstream processing must be
+    /// idempotent regardless of the strategy chosen.
+    /// </summary>
+    public enum CheckpointStrategy
+    {
+        /// <summary>
+        /// The CFP automatically checkpoints after each successfully processed batch (the default). Simple
+        /// and resilient; on a host restart/rebalance the last uncheckpointed batch is redelivered.
+        /// </summary>
+        AutomaticPerBatch,
+
+        /// <summary>
+        /// The delegate checkpoints manually to gain finer control over the at-least-once boundary (for
+        /// example checkpointing only after the SQL upsert/MERGE commits). Reduces duplicate reprocessing
+        /// at the cost of additional implementation complexity.
+        /// </summary>
+        ManualForAtLeastOnceControl
+    }
+
+    /// <summary>
+    /// Per-container Change Feed Processor implementation guidance (#140). Derived purely from the #134
+    /// <see cref="ContainerChangeFeedReadiness"/>; performs no live Cosmos DB calls.
+    /// </summary>
+    public sealed class ContainerChangeFeedProcessorGuidance
+    {
+        /// <summary>Name of the Cosmos DB container the guidance applies to.</summary>
+        public string ContainerName { get; set; } = string.Empty;
+
+        /// <summary>The change feed mode recommended for this container (from the #134 readiness analysis).</summary>
+        public ChangeFeedMode RecommendedMode { get; set; } = ChangeFeedMode.LatestVersion;
+
+        /// <summary>
+        /// Approximate feed-range (physical-partition) count for the container, captured during analysis.
+        /// <c>0</c> when the value could not be read; see <see cref="FeedRangeCountKnown"/>.
+        /// </summary>
+        public int FeedRangeCount { get; set; }
+
+        /// <summary>Whether <see cref="FeedRangeCount"/> is a known value (greater than zero) rather than unreadable.</summary>
+        public bool FeedRangeCountKnown { get; set; }
+
+        /// <summary>
+        /// Upper bound on the number of compute instances that can usefully process this container's change
+        /// feed in parallel (one lease per feed range). <c>null</c> when the feed-range count is unknown.
+        /// This is a runtime-varying ceiling (partition split/merge), not a guaranteed degree of parallelism.
+        /// </summary>
+        public int? MaxUsefulComputeInstances { get; set; }
+
+        /// <summary>
+        /// Whether the recommended mode requires the account to have continuous backup enabled. Always
+        /// <c>true</c> for <see cref="ChangeFeedMode.AllVersionsAndDeletes"/>; otherwise <c>false</c>.
+        /// </summary>
+        public bool RequiresContinuousBackup { get; set; }
+
+        /// <summary>
+        /// Whether this container's processor needs isolated lease state — a dedicated lease container or, at
+        /// minimum, a distinct processor name / lease prefix. Always <c>true</c> for all-versions-and-deletes
+        /// (its checkpoint state must never be shared with a latest-version processor).
+        /// </summary>
+        public bool RequiresIsolatedLeaseState { get; set; }
+
+        /// <summary>Note describing how deletes must be handled for this container under the recommended mode.</summary>
+        public string DeleteHandlingNote { get; set; } = string.Empty;
+
+        /// <summary>Additional informational notes for this container's processor guidance.</summary>
+        public List<string> Notes { get; set; } = new();
+    }
+
+    /// <summary>
+    /// Database-level Change Feed Processor (CFP) implementation guidance (#140 of parent #69). Produced from
+    /// the #134 change-feed availability analysis, it advises on building a CFP worker as an alternative (or
+    /// complement) to the Azure Data Factory <c>_ts</c>-watermark incremental copy pipeline this tool also
+    /// generates. All figures are conservative planning guidance, not validated sizing — monitor and adjust.
+    /// </summary>
+    public sealed class ChangeFeedProcessorGuidance
+    {
+        /// <summary>Recommended name for the dedicated lease container.</summary>
+        public string RecommendedLeaseContainerName { get; set; } = "leases";
+
+        /// <summary>Recommended partition-key path for the lease container.</summary>
+        public string LeaseContainerPartitionKeyPath { get; set; } = "/id";
+
+        /// <summary>
+        /// A conservative <b>starting</b> throughput (RU/s, expressed as an autoscale maximum) for the lease
+        /// container — not validated sizing. Lease workload is driven mostly by checkpoint frequency, lease
+        /// renew/acquire cadence, failovers, and lease count; monitor for throttling (429s) and adjust.
+        /// </summary>
+        public int SuggestedLeaseContainerStartingRUs { get; set; }
+
+        /// <summary>Whether the lease-container throughput is recommended to use autoscale (its RU value is the autoscale maximum).</summary>
+        public bool LeaseContainerUsesAutoscale { get; set; } = true;
+
+        /// <summary>The checkpointing strategy recommended for the worker.</summary>
+        public CheckpointStrategy CheckpointStrategy { get; set; } = CheckpointStrategy.AutomaticPerBatch;
+
+        /// <summary>Note describing the at-least-once delivery / idempotency implication of the checkpoint strategy.</summary>
+        public string CheckpointingNote { get; set; } = string.Empty;
+
+        /// <summary>Recommended number of compute instances to start with (kept deliberately small; scale out on evidence).</summary>
+        public int RecommendedInitialComputeInstances { get; set; } = 1;
+
+        /// <summary>
+        /// Useful scale-out ceiling when a single worker fleet runs the processors for all containers: the
+        /// largest single-container feed-range count (a host can run multiple containers' processors).
+        /// <c>null</c> when no container has a known feed-range count.
+        /// </summary>
+        public int? ComputeScaleOutCeilingSharedFleet { get; set; }
+
+        /// <summary>
+        /// Useful scale-out ceiling when each container is processed by an independent worker pool: the sum of
+        /// the per-container feed-range counts. <c>null</c> when no container has a known feed-range count.
+        /// </summary>
+        public int? ComputeScaleOutCeilingIndependentPools { get; set; }
+
+        /// <summary>Guidance on what to scale on (and up to which ceiling).</summary>
+        public string ScaleOutTrigger { get; set; } = string.Empty;
+
+        /// <summary>Whether any container is recommended to use all-versions-and-deletes mode.</summary>
+        public bool AnyContainerRequiresAllVersionsAndDeletes { get; set; }
+
+        /// <summary>Whether the account must have continuous backup enabled (true when any container needs all-versions-and-deletes).</summary>
+        public bool RequiresContinuousBackupForDeletes { get; set; }
+
+        /// <summary>Per-container processor guidance.</summary>
+        public List<ContainerChangeFeedProcessorGuidance> Containers { get; set; } = new();
+
+        /// <summary>Ordered, actionable implementation steps for standing up the CFP worker.</summary>
+        public List<string> ImplementationSteps { get; set; } = new();
+
+        /// <summary>The explicit assumptions behind this guidance.</summary>
+        public List<string> Assumptions { get; set; } = new();
+
+        /// <summary>Warnings and caveats that qualify the guidance.</summary>
+        public List<string> Warnings { get; set; } = new();
+
+        /// <summary>
+        /// How a Change Feed Processor worker relates to the Azure Data Factory <c>_ts</c>-watermark
+        /// incremental copy pipeline this tool also generates: the trade-offs and the rule that both must
+        /// not write the same SQL target without idempotency and duplicate-boundary handling.
+        /// </summary>
+        public List<string> RelationshipToDataFactoryWatermarkPipeline { get; set; } = new();
+    }
+}

--- a/Models/Migration/CutoverModels.cs
+++ b/Models/Migration/CutoverModels.cs
@@ -1,0 +1,161 @@
+namespace CosmosToSqlAssessment.Models.Migration
+{
+    /// <summary>
+    /// Whether the estimated cutover downtime window can be bounded with the available estimates (#136).
+    /// </summary>
+    public enum CutoverFeasibility
+    {
+        /// <summary>Feasibility could not be determined (e.g. no containers analyzed with indeterminate scope).</summary>
+        Unknown,
+
+        /// <summary>Every container's residual backlog can be drained at the estimated capacity ⇒ a bounded downtime window exists.</summary>
+        Feasible,
+
+        /// <summary>
+        /// At least one container has unbounded pre-cutover lag (steady-state unsustainable) or unknown
+        /// incremental capacity, so the final-sync drain — and therefore the full window — cannot be bounded
+        /// until zero lag is achieved before cutover. The fixed-overhead floor is still known.
+        /// </summary>
+        RequiresPreCutoverCatchUp
+    }
+
+    /// <summary>
+    /// Risk band for the estimated cutover downtime window, assessed relative to a configurable target
+    /// downtime (RTO). Derived from the estimated total downtime versus <c>CutoverTargetDowntimeMinutes</c>.
+    /// </summary>
+    public enum CutoverDowntimeRisk
+    {
+        /// <summary>The downtime window could not be bounded (pre-cutover catch-up required).</summary>
+        Unknown,
+
+        /// <summary>Estimated downtime is within the target downtime.</summary>
+        Low,
+
+        /// <summary>Estimated downtime is above target but within twice the target.</summary>
+        Moderate,
+
+        /// <summary>Estimated downtime exceeds twice the target downtime.</summary>
+        High
+    }
+
+    /// <summary>
+    /// Per-container contribution to the cutover downtime window (#136): the residual change-feed backlog
+    /// expected at the moment the source is quiesced and the time to drain it at the estimated capacity.
+    /// All figures are heuristic planning estimates, not guaranteed SLAs.
+    /// </summary>
+    public sealed class ContainerCutoverEstimate
+    {
+        /// <summary>Source container name.</summary>
+        public string ContainerName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Estimated residual backlog (documents) accumulated since the last completed sync checkpoint —
+        /// the worst-case churn over one steady-state sync lag. Excludes any pre-existing unbounded lag.
+        /// </summary>
+        public long ResidualBacklogDocuments { get; set; }
+
+        /// <summary>Estimated incremental drain capacity in documents per second (from the #135 sync estimate).</summary>
+        public double DrainCapacityDocsPerSecond { get; set; }
+
+        /// <summary>
+        /// Estimated time to drain <see cref="ResidualBacklogDocuments"/> at <see cref="DrainCapacityDocsPerSecond"/>
+        /// once the source is quiesced. <c>null</c> when the drain cannot be bounded (see <see cref="DrainBounded"/>).
+        /// </summary>
+        public TimeSpan? ResidualDrainDuration { get; set; }
+
+        /// <summary>
+        /// Whether the residual drain is bounded. <c>false</c> when the container's steady-state sync is
+        /// unsustainable (pre-cutover lag grows without bound) or its incremental capacity is unknown.
+        /// </summary>
+        public bool DrainBounded { get; set; }
+
+        /// <summary>Informational notes / remediation callouts for this container's cutover contribution.</summary>
+        public List<string> Notes { get; set; } = new();
+    }
+
+    /// <summary>
+    /// Estimated cutover downtime window for an online (change-feed-based) migration (#136). Models the
+    /// final maintenance window during which the source is quiesced (read-only): quiesce overhead, final
+    /// delta-sync drain of the residual change-feed backlog, data validation, connection switchover, plus
+    /// a safety buffer. Consumes the #135 <see cref="IncrementalSyncEstimate"/>. Grounds the phased plan
+    /// (#137) and report runbook (#139).
+    /// </summary>
+    public sealed class CutoverWindowEstimate
+    {
+        /// <summary>Fixed time to quiesce the application / place the source in read-only mode.</summary>
+        public TimeSpan AppQuiesceDuration { get; set; }
+
+        /// <summary>
+        /// Estimated time to drain the residual change-feed backlog to zero after quiesce, blended between
+        /// the fully-parallel and fully-contended bounds by the configured drain parallelism. <c>null</c>
+        /// when any container's drain is unbounded (pre-cutover catch-up required).
+        /// </summary>
+        public TimeSpan? FinalSyncDrainDuration { get; set; }
+
+        /// <summary>
+        /// Best-case drain assuming every container drains independently in parallel (the slowest container,
+        /// <c>max(residual ÷ capacity)</c>). <c>null</c> when the drain is unbounded.
+        /// </summary>
+        public TimeSpan? ParallelDrainDuration { get; set; }
+
+        /// <summary>
+        /// Worst-case drain assuming the containers fully contend for the target and drain serially
+        /// (<c>Σ(residual ÷ capacity)</c>). <c>null</c> when the drain is unbounded.
+        /// </summary>
+        public TimeSpan? FullyContendedDrainDuration { get; set; }
+
+        /// <summary>The assumed drain parallelism percentage (100 = fully parallel/independent, 0 = fully serial).</summary>
+        public double DrainParallelismPercent { get; set; }
+
+        /// <summary>Fixed time for post-cutover data validation / smoke tests.</summary>
+        public TimeSpan DataValidationDuration { get; set; }
+
+        /// <summary>Fixed time to switch the application connection string / DNS to the target.</summary>
+        public TimeSpan ConnectionSwitchDuration { get; set; }
+
+        /// <summary>Safety buffer percentage applied to the summed window.</summary>
+        public double SafetyBufferPercent { get; set; }
+
+        /// <summary>
+        /// Sum of the fixed overheads (quiesce + validation + connection switch), excluding drain and buffer.
+        /// Always known, even when the full window cannot be bounded.
+        /// </summary>
+        public TimeSpan FixedOverheadDuration { get; set; }
+
+        /// <summary>
+        /// The known lower bound on downtime: the fixed overhead with the safety buffer applied. Useful to
+        /// downstream consumers even when <see cref="TotalDowntime"/> is <c>null</c>.
+        /// </summary>
+        public TimeSpan MinimumKnownDowntime { get; set; }
+
+        /// <summary>
+        /// Estimated total cutover downtime (fixed overhead + final-sync drain, with the safety buffer
+        /// applied). <c>null</c> when the final-sync drain cannot be bounded (pre-cutover catch-up required).
+        /// </summary>
+        public TimeSpan? TotalDowntime { get; set; }
+
+        /// <summary>Whether the final-sync drain — and therefore the full window — is bounded.</summary>
+        public bool DrainBounded { get; set; }
+
+        /// <summary>Overall feasibility of bounding the cutover window with the available estimates.</summary>
+        public CutoverFeasibility Feasibility { get; set; } = CutoverFeasibility.Unknown;
+
+        /// <summary>Risk band relative to the configured target downtime (RTO).</summary>
+        public CutoverDowntimeRisk Risk { get; set; } = CutoverDowntimeRisk.Unknown;
+
+        /// <summary>The target downtime (RTO) the window was assessed against.</summary>
+        public TimeSpan TargetDowntime { get; set; }
+
+        /// <summary>Per-container cutover drain estimates.</summary>
+        public List<ContainerCutoverEstimate> Containers { get; set; } = new();
+
+        /// <summary>Names of containers that require pre-cutover catch-up before a bounded window is possible.</summary>
+        public List<string> ContainersRequiringPreCutoverCatchUp { get; set; } = new();
+
+        /// <summary>The explicit assumptions behind the cutover estimate.</summary>
+        public List<string> Assumptions { get; set; } = new();
+
+        /// <summary>Additional informational notes.</summary>
+        public List<string> Notes { get; set; } = new();
+    }
+}

--- a/Models/Migration/IncrementalMigrationAnalysis.cs
+++ b/Models/Migration/IncrementalMigrationAnalysis.cs
@@ -13,5 +13,11 @@ namespace CosmosToSqlAssessment.Models.Migration
         /// Per-container change feed availability and readiness for incremental synchronization (#134).
         /// </summary>
         public ChangeFeedAvailabilityAnalysis ChangeFeed { get; set; } = new();
+
+        /// <summary>
+        /// Estimated initial bulk-load time versus change-feed incremental sync time and steady-state
+        /// behavior (#135).
+        /// </summary>
+        public IncrementalSyncEstimate SyncEstimate { get; set; } = new();
     }
 }

--- a/Models/Migration/IncrementalMigrationAnalysis.cs
+++ b/Models/Migration/IncrementalMigrationAnalysis.cs
@@ -24,5 +24,10 @@ namespace CosmosToSqlAssessment.Models.Migration
         /// Estimated cutover downtime window for the final online-migration maintenance window (#136).
         /// </summary>
         public CutoverWindowEstimate CutoverWindow { get; set; } = new();
+
+        /// <summary>
+        /// The synthesized phased migration plan with an overall readiness verdict (#137).
+        /// </summary>
+        public PhasedMigrationPlan Plan { get; set; } = new();
     }
 }

--- a/Models/Migration/IncrementalMigrationAnalysis.cs
+++ b/Models/Migration/IncrementalMigrationAnalysis.cs
@@ -35,5 +35,12 @@ namespace CosmosToSqlAssessment.Models.Migration
         /// slicing recommendations per container (#138).
         /// </summary>
         public TimeBasedPartitioningAnalysis Partitioning { get; set; } = new();
+
+        /// <summary>
+        /// Change Feed Processor (CFP) implementation guidance — lease container sizing, parallelism ceilings,
+        /// mode selection, and checkpointing — for building a continuous-sync worker as an alternative to the
+        /// generated Data Factory <c>_ts</c>-watermark incremental copy pipeline (#140).
+        /// </summary>
+        public ChangeFeedProcessorGuidance ProcessorGuidance { get; set; } = new();
     }
 }

--- a/Models/Migration/IncrementalMigrationAnalysis.cs
+++ b/Models/Migration/IncrementalMigrationAnalysis.cs
@@ -1,0 +1,17 @@
+namespace CosmosToSqlAssessment.Models.Migration
+{
+    /// <summary>
+    /// Aggregate result for the incremental (change-feed-based) migration assessment of a database.
+    /// Attached to <see cref="AssessmentResult"/> as an optional analysis. Each parent #69 sub-issue
+    /// populates one facet: change feed availability (#134), sync time estimates (#135), cutover window
+    /// (#136), the phased plan (#137), time-based partitioning (#138), and change feed processor
+    /// guidance (#140).
+    /// </summary>
+    public sealed class IncrementalMigrationAnalysis
+    {
+        /// <summary>
+        /// Per-container change feed availability and readiness for incremental synchronization (#134).
+        /// </summary>
+        public ChangeFeedAvailabilityAnalysis ChangeFeed { get; set; } = new();
+    }
+}

--- a/Models/Migration/IncrementalMigrationAnalysis.cs
+++ b/Models/Migration/IncrementalMigrationAnalysis.cs
@@ -29,5 +29,11 @@ namespace CosmosToSqlAssessment.Models.Migration
         /// The synthesized phased migration plan with an overall readiness verdict (#137).
         /// </summary>
         public PhasedMigrationPlan Plan { get; set; } = new();
+
+        /// <summary>
+        /// Time-based target SQL table partitioning strategies and Cosmos <c>_ts</c>-based initial-load
+        /// slicing recommendations per container (#138).
+        /// </summary>
+        public TimeBasedPartitioningAnalysis Partitioning { get; set; } = new();
     }
 }

--- a/Models/Migration/IncrementalMigrationAnalysis.cs
+++ b/Models/Migration/IncrementalMigrationAnalysis.cs
@@ -19,5 +19,10 @@ namespace CosmosToSqlAssessment.Models.Migration
         /// behavior (#135).
         /// </summary>
         public IncrementalSyncEstimate SyncEstimate { get; set; } = new();
+
+        /// <summary>
+        /// Estimated cutover downtime window for the final online-migration maintenance window (#136).
+        /// </summary>
+        public CutoverWindowEstimate CutoverWindow { get; set; } = new();
     }
 }

--- a/Models/Migration/IncrementalSyncModels.cs
+++ b/Models/Migration/IncrementalSyncModels.cs
@@ -1,0 +1,162 @@
+namespace CosmosToSqlAssessment.Models.Migration
+{
+    /// <summary>
+    /// Risk band describing whether the change-feed incremental sync can keep pace with the source
+    /// change rate, derived from estimated utilization (change rate ÷ estimated incremental capacity).
+    /// </summary>
+    public enum SyncSustainabilityRisk
+    {
+        /// <summary>Utilization could not be determined (e.g. unknown initial-load throughput).</summary>
+        Unknown,
+
+        /// <summary>Utilization below 50%: comfortable headroom.</summary>
+        Healthy,
+
+        /// <summary>Utilization 50–80%: sustainable but with limited headroom.</summary>
+        Moderate,
+
+        /// <summary>Utilization 80–100%: sustainable only under stable conditions; high lag risk under bursts.</summary>
+        High,
+
+        /// <summary>Utilization ≥ 100%: the change rate exceeds estimated capacity; backlog cannot drain.</summary>
+        Unsustainable
+    }
+
+    /// <summary>
+    /// Per-container comparison of estimated initial bulk-load time versus change-feed incremental sync
+    /// behavior (#135). All throughput figures are heuristic planning estimates, not guaranteed SLAs.
+    /// </summary>
+    public sealed class ContainerIncrementalSyncEstimate
+    {
+        /// <summary>Source container name.</summary>
+        public string ContainerName { get; set; } = string.Empty;
+
+        /// <summary>Approximate document count for the container.</summary>
+        public long DocumentCount { get; set; }
+
+        /// <summary>Approximate stored size of the container in bytes.</summary>
+        public long SizeBytes { get; set; }
+
+        /// <summary>Average document size in bytes (<c>SizeBytes / DocumentCount</c>; 0 when no documents).</summary>
+        public double AverageDocumentSizeBytes { get; set; }
+
+        /// <summary>Approximate feed-range (physical-partition) count; a parallelism signal for change-feed processing.</summary>
+        public int FeedRangeCount { get; set; }
+
+        /// <summary>Estimated initial bulk-load duration for this container (reused from the Data Factory estimate).</summary>
+        public TimeSpan InitialLoadDuration { get; set; }
+
+        /// <summary>
+        /// Whether the initial-load throughput could be derived (false when the estimated initial-load
+        /// duration was non-positive while documents exist, making capacity indeterminate).
+        /// </summary>
+        public bool InitialLoadThroughputKnown { get; set; }
+
+        /// <summary>Estimated documents-per-second of the initial bulk load (<c>DocumentCount / initialLoadSeconds</c>).</summary>
+        public double InitialLoadDocsPerSecond { get; set; }
+
+        /// <summary>Assumed daily document churn rate (percentage of documents changed per day).</summary>
+        public double DailyDocumentChangeRatePercent { get; set; }
+
+        /// <summary>Estimated number of documents changed per day at the assumed churn rate.</summary>
+        public long EstimatedChangedDocumentsPerDay { get; set; }
+
+        /// <summary>Estimated steady-state changed documents per second.</summary>
+        public double EstimatedChangedDocumentsPerSecond { get; set; }
+
+        /// <summary>Estimated changed data volume per day in megabytes (churn rate applied to stored size).</summary>
+        public double EstimatedChangedDataPerDayMB { get; set; }
+
+        /// <summary>
+        /// Estimated incremental sync capacity in documents per second
+        /// (<c>InitialLoadDocsPerSecond × IncrementalThroughputFactor</c>). 0 when capacity is unknown.
+        /// </summary>
+        public double EstimatedIncrementalCapacityDocsPerSecond { get; set; }
+
+        /// <summary>Estimated utilization percentage (change rate ÷ incremental capacity × 100). 0 when unknown.</summary>
+        public double UtilizationPercent { get; set; }
+
+        /// <summary>Risk band derived from <see cref="UtilizationPercent"/>.</summary>
+        public SyncSustainabilityRisk Risk { get; set; } = SyncSustainabilityRisk.Unknown;
+
+        /// <summary>Whether the steady-state change rate is below the estimated incremental capacity.</summary>
+        public bool SteadyStateSustainable { get; set; }
+
+        /// <summary>Estimated number of changed documents accumulated during the initial load (the post-load backlog).</summary>
+        public long EstimatedBacklogDocumentsAfterInitialLoad { get; set; }
+
+        /// <summary>
+        /// Estimated time to drain the post-initial-load backlog while still ingesting new changes.
+        /// <c>null</c> when the stream is unsustainable or capacity is unknown (the backlog cannot be drained).
+        /// </summary>
+        public TimeSpan? EstimatedBacklogCatchUp { get; set; }
+
+        /// <summary>Estimated steady-state sync lag (sync interval plus one interval's processing time).</summary>
+        public TimeSpan EstimatedSteadyStateSyncLag { get; set; }
+
+        /// <summary>Informational notes / risk callouts for this container.</summary>
+        public List<string> Notes { get; set; } = new();
+    }
+
+    /// <summary>
+    /// Database-level comparison of initial bulk-load time versus change-feed incremental sync time and
+    /// steady-state behavior (#135). Grounds the cutover-window (#136) and phased-plan (#137) sub-issues.
+    /// </summary>
+    public sealed class IncrementalSyncEstimate
+    {
+        /// <summary>Assumed daily document churn rate used for all containers.</summary>
+        public double DailyDocumentChangeRatePercent { get; set; }
+
+        /// <summary>Assumed incremental sync interval (trigger cadence) used for steady-state lag.</summary>
+        public TimeSpan SyncInterval { get; set; }
+
+        /// <summary>
+        /// Multiplier applied to estimated initial-load throughput to approximate incremental sync capacity.
+        /// Relative to end-to-end initial-load throughput, not raw change-feed read throughput.
+        /// </summary>
+        public double IncrementalThroughputFactorRelativeToInitialLoad { get; set; }
+
+        /// <summary>Overall estimated initial bulk-load duration (reused from the Data Factory estimate).</summary>
+        public TimeSpan InitialLoadDuration { get; set; }
+
+        /// <summary>Total document count across all containers.</summary>
+        public long TotalDocuments { get; set; }
+
+        /// <summary>Estimated total changed documents per day across all containers.</summary>
+        public long EstimatedTotalChangedDocumentsPerDay { get; set; }
+
+        /// <summary>Estimated total changed documents per second across all containers.</summary>
+        public double EstimatedTotalChangedDocumentsPerSecond { get; set; }
+
+        /// <summary>Estimated total backlog documents accumulated during the initial load.</summary>
+        public long EstimatedBacklogDocumentsAfterInitialLoad { get; set; }
+
+        /// <summary>
+        /// Estimated time for the slowest container to drain its post-initial-load backlog (containers
+        /// sync in parallel, so the overall catch-up is the maximum across containers). <c>null</c> when
+        /// any container is unsustainable or its capacity is unknown.
+        /// </summary>
+        public TimeSpan? EstimatedBacklogCatchUpAfterInitialLoad { get; set; }
+
+        /// <summary>Estimated steady-state sync lag (maximum across containers).</summary>
+        public TimeSpan EstimatedSteadyStateSyncLag { get; set; }
+
+        /// <summary>Whether every container's steady-state change rate is below its estimated capacity.</summary>
+        public bool SteadyStateSustainable { get; set; }
+
+        /// <summary>Worst (highest) risk band across all containers.</summary>
+        public SyncSustainabilityRisk OverallRisk { get; set; } = SyncSustainabilityRisk.Unknown;
+
+        /// <summary>Per-container incremental sync estimates.</summary>
+        public List<ContainerIncrementalSyncEstimate> Containers { get; set; } = new();
+
+        /// <summary>Names of the highest-risk containers (by utilization / catch-up), most critical first.</summary>
+        public List<string> HighestRiskContainers { get; set; } = new();
+
+        /// <summary>The explicit assumptions behind these estimates.</summary>
+        public List<string> Assumptions { get; set; } = new();
+
+        /// <summary>Additional informational notes.</summary>
+        public List<string> Notes { get; set; } = new();
+    }
+}

--- a/Models/Migration/MigrationPlanModels.cs
+++ b/Models/Migration/MigrationPlanModels.cs
@@ -1,0 +1,114 @@
+namespace CosmosToSqlAssessment.Models.Migration
+{
+    /// <summary>
+    /// Overall readiness verdict for an incremental (change-feed-based) Cosmos DB → SQL migration (#137),
+    /// synthesized from change-feed availability (#134), sync estimates (#135), and the cutover window (#136).
+    /// </summary>
+    public enum MigrationReadiness
+    {
+        /// <summary>Readiness could not be determined (e.g. no containers in scope).</summary>
+        Unknown,
+
+        /// <summary>All signals are healthy; the phased plan can proceed with standard precautions.</summary>
+        Ready,
+
+        /// <summary>Viable, but with caveats that must be addressed (e.g. delete-fidelity verification, elevated risk, cutover needs pre-catch-up).</summary>
+        ReadyWithCaveats,
+
+        /// <summary>A blocking issue prevents a reliable incremental migration (e.g. unsustainable steady-state sync, no migration scope).</summary>
+        NotReady
+    }
+
+    /// <summary>
+    /// A single phase of the phased migration plan (#137): its objective, tooling, ordered steps, entry and
+    /// exit criteria, an optional modeled duration, risks, and rollback guidance where relevant.
+    /// </summary>
+    public sealed class MigrationPlanPhase
+    {
+        /// <summary>1-based ordinal position of the phase in the plan.</summary>
+        public int Order { get; set; }
+
+        /// <summary>Short phase name.</summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>The phase's objective / definition of done.</summary>
+        public string Objective { get; set; } = string.Empty;
+
+        /// <summary>The primary Azure tooling for the phase.</summary>
+        public string PrimaryTooling { get; set; } = string.Empty;
+
+        /// <summary>Ordered, actionable steps for the phase.</summary>
+        public List<string> Steps { get; set; } = new();
+
+        /// <summary>Conditions that must hold before the phase can start.</summary>
+        public List<string> EntryCriteria { get; set; } = new();
+
+        /// <summary>Conditions that must hold before the phase is considered complete.</summary>
+        public List<string> ExitCriteria { get; set; } = new();
+
+        /// <summary>
+        /// Modeled duration for the phase, when one can be estimated. <c>null</c> for operationally-scheduled
+        /// phases (e.g. cutover preparation, verification) or when an upstream estimate is unavailable.
+        /// </summary>
+        public TimeSpan? EstimatedDuration { get; set; }
+
+        /// <summary>Explanation of how <see cref="EstimatedDuration"/> was derived (or why it is unavailable).</summary>
+        public string DurationBasis { get; set; } = string.Empty;
+
+        /// <summary>Risks and watch-outs specific to the phase.</summary>
+        public List<string> Risks { get; set; } = new();
+
+        /// <summary>Rollback / contingency guidance relevant to the phase, when applicable.</summary>
+        public string? RollbackGuidance { get; set; }
+    }
+
+    /// <summary>
+    /// A phased migration plan for an incremental (change-feed-based) Cosmos DB → SQL migration (#137).
+    /// Synthesizes the #134/#135/#136 analyses into an ordered, criteria-driven plan with an overall
+    /// readiness verdict. Deliberately separates elapsed preparation time from business downtime so the
+    /// two are never conflated. All durations are heuristic planning estimates, not guaranteed SLAs.
+    /// </summary>
+    public sealed class PhasedMigrationPlan
+    {
+        /// <summary>The ordered migration phases.</summary>
+        public List<MigrationPlanPhase> Phases { get; set; } = new();
+
+        /// <summary>Overall readiness verdict.</summary>
+        public MigrationReadiness OverallReadiness { get; set; } = MigrationReadiness.Unknown;
+
+        /// <summary>The specific signals that drove <see cref="OverallReadiness"/>.</summary>
+        public List<string> ReadinessFactors { get; set; } = new();
+
+        /// <summary>
+        /// Estimated elapsed (wall-clock) preparation time before cutover: the initial bulk load plus the
+        /// incremental-sync catch-up and minimum stabilization. <c>null</c> when an upstream estimate is
+        /// unavailable. This is NOT business downtime — see <see cref="EstimatedBusinessDowntime"/>.
+        /// </summary>
+        public TimeSpan? EstimatedElapsedPreparationDuration { get; set; }
+
+        /// <summary>
+        /// Estimated business downtime during cutover only (the maintenance window). <c>null</c> when the
+        /// cutover window cannot be bounded until pre-cutover catch-up is achieved; in that case
+        /// <see cref="MinimumBusinessDowntime"/> still gives the known floor.
+        /// </summary>
+        public TimeSpan? EstimatedBusinessDowntime { get; set; }
+
+        /// <summary>The known lower bound on business downtime (cutover fixed overhead with safety buffer).</summary>
+        public TimeSpan MinimumBusinessDowntime { get; set; }
+
+        /// <summary>Aggregated key risks across the plan, most significant first.</summary>
+        public List<string> KeyRisks { get; set; } = new();
+
+        /// <summary>
+        /// Consistency diagnostics surfaced when upstream analyses are incomplete or appear to disagree, so
+        /// the plan cannot be silently misread.
+        /// </summary>
+        public List<string> PlanWarnings { get; set; } = new();
+
+        /// <summary>The explicit assumptions behind the plan.</summary>
+        public List<string> Assumptions { get; set; } = new();
+
+        /// <summary>Additional informational notes.</summary>
+        public List<string> Notes { get; set; } = new();
+    }
+}

--- a/Models/Migration/PartitioningModels.cs
+++ b/Models/Migration/PartitioningModels.cs
@@ -1,0 +1,217 @@
+using System.Collections.Generic;
+
+namespace CosmosToSqlAssessment.Models.Migration
+{
+    /// <summary>
+    /// Recommended Azure SQL time-based partition granularity for a migrated container's target table
+    /// (#138 of parent #69). The granularity reflects a manageability suggestion derived from data volume;
+    /// it is never a guarantee that partitioning improves query performance.
+    /// </summary>
+    public enum PartitionGranularity
+    {
+        /// <summary>No time-based partitioning recommended (the overhead is not justified by the data volume).</summary>
+        None = 0,
+
+        /// <summary>One partition per calendar year.</summary>
+        Year = 1,
+
+        /// <summary>One partition per calendar month.</summary>
+        Month = 2,
+
+        /// <summary>One partition per calendar day.</summary>
+        Day = 3,
+    }
+
+    /// <summary>
+    /// Overall strength of the time-based partitioning recommendation for a container's target SQL table.
+    /// Partitioning in Azure SQL is primarily a manageability feature (sliding-window aging, partition-level
+    /// maintenance) rather than a general query-performance feature, so the default leans conservative.
+    /// </summary>
+    public enum PartitioningStrength
+    {
+        /// <summary>
+        /// Partitioning is not recommended. Applies to small containers, containers with no usable schema
+        /// evidence, or empty containers where a single non-partitioned table is simpler and sufficient.
+        /// </summary>
+        NotRecommended = 0,
+
+        /// <summary>
+        /// Partitioning may help with manageability at this data volume, but the decision must be validated
+        /// against the expected query predicates and the retention/archival policy before adopting it.
+        /// </summary>
+        ConditionalManageability = 1,
+
+        /// <summary>
+        /// Partitioning is recommended: the data volume is large and a high-confidence immutable temporal
+        /// column is available to serve as the partitioning key.
+        /// </summary>
+        Recommended = 2,
+    }
+
+    /// <summary>
+    /// Confidence that a detected field is a suitable, stable temporal partitioning key candidate.
+    /// </summary>
+    public enum TemporalColumnConfidence
+    {
+        /// <summary>Low confidence: ambiguous, business-specific, or likely-mutable temporal field.</summary>
+        Low = 0,
+
+        /// <summary>Medium confidence: an event/occurrence-style timestamp that is usually but not always immutable.</summary>
+        Medium = 1,
+
+        /// <summary>High confidence: a creation/insertion timestamp that is almost certainly immutable.</summary>
+        High = 2,
+    }
+
+    /// <summary>
+    /// Heuristic assessment of whether a temporal field's value is stable (immutable) over a document's
+    /// lifetime. Mutable partitioning columns force expensive cross-partition row movement on update and
+    /// must be avoided as Azure SQL partitioning keys.
+    /// </summary>
+    public enum TemporalColumnMutabilityRisk
+    {
+        /// <summary>Mutability cannot be inferred from the field name; user validation required.</summary>
+        Unknown = 0,
+
+        /// <summary>The field name suggests an immutable creation/event timestamp.</summary>
+        ImmutableLikely = 1,
+
+        /// <summary>The field name suggests a mutable last-modified/business timestamp; avoid as a partition key.</summary>
+        MutableLikely = 2,
+    }
+
+    /// <summary>
+    /// Whether sliding-window partition maintenance (aging out the oldest partition via SWITCH/DROP rather
+    /// than row-by-row deletes) is applicable for the container's target table.
+    /// </summary>
+    public enum SlidingWindowConsideration
+    {
+        /// <summary>Not applicable: no time-to-live signal or no partitioning recommended.</summary>
+        NotApplicable = 0,
+
+        /// <summary>
+        /// May apply, but only after validating that the SQL partition column's age basis matches the
+        /// Cosmos TTL age basis (TTL ages by <c>_ts</c> last-modified, which differs from a creation column).
+        /// </summary>
+        ConsiderWithValidation = 1,
+    }
+
+    /// <summary>
+    /// A detected document field evaluated as a potential Azure SQL time-based partitioning key (#138).
+    /// </summary>
+    public sealed class TemporalColumnCandidate
+    {
+        /// <summary>The source field name as detected in the Cosmos documents.</summary>
+        public string FieldName { get; set; } = string.Empty;
+
+        /// <summary>The recommended SQL data type for the field (for example <c>datetime2</c>).</summary>
+        public string RecommendedSqlType { get; set; } = string.Empty;
+
+        /// <summary>The raw JSON/CLR types detected for the field across sampled documents.</summary>
+        public List<string> DetectedTypes { get; set; } = new();
+
+        /// <summary>Confidence that this field is a suitable, stable partitioning key.</summary>
+        public TemporalColumnConfidence Confidence { get; set; }
+
+        /// <summary>Heuristic mutability risk of the field's value over a document's lifetime.</summary>
+        public TemporalColumnMutabilityRisk MutabilityRisk { get; set; }
+
+        /// <summary>
+        /// Fraction (0–1) of the container's detected schema variants (weighted by prevalence) in which the
+        /// field appears. Low prevalence indicates a sparse field that may be unsuitable as a partition key.
+        /// </summary>
+        public double SchemaPrevalence { get; set; }
+
+        /// <summary>Human-readable rationale for the confidence and mutability classification.</summary>
+        public string Rationale { get; set; } = string.Empty;
+
+        /// <summary>
+        /// <c>true</c> when this candidate is a synthetic <c>InitialLoadTimestamp</c> column captured from the
+        /// Cosmos <c>_ts</c> value at load time rather than an existing document field. Such a column is a
+        /// stable partitioning value but is NOT the document's true creation time.
+        /// </summary>
+        public bool IsSyntheticFromInitialLoad { get; set; }
+    }
+
+    /// <summary>
+    /// Time-based partitioning recommendation for a single container's target Azure SQL table (#138).
+    /// </summary>
+    public sealed class ContainerPartitioningRecommendation
+    {
+        /// <summary>The Cosmos container name.</summary>
+        public string ContainerName { get; set; } = string.Empty;
+
+        /// <summary>The container's document count (echoed for reporting context).</summary>
+        public long DocumentCount { get; set; }
+
+        /// <summary>The container's data size in bytes (echoed for reporting context).</summary>
+        public long SizeBytes { get; set; }
+
+        /// <summary>Overall strength of the partitioning recommendation.</summary>
+        public PartitioningStrength Strength { get; set; }
+
+        /// <summary>Recommended time-based partition granularity (or <see cref="PartitionGranularity.None"/>).</summary>
+        public PartitionGranularity RecommendedGranularity { get; set; }
+
+        /// <summary>
+        /// The Azure SQL partition function range direction recommended for a temporal key. Always
+        /// <c>RANGE RIGHT</c>, which is conventional for ascending date boundaries.
+        /// </summary>
+        public string PartitionFunctionType { get; set; } = "RANGE RIGHT";
+
+        /// <summary>Ranked shortlist of candidate temporal partitioning columns (highest confidence first).</summary>
+        public List<TemporalColumnCandidate> TemporalColumnCandidates { get; set; } = new();
+
+        /// <summary>
+        /// The single recommended partition column name, set only when exactly one high-confidence immutable
+        /// candidate exists; otherwise <c>null</c>, meaning the column choice requires user validation.
+        /// </summary>
+        public string? RecommendedPartitionColumn { get; set; }
+
+        /// <summary>
+        /// <c>true</c> when no suitable immutable temporal column was detected and the recommendation is to
+        /// capture the initial Cosmos <c>_ts</c> as a stable <c>InitialLoadTimestamp</c> column at load time.
+        /// </summary>
+        public bool RequiresSyntheticCreationColumn { get; set; }
+
+        /// <summary>Whether sliding-window partition maintenance should be considered (TTL-driven).</summary>
+        public SlidingWindowConsideration SlidingWindow { get; set; }
+
+        /// <summary>
+        /// Upper bound on parallel initial-load workers, derived from the container's feed-range count. This
+        /// is a ceiling, not a guaranteed degree of parallelism (RU limits, throttling, hot ranges, and
+        /// feed-range split/merge apply).
+        /// </summary>
+        public int InitialLoadParallelismUpperBound { get; set; }
+
+        /// <summary>Recommended approach for slicing the initial bulk load by Cosmos <c>_ts</c> windows.</summary>
+        public string InitialLoadSlicingApproach { get; set; } = string.Empty;
+
+        /// <summary>Azure SQL partition/index alignment caveats the user must honor when implementing.</summary>
+        public List<string> IndexAlignmentCaveats { get; set; } = new();
+
+        /// <summary>Rationale lines explaining the recommendation.</summary>
+        public List<string> Rationale { get; set; } = new();
+
+        /// <summary>Caveats and warnings that qualify the recommendation.</summary>
+        public List<string> Caveats { get; set; } = new();
+    }
+
+    /// <summary>
+    /// Database-level time-based partitioning analysis aggregating per-container recommendations (#138).
+    /// </summary>
+    public sealed class TimeBasedPartitioningAnalysis
+    {
+        /// <summary>Per-container time-based partitioning recommendations.</summary>
+        public List<ContainerPartitioningRecommendation> Containers { get; set; } = new();
+
+        /// <summary>Count of containers for which partitioning is recommended or conditionally suggested.</summary>
+        public int ContainersRecommendedForPartitioning { get; set; }
+
+        /// <summary>Assumptions underpinning the analysis (for example detection heuristics and thresholds).</summary>
+        public List<string> Assumptions { get; set; } = new();
+
+        /// <summary>Database-wide notes applicable across all containers.</summary>
+        public List<string> Notes { get; set; } = new();
+    }
+}

--- a/Orchestration/AssessmentOrchestrator.cs
+++ b/Orchestration/AssessmentOrchestrator.cs
@@ -533,6 +533,15 @@ internal sealed class AssessmentOrchestrator
                 ? $"{cu:hh\\:mm\\:ss}"
                 : "unsustainable at estimated capacity";
             Console.WriteLine($"   ✅ Incremental sync: overall risk {sync.OverallRisk}, backlog catch-up {catchUp}");
+
+            var cutoverCalculator = serviceProvider.GetRequiredService<CutoverWindowCalculator>();
+            incremental.CutoverWindow = cutoverCalculator.Calculate(incremental.SyncEstimate);
+
+            var cutover = incremental.CutoverWindow;
+            var downtime = cutover.TotalDowntime is { } dt
+                ? $"~{dt:hh\\:mm\\:ss} (risk {cutover.Risk})"
+                : $"unbounded until pre-cutover catch-up (floor ~{cutover.MinimumKnownDowntime:hh\\:mm\\:ss})";
+            Console.WriteLine($"   ✅ Cutover window: {downtime}");
         }
         catch (Exception ex)
         {

--- a/Orchestration/AssessmentOrchestrator.cs
+++ b/Orchestration/AssessmentOrchestrator.cs
@@ -550,6 +550,13 @@ internal sealed class AssessmentOrchestrator
             var partitioningAnalyzer = serviceProvider.GetRequiredService<TimeBasedPartitioningAnalyzer>();
             incremental.Partitioning = partitioningAnalyzer.Analyze(assessmentResult.CosmosAnalysis);
             Console.WriteLine($"   ✅ Time-based partitioning: {incremental.Partitioning.ContainersRecommendedForPartitioning} of {incremental.Partitioning.Containers.Count} container(s) suited to partitioning");
+
+            var processorGuidanceGenerator = serviceProvider.GetRequiredService<ChangeFeedProcessorGuidanceGenerator>();
+            incremental.ProcessorGuidance = processorGuidanceGenerator.Generate(incremental);
+            var avadNote = incremental.ProcessorGuidance.AnyContainerRequiresAllVersionsAndDeletes
+                ? " (all-versions-and-deletes required → continuous backup)"
+                : string.Empty;
+            Console.WriteLine($"   ✅ Change feed processor guidance: lease container ~{incremental.ProcessorGuidance.SuggestedLeaseContainerStartingRUs} RU/s autoscale{avadNote}");
         }
         catch (Exception ex)
         {

--- a/Orchestration/AssessmentOrchestrator.cs
+++ b/Orchestration/AssessmentOrchestrator.cs
@@ -546,6 +546,10 @@ internal sealed class AssessmentOrchestrator
             var planGenerator = serviceProvider.GetRequiredService<PhasedMigrationPlanGenerator>();
             incremental.Plan = planGenerator.Generate(incremental);
             Console.WriteLine($"   ✅ Phased migration plan: {incremental.Plan.Phases.Count} phases, readiness {incremental.Plan.OverallReadiness}");
+
+            var partitioningAnalyzer = serviceProvider.GetRequiredService<TimeBasedPartitioningAnalyzer>();
+            incremental.Partitioning = partitioningAnalyzer.Analyze(assessmentResult.CosmosAnalysis);
+            Console.WriteLine($"   ✅ Time-based partitioning: {incremental.Partitioning.ContainersRecommendedForPartitioning} of {incremental.Partitioning.Containers.Count} container(s) suited to partitioning");
         }
         catch (Exception ex)
         {

--- a/Orchestration/AssessmentOrchestrator.cs
+++ b/Orchestration/AssessmentOrchestrator.cs
@@ -513,6 +513,12 @@ internal sealed class AssessmentOrchestrator
             {
                 ChangeFeed = changeFeedAnalyzer.Analyze(assessmentResult.CosmosAnalysis),
             };
+
+            var syncEstimator = serviceProvider.GetRequiredService<IncrementalSyncEstimator>();
+            incremental.SyncEstimate = syncEstimator.Estimate(
+                assessmentResult.CosmosAnalysis,
+                assessmentResult.DataFactoryEstimate);
+
             assessmentResult.IncrementalMigration = incremental;
 
             var ttlContainers = incremental.ChangeFeed.Containers.Count(c => c.KnownServerSideTtlDeletes);
@@ -521,6 +527,12 @@ internal sealed class AssessmentOrchestrator
             {
                 Console.WriteLine($"   ⚠️  {ttlContainers} container(s) have TTL deletes that latest-version change feed won't surface");
             }
+
+            var sync = incremental.SyncEstimate;
+            var catchUp = sync.EstimatedBacklogCatchUpAfterInitialLoad is { } cu
+                ? $"{cu:hh\\:mm\\:ss}"
+                : "unsustainable at estimated capacity";
+            Console.WriteLine($"   ✅ Incremental sync: overall risk {sync.OverallRisk}, backlog catch-up {catchUp}");
         }
         catch (Exception ex)
         {

--- a/Orchestration/AssessmentOrchestrator.cs
+++ b/Orchestration/AssessmentOrchestrator.cs
@@ -7,11 +7,13 @@ using CosmosToSqlAssessment.Cli;
 using CosmosToSqlAssessment.DependencyInjection;
 using CosmosToSqlAssessment.Models;
 using CosmosToSqlAssessment.Models.Monitoring;
+using CosmosToSqlAssessment.Models.Migration;
 using CosmosToSqlAssessment.Reporting;
 using CosmosToSqlAssessment.Services;
 using CosmosToSqlAssessment.Services.DataFactory;
 using CosmosToSqlAssessment.Services.Discovery;
 using CosmosToSqlAssessment.Services.Monitoring;
+using CosmosToSqlAssessment.Services.Migration;
 using CosmosToSqlAssessment.SqlProject;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Configuration;
@@ -407,6 +409,8 @@ internal sealed class AssessmentOrchestrator
             throw new InvalidOperationException($"Data Factory estimation failed for database {databaseName}: {ex.Message}", ex);
         }
 
+        AttachIncrementalMigrationAnalysis(activeServiceProvider, assessmentResult);
+
         return assessmentResult;
     }
 
@@ -477,7 +481,52 @@ internal sealed class AssessmentOrchestrator
         Console.WriteLine($"   ✅ Estimated migration time: {assessmentResult.DataFactoryEstimate.EstimatedDuration:hh\\:mm\\:ss}");
         Console.WriteLine($"   {(run.IsAcceptable ? "✅ Validation: acceptable" : "⚠️  Validation: complete but with consistency warnings")}");
 
+        AttachIncrementalMigrationAnalysis(activeServiceProvider, assessmentResult);
+
         return assessmentResult;
+    }
+
+    /// <summary>
+    /// Computes the optional incremental (change-feed-based) migration analysis (parent #69) and attaches
+    /// it to <paramref name="assessmentResult"/>. Shared by both the single-pass and <c>--agentic</c>
+    /// per-database paths so the behavior is identical. Failure-isolated: any error is logged and the
+    /// overall assessment continues without the incremental section.
+    /// </summary>
+    /// <param name="serviceProvider">The active (possibly endpoint-overridden) service provider.</param>
+    /// <param name="assessmentResult">The assessment result to enrich. Must already have <c>CosmosAnalysis</c>.</param>
+    private void AttachIncrementalMigrationAnalysis(
+        IServiceProvider serviceProvider,
+        AssessmentResult assessmentResult)
+    {
+        if (assessmentResult.CosmosAnalysis is null)
+        {
+            return;
+        }
+
+        try
+        {
+            Console.WriteLine();
+            Console.WriteLine("🔁 Phase 5: Assessing incremental change-feed migration readiness...");
+
+            var changeFeedAnalyzer = serviceProvider.GetRequiredService<ChangeFeedAvailabilityAnalyzer>();
+            var incremental = new IncrementalMigrationAnalysis
+            {
+                ChangeFeed = changeFeedAnalyzer.Analyze(assessmentResult.CosmosAnalysis),
+            };
+            assessmentResult.IncrementalMigration = incremental;
+
+            var ttlContainers = incremental.ChangeFeed.Containers.Count(c => c.KnownServerSideTtlDeletes);
+            Console.WriteLine($"   ✅ Change feed readiness assessed for {incremental.ChangeFeed.Containers.Count} container(s)");
+            if (ttlContainers > 0)
+            {
+                Console.WriteLine($"   ⚠️  {ttlContainers} container(s) have TTL deletes that latest-version change feed won't surface");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to compute incremental change-feed migration analysis - continuing without it");
+            Console.WriteLine($"   ⚠️  Incremental migration analysis skipped due to error: {ex.Message}");
+        }
     }
 
     private async Task GenerateOutputsAsync(

--- a/Orchestration/AssessmentOrchestrator.cs
+++ b/Orchestration/AssessmentOrchestrator.cs
@@ -542,6 +542,10 @@ internal sealed class AssessmentOrchestrator
                 ? $"~{dt:hh\\:mm\\:ss} (risk {cutover.Risk})"
                 : $"unbounded until pre-cutover catch-up (floor ~{cutover.MinimumKnownDowntime:hh\\:mm\\:ss})";
             Console.WriteLine($"   ✅ Cutover window: {downtime}");
+
+            var planGenerator = serviceProvider.GetRequiredService<PhasedMigrationPlanGenerator>();
+            incremental.Plan = planGenerator.Generate(incremental);
+            Console.WriteLine($"   ✅ Phased migration plan: {incremental.Plan.Phases.Count} phases, readiness {incremental.Plan.OverallReadiness}");
         }
         catch (Exception ex)
         {

--- a/Reporting/ReportGenerationService.cs
+++ b/Reporting/ReportGenerationService.cs
@@ -1395,6 +1395,52 @@ namespace CosmosToSqlAssessment.Reporting
             }
             row++;
 
+            // Change feed processor guidance
+            var processor = incremental.ProcessorGuidance;
+            SectionTitle("Change Feed Processor Guidance (#140)");
+            KeyVal("Recommended Lease Container:", processor.RecommendedLeaseContainerName);
+            KeyVal("Lease Partition Key:", processor.LeaseContainerPartitionKeyPath);
+            KeyVal("Lease Container Starting Throughput:", $"{processor.SuggestedLeaseContainerStartingRUs} RU/s ({(processor.LeaseContainerUsesAutoscale ? "autoscale max" : "manual")})");
+            KeyVal("Checkpoint Strategy:", processor.CheckpointStrategy.ToString());
+            KeyVal("Recommended Initial Compute Instances:", processor.RecommendedInitialComputeInstances.ToString());
+            KeyVal("Scale-Out Ceiling (shared fleet):", processor.ComputeScaleOutCeilingSharedFleet.HasValue ? processor.ComputeScaleOutCeilingSharedFleet.Value.ToString() : "unknown");
+            KeyVal("Scale-Out Ceiling (independent pools):", processor.ComputeScaleOutCeilingIndependentPools.HasValue ? processor.ComputeScaleOutCeilingIndependentPools.Value.ToString() : "unknown");
+            KeyVal("Any Container Requires All-Versions-and-Deletes:", processor.AnyContainerRequiresAllVersionsAndDeletes ? "Yes" : "No");
+            KeyVal("Requires Continuous Backup for Deletes:", processor.RequiresContinuousBackupForDeletes ? "Yes" : "No");
+            Header("Container", "Recommended Mode", "Feed Ranges", "Max Useful Instances", "Continuous Backup", "Isolated Lease State");
+            foreach (var container in processor.Containers)
+            {
+                ws.Cell(row, 1).Value = container.ContainerName;
+                ws.Cell(row, 2).Value = container.RecommendedMode.ToString();
+                ws.Cell(row, 3).Value = container.FeedRangeCountKnown ? container.FeedRangeCount.ToString() : "unknown";
+                ws.Cell(row, 4).Value = container.MaxUsefulComputeInstances.HasValue ? container.MaxUsefulComputeInstances.Value.ToString() : "unknown";
+                ws.Cell(row, 5).Value = container.RequiresContinuousBackup ? "Required" : "Not required";
+                ws.Cell(row, 6).Value = container.RequiresIsolatedLeaseState ? "Required" : "Not required";
+                row++;
+            }
+            row++;
+            if (processor.ImplementationSteps.Any())
+            {
+                ws.Cell(row, 1).Value = "Implementation Steps:";
+                ws.Cell(row, 1).Style.Font.Bold = true;
+                row++;
+                foreach (var step in processor.ImplementationSteps)
+                {
+                    Bullet(step);
+                }
+            }
+            if (processor.RelationshipToDataFactoryWatermarkPipeline.Any())
+            {
+                ws.Cell(row, 1).Value = "Relationship to Data Factory _ts-Watermark Pipeline:";
+                ws.Cell(row, 1).Style.Font.Bold = true;
+                row++;
+                foreach (var note in processor.RelationshipToDataFactoryWatermarkPipeline)
+                {
+                    Bullet(note);
+                }
+            }
+            row++;
+
             // Assumptions & warnings
             SectionTitle("Assumptions & Warnings");
             foreach (var warning in changeFeed.GlobalWarnings)
@@ -1416,6 +1462,14 @@ namespace CosmosToSqlAssessment.Reporting
             foreach (var assumption in partitioning.Assumptions)
             {
                 Bullet($"[Partitioning] {assumption}");
+            }
+            foreach (var assumption in processor.Assumptions)
+            {
+                Bullet($"[Processor] {assumption}");
+            }
+            foreach (var warning in processor.Warnings)
+            {
+                Bullet($"[Processor] {warning}");
             }
 
             ws.Columns().AdjustToContents();
@@ -2402,6 +2456,51 @@ namespace CosmosToSqlAssessment.Reporting
                 var column = container.RecommendedPartitionColumn
                     ?? (container.RequiresSyntheticCreationColumn ? "InitialLoadTimestamp (synthetic)" : "requires validation");
                 AddWordParagraph(body, $"• {container.ContainerName}: {container.Strength}, {container.RecommendedGranularity} granularity, partition column: {column}");
+            }
+            AddEmptyLine(body);
+
+            // Change feed processor guidance
+            var processor = incremental.ProcessorGuidance;
+            AddWordHeading(body, "Change Feed Processor Guidance", 2);
+            AddWordParagraph(body,
+                "Guidance for building a Change Feed Processor worker as an alternative or complement to the generated Data " +
+                "Factory watermark pipeline. All sizing figures are conservative starting points to monitor and adjust.");
+            var processorTable = CreateBorderedTable();
+            AddTableRow(processorTable, "Recommended Lease Container", processor.RecommendedLeaseContainerName);
+            AddTableRow(processorTable, "Lease Partition Key", processor.LeaseContainerPartitionKeyPath);
+            AddTableRow(processorTable, "Lease Starting Throughput",
+                $"{processor.SuggestedLeaseContainerStartingRUs} RU/s ({(processor.LeaseContainerUsesAutoscale ? "autoscale max" : "manual")})");
+            AddTableRow(processorTable, "Checkpoint Strategy", processor.CheckpointStrategy.ToString());
+            AddTableRow(processorTable, "Recommended Initial Compute Instances", processor.RecommendedInitialComputeInstances.ToString());
+            AddTableRow(processorTable, "Scale-Out Ceiling (shared fleet)",
+                processor.ComputeScaleOutCeilingSharedFleet.HasValue ? processor.ComputeScaleOutCeilingSharedFleet.Value.ToString() : "unknown");
+            AddTableRow(processorTable, "Scale-Out Ceiling (independent pools)",
+                processor.ComputeScaleOutCeilingIndependentPools.HasValue ? processor.ComputeScaleOutCeilingIndependentPools.Value.ToString() : "unknown");
+            AddTableRow(processorTable, "Requires Continuous Backup for Deletes", processor.RequiresContinuousBackupForDeletes ? "Yes" : "No");
+            body.AppendChild(processorTable);
+            foreach (var container in processor.Containers)
+            {
+                var ranges = container.FeedRangeCountKnown ? container.FeedRangeCount.ToString() : "unknown";
+                var maxInstances = container.MaxUsefulComputeInstances.HasValue ? container.MaxUsefulComputeInstances.Value.ToString() : "unknown";
+                AddWordParagraph(body, $"• {container.ContainerName}: {container.RecommendedMode} mode, {ranges} feed range(s), up to {maxInstances} useful instance(s)");
+            }
+            if (processor.ImplementationSteps.Any())
+            {
+                AddWordParagraph(body, "Implementation steps:");
+                var stepNumber = 1;
+                foreach (var step in processor.ImplementationSteps)
+                {
+                    AddWordParagraph(body, $"{stepNumber}. {step}");
+                    stepNumber++;
+                }
+            }
+            foreach (var note in processor.RelationshipToDataFactoryWatermarkPipeline)
+            {
+                AddWordParagraph(body, $"• {note}");
+            }
+            foreach (var warning in processor.Warnings)
+            {
+                AddWordParagraph(body, $"• Processor warning: {warning}");
             }
         }
 

--- a/Reporting/ReportGenerationService.cs
+++ b/Reporting/ReportGenerationService.cs
@@ -1,4 +1,5 @@
 using CosmosToSqlAssessment.Models;
+using CosmosToSqlAssessment.Models.Migration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using ClosedXML.Excel;
@@ -278,6 +279,10 @@ namespace CosmosToSqlAssessment.Reporting
             cancellationToken.ThrowIfCancellationRequested();
             
             CreateMigrationEstimatesWorksheet(workbook, assessmentResult);
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            CreateIncrementalMigrationWorksheet(workbook, assessmentResult);
 
             cancellationToken.ThrowIfCancellationRequested();
             
@@ -1203,6 +1208,220 @@ namespace CosmosToSqlAssessment.Reporting
         }
 
         /// <summary>
+        /// Creates the incremental (change-feed-based) migration worksheet documenting the change-feed sync
+        /// process: change-feed availability (#134), initial-load vs incremental-sync estimates (#135), the
+        /// cutover window (#136), the phased plan (#137), and time-based partitioning (#138). Renders from
+        /// the optional <see cref="AssessmentResult.IncrementalMigration"/> aggregate.
+        /// </summary>
+        /// <param name="workbook">The workbook to add the worksheet to.</param>
+        /// <param name="assessmentResult">The assessment result supplying the incremental migration analysis.</param>
+        private void CreateIncrementalMigrationWorksheet(XLWorkbook workbook, AssessmentResult assessmentResult)
+        {
+            var ws = workbook.Worksheets.Add("Incremental Migration");
+
+            ws.Cell("A1").Value = "Incremental (Change Feed) Migration & Sync Process";
+            ws.Cell("A1").Style.Font.Bold = true;
+            ws.Cell("A1").Style.Font.FontSize = 16;
+            ws.Cell("A1").Style.Fill.BackgroundColor = XLColor.LightBlue;
+
+            var incremental = assessmentResult.IncrementalMigration;
+            if (incremental == null)
+            {
+                ws.Cell("A3").Value = "Incremental migration analysis not available for this assessment.";
+                return;
+            }
+
+            var row = 3;
+
+            void SectionTitle(string title)
+            {
+                ws.Cell(row, 1).Value = title;
+                ws.Cell(row, 1).Style.Font.Bold = true;
+                ws.Cell(row, 1).Style.Font.FontSize = 13;
+                ws.Cell(row, 1).Style.Fill.BackgroundColor = XLColor.LightGray;
+                row++;
+            }
+
+            void KeyVal(string key, string value)
+            {
+                ws.Cell(row, 1).Value = key;
+                ws.Cell(row, 1).Style.Font.Bold = true;
+                ws.Cell(row, 2).Value = value;
+                row++;
+            }
+
+            void Bullet(string text)
+            {
+                ws.Cell(row, 1).Value = $"• {text}";
+                row++;
+            }
+
+            void Header(params string[] columns)
+            {
+                for (var i = 0; i < columns.Length; i++)
+                {
+                    var cell = ws.Cell(row, i + 1);
+                    cell.Value = columns[i];
+                    cell.Style.Font.Bold = true;
+                    cell.Style.Fill.BackgroundColor = XLColor.LightBlue;
+                }
+                row++;
+            }
+
+            static string Dur(TimeSpan? value) => value.HasValue ? value.Value.ToString(@"hh\:mm\:ss") : "unbounded";
+
+            // Overall readiness
+            var plan = incremental.Plan;
+            SectionTitle("Overall Readiness");
+            var readinessCell = ws.Cell(row, 2);
+            ws.Cell(row, 1).Value = "Migration Readiness:";
+            ws.Cell(row, 1).Style.Font.Bold = true;
+            readinessCell.Value = plan.OverallReadiness.ToString();
+            readinessCell.Style.Font.Bold = true;
+            readinessCell.Style.Fill.BackgroundColor = plan.OverallReadiness switch
+            {
+                MigrationReadiness.Ready => XLColor.LightGreen,
+                MigrationReadiness.ReadyWithCaveats => XLColor.LightYellow,
+                MigrationReadiness.NotReady => XLColor.Rose,
+                _ => XLColor.White
+            };
+            row++;
+            KeyVal("Elapsed Preparation (wall-clock):", Dur(plan.EstimatedElapsedPreparationDuration));
+            KeyVal("Business Downtime (cutover):", Dur(plan.EstimatedBusinessDowntime));
+            KeyVal("Minimum Business Downtime (floor):", plan.MinimumBusinessDowntime.ToString(@"hh\:mm\:ss"));
+            if (plan.ReadinessFactors.Any())
+            {
+                ws.Cell(row, 1).Value = "Readiness Factors:";
+                ws.Cell(row, 1).Style.Font.Bold = true;
+                row++;
+                foreach (var factor in plan.ReadinessFactors)
+                {
+                    Bullet(factor);
+                }
+            }
+            row++;
+
+            // Change feed availability
+            var changeFeed = incremental.ChangeFeed;
+            SectionTitle("Change Feed Availability (#134)");
+            KeyVal("All containers support latest-version sync:", changeFeed.AllContainersSupportLatestVersionIncrementalSync ? "Yes" : "No");
+            KeyVal("Any container has server-side TTL deletes:", changeFeed.AnyContainerHasKnownServerSideDeletes ? "Yes" : "No");
+            KeyVal("Delete handling needs external validation:", changeFeed.DeletePropagationRequiresExternalValidation ? "Yes" : "No");
+            Header("Container", "Latest-Version Feed", "Recommended Mode", "TTL Enabled", "Known TTL Deletes", "Feed Ranges");
+            foreach (var container in changeFeed.Containers)
+            {
+                ws.Cell(row, 1).Value = container.ContainerName;
+                ws.Cell(row, 2).Value = container.LatestVersionChangeFeedAvailable ? "Available" : "Unavailable";
+                ws.Cell(row, 3).Value = container.RecommendedMode.ToString();
+                ws.Cell(row, 4).Value = container.TimeToLiveEnabled ? "Yes" : "No";
+                ws.Cell(row, 5).Value = container.KnownServerSideTtlDeletes ? "Yes" : "No";
+                ws.Cell(row, 6).Value = container.FeedRangeCount;
+                row++;
+            }
+            row++;
+
+            // Initial load vs incremental sync
+            var sync = incremental.SyncEstimate;
+            SectionTitle("Initial Load vs Incremental Sync (#135)");
+            KeyVal("Overall Sync Risk:", sync.OverallRisk.ToString());
+            KeyVal("Steady-State Sustainable:", sync.SteadyStateSustainable ? "Yes" : "No");
+            KeyVal("Assumed Daily Change Rate:", $"{sync.DailyDocumentChangeRatePercent:F1}%");
+            KeyVal("Sync Interval:", sync.SyncInterval.ToString(@"hh\:mm\:ss"));
+            KeyVal("Initial Load Duration:", sync.InitialLoadDuration.ToString(@"hh\:mm\:ss"));
+            KeyVal("Post-Load Backlog Catch-Up:", Dur(sync.EstimatedBacklogCatchUpAfterInitialLoad));
+            KeyVal("Steady-State Sync Lag:", sync.EstimatedSteadyStateSyncLag.ToString(@"hh\:mm\:ss"));
+            KeyVal("Total Changed Docs/Day:", sync.EstimatedTotalChangedDocumentsPerDay.ToString("N0"));
+            Header("Container", "Documents", "Initial Load", "Utilization %", "Risk", "Sustainable", "Backlog Catch-Up", "Steady Lag");
+            foreach (var container in sync.Containers)
+            {
+                ws.Cell(row, 1).Value = container.ContainerName;
+                ws.Cell(row, 2).Value = container.DocumentCount;
+                ws.Cell(row, 3).Value = container.InitialLoadDuration.ToString(@"hh\:mm\:ss");
+                ws.Cell(row, 4).Value = container.InitialLoadThroughputKnown ? $"{container.UtilizationPercent:F1}%" : "unknown";
+                ws.Cell(row, 5).Value = container.Risk.ToString();
+                ws.Cell(row, 6).Value = container.SteadyStateSustainable ? "Yes" : "No";
+                ws.Cell(row, 7).Value = Dur(container.EstimatedBacklogCatchUp);
+                ws.Cell(row, 8).Value = container.EstimatedSteadyStateSyncLag.ToString(@"hh\:mm\:ss");
+                row++;
+            }
+            row++;
+
+            // Cutover window
+            var cutover = incremental.CutoverWindow;
+            SectionTitle("Cutover Downtime Window (#136)");
+            KeyVal("Feasibility:", cutover.Feasibility.ToString());
+            KeyVal("Downtime Risk (vs RTO):", cutover.Risk.ToString());
+            KeyVal("Estimated Total Downtime:", Dur(cutover.TotalDowntime));
+            KeyVal("Minimum Known Downtime (floor):", cutover.MinimumKnownDowntime.ToString(@"hh\:mm\:ss"));
+            KeyVal("Fixed Overhead:", cutover.FixedOverheadDuration.ToString(@"hh\:mm\:ss"));
+            KeyVal("Parallel Drain (best case):", Dur(cutover.ParallelDrainDuration));
+            KeyVal("Fully-Contended Drain (worst case):", Dur(cutover.FullyContendedDrainDuration));
+            KeyVal("Target Downtime (RTO):", cutover.TargetDowntime.ToString(@"hh\:mm\:ss"));
+            if (cutover.ContainersRequiringPreCutoverCatchUp.Any())
+            {
+                KeyVal("Containers Requiring Pre-Cutover Catch-Up:", string.Join(", ", cutover.ContainersRequiringPreCutoverCatchUp));
+            }
+            row++;
+
+            // Phased plan
+            SectionTitle("Phased Migration Plan (#137)");
+            Header("#", "Phase", "Objective", "Primary Tooling", "Est. Duration");
+            foreach (var phase in plan.Phases)
+            {
+                ws.Cell(row, 1).Value = phase.Order;
+                ws.Cell(row, 2).Value = phase.Name;
+                ws.Cell(row, 3).Value = phase.Objective;
+                ws.Cell(row, 4).Value = phase.PrimaryTooling;
+                ws.Cell(row, 5).Value = phase.EstimatedDuration.HasValue ? phase.EstimatedDuration.Value.ToString(@"hh\:mm\:ss") : "scheduled";
+                row++;
+            }
+            row++;
+
+            // Time-based partitioning
+            var partitioning = incremental.Partitioning;
+            SectionTitle("Time-Based Partitioning (#138)");
+            KeyVal("Containers Suited to Partitioning:", $"{partitioning.ContainersRecommendedForPartitioning} of {partitioning.Containers.Count}");
+            Header("Container", "Strength", "Granularity", "Partition Column", "Synthetic Column", "Sliding Window", "Load Parallelism");
+            foreach (var container in partitioning.Containers)
+            {
+                ws.Cell(row, 1).Value = container.ContainerName;
+                ws.Cell(row, 2).Value = container.Strength.ToString();
+                ws.Cell(row, 3).Value = container.RecommendedGranularity.ToString();
+                ws.Cell(row, 4).Value = container.RecommendedPartitionColumn ?? "requires validation";
+                ws.Cell(row, 5).Value = container.RequiresSyntheticCreationColumn ? "InitialLoadTimestamp" : "—";
+                ws.Cell(row, 6).Value = container.SlidingWindow.ToString();
+                ws.Cell(row, 7).Value = container.InitialLoadParallelismUpperBound;
+                row++;
+            }
+            row++;
+
+            // Assumptions & warnings
+            SectionTitle("Assumptions & Warnings");
+            foreach (var warning in changeFeed.GlobalWarnings)
+            {
+                Bullet($"[Change Feed] {warning}");
+            }
+            foreach (var assumption in sync.Assumptions)
+            {
+                Bullet($"[Sync] {assumption}");
+            }
+            foreach (var assumption in cutover.Assumptions)
+            {
+                Bullet($"[Cutover] {assumption}");
+            }
+            foreach (var warning in plan.PlanWarnings)
+            {
+                Bullet($"[Plan] {warning}");
+            }
+            foreach (var assumption in partitioning.Assumptions)
+            {
+                Bullet($"[Partitioning] {assumption}");
+            }
+
+            ws.Columns().AdjustToContents();
+        }
+
+        /// <summary>
         /// Generates comprehensive Word report with the new structure
         /// Follows Azure documentation standards
         /// </summary>
@@ -1355,6 +1574,16 @@ namespace CosmosToSqlAssessment.Reporting
                     AddEmptyLine(body);
 
                     cancellationToken.ThrowIfCancellationRequested();
+
+                    // Level 1 Header: Incremental (Change Feed) Migration & Sync Process
+                    if (assessmentResult.IncrementalMigration != null)
+                    {
+                        AddWordHeading(body, "Incremental Migration and Sync Process", 1);
+                        AddIncrementalMigrationAnalysis(body, assessmentResult);
+                        AddEmptyLine(body);
+
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
 
                     // Level 1 Header: Proposed SQL Schema Layout
                     AddWordHeading(body, "Proposed SQL Schema Layout", 1);
@@ -2037,6 +2266,142 @@ namespace CosmosToSqlAssessment.Reporting
                 AddWordParagraph(body, $"• Estimated Cost: ${assessmentResult.DataFactoryEstimate.EstimatedCostUSD:F2}");
                 AddWordParagraph(body, $"• Data Volume (GB): {assessmentResult.DataFactoryEstimate.TotalDataSizeGB}");
                 AddWordParagraph(body, $"• Recommended DIUs: {assessmentResult.DataFactoryEstimate.RecommendedDIUs}");
+            }
+        }
+
+        /// <summary>
+        /// Creates a <see cref="Table"/> pre-configured with the report's standard single-line borders.
+        /// </summary>
+        /// <returns>A bordered, empty table ready for rows.</returns>
+        private static Table CreateBorderedTable()
+        {
+            var table = new Table();
+            table.AppendChild(new TableProperties(
+                new TableBorders(
+                    new TopBorder() { Val = new EnumValue<BorderValues>(BorderValues.Single), Size = 12 },
+                    new BottomBorder() { Val = new EnumValue<BorderValues>(BorderValues.Single), Size = 12 },
+                    new LeftBorder() { Val = new EnumValue<BorderValues>(BorderValues.Single), Size = 12 },
+                    new RightBorder() { Val = new EnumValue<BorderValues>(BorderValues.Single), Size = 12 },
+                    new InsideHorizontalBorder() { Val = new EnumValue<BorderValues>(BorderValues.Single), Size = 6 },
+                    new InsideVerticalBorder() { Val = new EnumValue<BorderValues>(BorderValues.Single), Size = 6 }
+                )));
+            return table;
+        }
+
+        /// <summary>
+        /// Adds the incremental (change-feed-based) migration and synchronization section to the Word report,
+        /// documenting change-feed availability (#134), initial-load vs incremental-sync estimates (#135), the
+        /// cutover window (#136), the phased plan (#137), and time-based partitioning (#138). Renders from the
+        /// optional <see cref="AssessmentResult.IncrementalMigration"/> aggregate.
+        /// </summary>
+        /// <param name="body">The Word document body to append content to.</param>
+        /// <param name="assessmentResult">The assessment result supplying the incremental migration analysis.</param>
+        private void AddIncrementalMigrationAnalysis(Body body, AssessmentResult assessmentResult)
+        {
+            var incremental = assessmentResult.IncrementalMigration;
+            if (incremental == null)
+            {
+                AddWordParagraph(body, "Incremental migration analysis not available for this assessment.");
+                return;
+            }
+
+            var plan = incremental.Plan;
+            var changeFeed = incremental.ChangeFeed;
+            var sync = incremental.SyncEstimate;
+            var cutover = incremental.CutoverWindow;
+            var partitioning = incremental.Partitioning;
+
+            static string Dur(TimeSpan? value) =>
+                value.HasValue ? value.Value.ToString(@"hh\:mm\:ss") : "unbounded (pre-cutover catch-up required)";
+
+            AddWordParagraph(body,
+                "This section documents the online (change-feed-based) migration and ongoing synchronization process: " +
+                "change-feed availability, the initial bulk load versus incremental sync, the cutover downtime window, the " +
+                "phased plan, and target-table time-based partitioning. All durations are heuristic planning estimates, not " +
+                "guaranteed SLAs.");
+            AddEmptyLine(body);
+
+            // Readiness summary
+            AddWordHeading(body, "Migration Readiness", 2);
+            var readinessTable = CreateBorderedTable();
+            AddTableRow(readinessTable, "Overall Readiness", plan.OverallReadiness.ToString());
+            AddTableRow(readinessTable, "Elapsed Preparation (wall-clock)", Dur(plan.EstimatedElapsedPreparationDuration));
+            AddTableRow(readinessTable, "Business Downtime (cutover)", Dur(plan.EstimatedBusinessDowntime));
+            AddTableRow(readinessTable, "Minimum Business Downtime (floor)", plan.MinimumBusinessDowntime.ToString(@"hh\:mm\:ss"));
+            body.AppendChild(readinessTable);
+            foreach (var factor in plan.ReadinessFactors)
+            {
+                AddWordParagraph(body, $"• {factor}");
+            }
+            AddEmptyLine(body);
+
+            // Change feed availability
+            AddWordHeading(body, "Change Feed Availability", 2);
+            AddWordParagraph(body, $"• Latest-version change feed available on all containers: {(changeFeed.AllContainersSupportLatestVersionIncrementalSync ? "Yes" : "No")}");
+            AddWordParagraph(body, $"• Server-side TTL deletes present (invisible to the latest-version feed): {(changeFeed.AnyContainerHasKnownServerSideDeletes ? "Yes" : "No")}");
+            AddWordParagraph(body, $"• Delete handling requires external validation/design: {(changeFeed.DeletePropagationRequiresExternalValidation ? "Yes" : "No")}");
+            foreach (var warning in changeFeed.GlobalWarnings)
+            {
+                AddWordParagraph(body, $"• {warning}");
+            }
+            AddEmptyLine(body);
+
+            // Initial load vs incremental sync
+            AddWordHeading(body, "Initial Load vs Incremental Sync", 2);
+            var syncTable = CreateBorderedTable();
+            AddTableRow(syncTable, "Overall Sync Risk", sync.OverallRisk.ToString());
+            AddTableRow(syncTable, "Steady-State Sustainable", sync.SteadyStateSustainable ? "Yes" : "No");
+            AddTableRow(syncTable, "Assumed Daily Change Rate", $"{sync.DailyDocumentChangeRatePercent:F1}%");
+            AddTableRow(syncTable, "Sync Interval", sync.SyncInterval.ToString(@"hh\:mm\:ss"));
+            AddTableRow(syncTable, "Initial Load Duration", sync.InitialLoadDuration.ToString(@"hh\:mm\:ss"));
+            AddTableRow(syncTable, "Post-Load Backlog Catch-Up", Dur(sync.EstimatedBacklogCatchUpAfterInitialLoad));
+            AddTableRow(syncTable, "Steady-State Sync Lag", sync.EstimatedSteadyStateSyncLag.ToString(@"hh\:mm\:ss"));
+            body.AppendChild(syncTable);
+            if (sync.HighestRiskContainers.Any())
+            {
+                AddWordParagraph(body, $"• Highest-risk containers: {string.Join(", ", sync.HighestRiskContainers)}");
+            }
+            AddEmptyLine(body);
+
+            // Cutover window
+            AddWordHeading(body, "Cutover Downtime Window", 2);
+            var cutoverTable = CreateBorderedTable();
+            AddTableRow(cutoverTable, "Feasibility", cutover.Feasibility.ToString());
+            AddTableRow(cutoverTable, "Downtime Risk (vs RTO)", cutover.Risk.ToString());
+            AddTableRow(cutoverTable, "Estimated Total Downtime", Dur(cutover.TotalDowntime));
+            AddTableRow(cutoverTable, "Minimum Known Downtime (floor)", cutover.MinimumKnownDowntime.ToString(@"hh\:mm\:ss"));
+            AddTableRow(cutoverTable, "Fixed Overhead", cutover.FixedOverheadDuration.ToString(@"hh\:mm\:ss"));
+            AddTableRow(cutoverTable, "Target Downtime (RTO)", cutover.TargetDowntime.ToString(@"hh\:mm\:ss"));
+            body.AppendChild(cutoverTable);
+            if (cutover.ContainersRequiringPreCutoverCatchUp.Any())
+            {
+                AddWordParagraph(body, $"• Containers requiring pre-cutover catch-up: {string.Join(", ", cutover.ContainersRequiringPreCutoverCatchUp)}");
+            }
+            AddEmptyLine(body);
+
+            // Phased plan
+            AddWordHeading(body, "Phased Migration Plan", 2);
+            foreach (var phase in plan.Phases)
+            {
+                var durationSuffix = phase.EstimatedDuration.HasValue
+                    ? $" (est. {phase.EstimatedDuration.Value:hh\\:mm\\:ss})"
+                    : string.Empty;
+                AddWordParagraph(body, $"{phase.Order}. {phase.Name}{durationSuffix} — {phase.Objective}");
+            }
+            foreach (var warning in plan.PlanWarnings)
+            {
+                AddWordParagraph(body, $"• Plan warning: {warning}");
+            }
+            AddEmptyLine(body);
+
+            // Time-based partitioning
+            AddWordHeading(body, "Time-Based Partitioning", 2);
+            AddWordParagraph(body, $"• Containers suited to partitioning: {partitioning.ContainersRecommendedForPartitioning} of {partitioning.Containers.Count}");
+            foreach (var container in partitioning.Containers)
+            {
+                var column = container.RecommendedPartitionColumn
+                    ?? (container.RequiresSyntheticCreationColumn ? "InitialLoadTimestamp (synthetic)" : "requires validation");
+                AddWordParagraph(body, $"• {container.ContainerName}: {container.Strength}, {container.RecommendedGranularity} granularity, partition column: {column}");
             }
         }
 

--- a/Services/CosmosDbAnalysisService.cs
+++ b/Services/CosmosDbAnalysisService.cs
@@ -466,7 +466,33 @@ namespace CosmosToSqlAssessment.Services
                 var containerProperties = containerResponse.Resource;
 
                 analysis.PartitionKey = containerProperties.PartitionKeyPath ?? "/id";
-                
+
+                // Capture partition-key paths (multiple for hierarchical keys), TTL, and feed-range
+                // count to feed the incremental change-feed migration analysis (parent #69).
+                var partitionKeyPaths = containerProperties.PartitionKeyPaths;
+                if (partitionKeyPaths != null && partitionKeyPaths.Count > 0)
+                {
+                    analysis.PartitionKeyPaths = partitionKeyPaths.ToList();
+                }
+                else if (!string.IsNullOrEmpty(containerProperties.PartitionKeyPath))
+                {
+                    analysis.PartitionKeyPaths = new List<string> { containerProperties.PartitionKeyPath };
+                }
+
+                analysis.DefaultTimeToLiveSeconds = containerProperties.DefaultTimeToLive;
+
+                try
+                {
+                    var feedRanges = await container.GetFeedRangesAsync(cancellationToken);
+                    analysis.FeedRangeCount = feedRanges?.Count ?? 0;
+                }
+                catch (Exception ex)
+                {
+                    // Feed-range enumeration is best-effort; a failure here must not abort container analysis.
+                    _logger.LogWarning(ex, "Could not read feed ranges for container {ContainerName}; defaulting FeedRangeCount to 0", container.Id);
+                    analysis.FeedRangeCount = 0;
+                }
+
                 // Get throughput information
                 try
                 {

--- a/Services/Migration/ChangeFeedAvailabilityAnalyzer.cs
+++ b/Services/Migration/ChangeFeedAvailabilityAnalyzer.cs
@@ -1,0 +1,156 @@
+using CosmosToSqlAssessment.Models;
+using CosmosToSqlAssessment.Models.Migration;
+using Microsoft.Extensions.Logging;
+
+namespace CosmosToSqlAssessment.Services.Migration
+{
+    /// <summary>
+    /// Determines per-container change feed readiness for incremental (change-feed-based) migration.
+    /// Pure analysis over an already-collected <see cref="CosmosDbAnalysis"/>; performs no live Cosmos
+    /// DB calls so it is deterministic, fast, and unit-testable. Foundational sub-issue #134 of parent
+    /// #69 (incremental migration support with change feed).
+    /// </summary>
+    /// <remarks>
+    /// Key domain facts encoded here:
+    /// <list type="bullet">
+    ///   <item>The latest-version change feed is always available on the SQL (Core) API.</item>
+    ///   <item>The latest-version change feed never emits delete events, so hard deletes (application
+    ///   <c>DeleteItem</c> calls or TTL expiration) are invisible to it and must be handled separately.</item>
+    ///   <item>All-versions-and-deletes mode emits deletes within a retention window but requires a
+    ///   container <c>ChangeFeedPolicy</c> retention that the public .NET SDK does not expose — so its
+    ///   availability is reported as requiring manual verification.</item>
+    /// </list>
+    /// </remarks>
+    public sealed class ChangeFeedAvailabilityAnalyzer
+    {
+        private readonly ILogger<ChangeFeedAvailabilityAnalyzer> _logger;
+
+        /// <summary>Creates a new <see cref="ChangeFeedAvailabilityAnalyzer"/>.</summary>
+        /// <param name="logger">Logger for diagnostic output.</param>
+        public ChangeFeedAvailabilityAnalyzer(ILogger<ChangeFeedAvailabilityAnalyzer> logger)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// Produces a database-level change feed availability analysis from the supplied Cosmos analysis.
+        /// </summary>
+        /// <param name="cosmosAnalysis">The collected Cosmos DB analysis. Must not be <c>null</c>.</param>
+        /// <returns>A populated <see cref="ChangeFeedAvailabilityAnalysis"/>.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="cosmosAnalysis"/> is <c>null</c>.</exception>
+        public ChangeFeedAvailabilityAnalysis Analyze(CosmosDbAnalysis cosmosAnalysis)
+        {
+            ArgumentNullException.ThrowIfNull(cosmosAnalysis);
+
+            var analysis = new ChangeFeedAvailabilityAnalysis();
+
+            foreach (var container in cosmosAnalysis.Containers)
+            {
+                analysis.Containers.Add(AnalyzeContainer(container));
+            }
+
+            analysis.AllContainersSupportLatestVersionIncrementalSync =
+                analysis.Containers.All(c => c.LatestVersionChangeFeedAvailable);
+            analysis.AnyContainerHasKnownServerSideDeletes =
+                analysis.Containers.Any(c => c.KnownServerSideTtlDeletes);
+
+            analysis.GlobalWarnings.Add(
+                "The latest-version change feed never emits delete events. Hard deletes (application " +
+                "DeleteItem calls or TTL expiration) will not propagate to the SQL target through " +
+                "latest-version incremental sync and must be reconciled with a soft-delete pattern, a " +
+                "periodic full reconciliation, or all-versions-and-deletes mode.");
+
+            analysis.GlobalWarnings.Add(
+                "All-versions-and-deletes (full-fidelity) availability cannot be verified from public SDK " +
+                "metadata. If delete capture is required, confirm the container ChangeFeedPolicy retention " +
+                "is configured in the Azure portal / ARM before relying on it.");
+
+            if (analysis.AnyContainerHasKnownServerSideDeletes)
+            {
+                analysis.GlobalWarnings.Add(
+                    "One or more containers have TTL enabled. TTL-expired documents are deleted server-side " +
+                    "and are invisible to the latest-version change feed; plan an explicit strategy to age " +
+                    "out the corresponding SQL rows.");
+            }
+
+            _logger.LogInformation(
+                "Change feed availability analyzed for {ContainerCount} container(s); {TtlContainers} with TTL deletes",
+                analysis.Containers.Count,
+                analysis.Containers.Count(c => c.KnownServerSideTtlDeletes));
+
+            return analysis;
+        }
+
+        private static ContainerChangeFeedReadiness AnalyzeContainer(ContainerAnalysis container)
+        {
+            var ttl = container.DefaultTimeToLiveSeconds;
+            var ttlEnabled = ttl.HasValue;
+            var defaultExpiration = ttl is > 0;
+            var itemLevelTtlOnly = ttl == -1;
+
+            var partitionKeyPaths = (container.PartitionKeyPaths is { Count: > 0 })
+                ? container.PartitionKeyPaths.ToList()
+                : (!string.IsNullOrEmpty(container.PartitionKey)
+                    ? new List<string> { container.PartitionKey }
+                    : new List<string>());
+
+            var readiness = new ContainerChangeFeedReadiness
+            {
+                ContainerName = container.ContainerName,
+                LatestVersionChangeFeedAvailable = true,
+                AllVersionsAndDeletesAvailability = ChangeFeedModeAvailability.RequiresManualVerification,
+                TimeToLiveEnabled = ttlEnabled,
+                DefaultTtlExpirationEnabled = defaultExpiration,
+                ItemLevelTtlPossible = itemLevelTtlOnly,
+                DefaultTimeToLiveSeconds = ttl,
+                TimeToLivePropertyPath = container.TimeToLivePropertyPath,
+                PartitionKeyPaths = partitionKeyPaths,
+                PartitionKeyPathCount = partitionKeyPaths.Count,
+                IsHierarchicalPartitionKey = partitionKeyPaths.Count > 1,
+                FeedRangeCount = container.FeedRangeCount,
+                DeletePropagationSupportedByLatestVersion = false,
+                KnownServerSideTtlDeletes = ttlEnabled,
+                RequiresDeleteHandlingValidation = true,
+            };
+
+            readiness.Notes.Add("Latest-version change feed is available for incremental sync of creates and updates.");
+            readiness.Notes.Add(
+                "Latest-version change feed does not emit delete events; application hard deletes will not " +
+                "propagate to the SQL target via incremental sync.");
+
+            if (ttlEnabled)
+            {
+                readiness.RecommendedMode = ChangeFeedMode.AllVersionsAndDeletes;
+                var ttlDescription = defaultExpiration
+                    ? $"a default expiration of {ttl} second(s)"
+                    : "item-level TTL only (DefaultTimeToLive = -1)";
+                readiness.Warnings.Add(
+                    $"TTL is enabled ({ttlDescription}). TTL-expired documents are deleted server-side and are " +
+                    "not surfaced by the latest-version change feed. Use all-versions-and-deletes mode (verify " +
+                    "retention) or design an out-of-band aging/reconciliation strategy for the SQL target.");
+
+                if (!string.IsNullOrEmpty(container.TimeToLivePropertyPath))
+                {
+                    readiness.Notes.Add(
+                        $"Container uses a custom TTL property path '{container.TimeToLivePropertyPath}'.");
+                }
+            }
+            else
+            {
+                readiness.RecommendedMode = ChangeFeedMode.LatestVersion;
+                readiness.Notes.Add(
+                    "No TTL configured; recommend latest-version change feed for incremental sync, with a " +
+                    "delete-handling validation step before cutover.");
+            }
+
+            if (readiness.IsHierarchicalPartitionKey)
+            {
+                readiness.Notes.Add(
+                    $"Hierarchical partition key with {readiness.PartitionKeyPathCount} levels: " +
+                    string.Join(", ", partitionKeyPaths) + ".");
+            }
+
+            return readiness;
+        }
+    }
+}

--- a/Services/Migration/ChangeFeedProcessorGuidanceGenerator.cs
+++ b/Services/Migration/ChangeFeedProcessorGuidanceGenerator.cs
@@ -1,0 +1,159 @@
+using CosmosToSqlAssessment.Models.Migration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace CosmosToSqlAssessment.Services.Migration
+{
+    /// <summary>
+    /// Produces Change Feed Processor (CFP) implementation guidance (#140 of parent #69) from the already
+    /// computed #134 change-feed availability analysis. Pure composition; performs no live Cosmos DB calls.
+    /// </summary>
+    /// <remarks>
+    /// The guidance advises on building a CFP worker — lease container, parallelism ceilings, mode selection,
+    /// checkpointing, and bulk-load coordination — as an alternative or complement to the Azure Data Factory
+    /// <c>_ts</c>-watermark incremental copy pipeline this tool also generates. All sizing figures are
+    /// conservative starting guidance to monitor and adjust, not validated capacity numbers.
+    /// </remarks>
+    public sealed class ChangeFeedProcessorGuidanceGenerator
+    {
+        private const int MinimumLeaseContainerRUs = 400;
+
+        private readonly IConfiguration _configuration;
+        private readonly ILogger<ChangeFeedProcessorGuidanceGenerator> _logger;
+
+        /// <summary>Creates a new <see cref="ChangeFeedProcessorGuidanceGenerator"/>.</summary>
+        /// <param name="configuration">Configuration supplying the <c>IncrementalMigration:*</c> lease-sizing inputs.</param>
+        /// <param name="logger">Logger for diagnostic output.</param>
+        public ChangeFeedProcessorGuidanceGenerator(IConfiguration configuration, ILogger<ChangeFeedProcessorGuidanceGenerator> logger)
+        {
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// Generates Change Feed Processor guidance from the incremental migration analysis.
+        /// </summary>
+        /// <param name="analysis">The aggregate holding the #134 change-feed analysis. Must not be <c>null</c>.</param>
+        /// <returns>A populated <see cref="ChangeFeedProcessorGuidance"/>.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="analysis"/> is <c>null</c>.</exception>
+        public ChangeFeedProcessorGuidance Generate(IncrementalMigrationAnalysis analysis)
+        {
+            ArgumentNullException.ThrowIfNull(analysis);
+
+            var baseRUs = Math.Max(MinimumLeaseContainerRUs,
+                _configuration.GetValue("IncrementalMigration:ChangeFeedProcessorLeaseBaseRUs", MinimumLeaseContainerRUs));
+            var perLeaseRUs = Math.Max(0,
+                _configuration.GetValue("IncrementalMigration:ChangeFeedProcessorLeaseRUsPerLease", 100));
+
+            var readiness = analysis.ChangeFeed;
+            var guidance = new ChangeFeedProcessorGuidance();
+
+            var perContainerCeilings = new List<int>();
+            var anyUnknownFeedRange = false;
+
+            foreach (var container in readiness.Containers)
+            {
+                var known = container.FeedRangeCount > 0;
+                var avad = container.RecommendedMode == ChangeFeedMode.AllVersionsAndDeletes;
+
+                var item = new ContainerChangeFeedProcessorGuidance
+                {
+                    ContainerName = container.ContainerName,
+                    RecommendedMode = container.RecommendedMode,
+                    FeedRangeCount = container.FeedRangeCount,
+                    FeedRangeCountKnown = known,
+                    MaxUsefulComputeInstances = known ? Math.Max(1, container.FeedRangeCount) : null,
+                    RequiresContinuousBackup = avad,
+                    RequiresIsolatedLeaseState = avad,
+                    DeleteHandlingNote = avad
+                        ? "All-versions-and-deletes mode surfaces delete tombstones (within the continuous-backup retention window); apply them to the SQL target."
+                        : "Latest-version mode never emits deletes; handle hard/TTL deletes with a soft-delete pattern or periodic reconciliation."
+                };
+
+                if (known)
+                {
+                    perContainerCeilings.Add(Math.Max(1, container.FeedRangeCount));
+                }
+                else
+                {
+                    anyUnknownFeedRange = true;
+                    item.Notes.Add("Feed-range count was unreadable; determine it at runtime (GetFeedRangesAsync / CFP leases) before scaling out.");
+                }
+
+                guidance.Containers.Add(item);
+            }
+
+            var totalKnownRanges = perContainerCeilings.Sum();
+            var anyAvad = guidance.Containers.Any(c => c.RequiresContinuousBackup);
+
+            guidance.SuggestedLeaseContainerStartingRUs = Math.Max(MinimumLeaseContainerRUs, baseRUs + (perLeaseRUs * totalKnownRanges));
+            guidance.LeaseContainerUsesAutoscale = true;
+            guidance.CheckpointStrategy = CheckpointStrategy.AutomaticPerBatch;
+            guidance.CheckpointingNote = "The change feed processor delivers changes at least once: a host restart or lease rebalance redelivers the last uncheckpointed batch, so the SQL write path must be idempotent (upsert/MERGE keyed on the document id).";
+
+            guidance.RecommendedInitialComputeInstances = 1;
+            guidance.ComputeScaleOutCeilingSharedFleet = perContainerCeilings.Count > 0 ? perContainerCeilings.Max() : null;
+            guidance.ComputeScaleOutCeilingIndependentPools = perContainerCeilings.Count > 0 ? totalKnownRanges : null;
+            guidance.ScaleOutTrigger = "Start with one instance and scale out based on change feed estimator lag, host CPU/memory, and SQL write throughput, up to the feed-range ceiling (a host can run the processors for multiple containers).";
+
+            guidance.AnyContainerRequiresAllVersionsAndDeletes = anyAvad;
+            guidance.RequiresContinuousBackupForDeletes = anyAvad;
+
+            BuildImplementationSteps(guidance, anyAvad);
+            BuildAssumptions(guidance);
+            BuildWarnings(guidance, anyAvad, anyUnknownFeedRange, readiness.Containers.Count);
+            BuildDataFactoryRelationship(guidance);
+
+            _logger.LogInformation(
+                "Generated change feed processor guidance for {ContainerCount} container(s); lease container ~{LeaseRus} RU/s autoscale, AVAD required: {Avad}",
+                guidance.Containers.Count, guidance.SuggestedLeaseContainerStartingRUs, anyAvad);
+
+            return guidance;
+        }
+
+        private static void BuildImplementationSteps(ChangeFeedProcessorGuidance guidance, bool anyAvad)
+        {
+            guidance.ImplementationSteps.Add($"Provision a dedicated lease container named '{guidance.RecommendedLeaseContainerName}' with partition key '{guidance.LeaseContainerPartitionKeyPath}' (autoscale, starting ~{guidance.SuggestedLeaseContainerStartingRUs} RU/s max; monitor for throttling).");
+            guidance.ImplementationSteps.Add("Build a .NET worker with GetChangeFeedProcessorBuilder, setting a stable processor name and a unique instance name per host, pointing at the lease container.");
+            guidance.ImplementationSteps.Add("For latest-version mode, start the processor at or before the initial bulk-load snapshot boundary so no change is missed; expect (and tolerate) duplicate deliveries via an idempotent SQL upsert/MERGE.");
+            if (anyAvad)
+            {
+                guidance.ImplementationSteps.Add("For all-versions-and-deletes containers, enable continuous backup and the AVAD feature on the account, use isolated lease state (a dedicated lease container or a distinct processor name/lease prefix), and start within the retention window (historical/from-beginning starts are not available in AVAD).");
+            }
+            guidance.ImplementationSteps.Add("Make the change handler idempotent and checkpoint after the SQL write commits; the default is automatic per-batch checkpointing.");
+            guidance.ImplementationSteps.Add("Deploy a change feed estimator alongside the processor to monitor lag, and scale out instances (up to the feed-range ceiling) when lag grows.");
+        }
+
+        private static void BuildAssumptions(ChangeFeedProcessorGuidance guidance)
+        {
+            guidance.Assumptions.Add("Feed-range count approximates the container's physical-partition count; one lease is taken per feed range.");
+            guidance.Assumptions.Add("Lease-container throughput is a conservative starting estimate to monitor and adjust, not validated sizing — actual RU is driven by checkpoint frequency, lease renew/acquire cadence, and failovers.");
+            guidance.Assumptions.Add("Compute scale-out ceilings assume one lease per feed range; useful parallelism never exceeds the number of leases.");
+        }
+
+        private static void BuildWarnings(ChangeFeedProcessorGuidance guidance, bool anyAvad, bool anyUnknownFeedRange, int containerCount)
+        {
+            guidance.Warnings.Add("Feed-range counts vary at runtime (partition split/merge), so the parallelism ceiling is approximate, not a guarantee.");
+            if (anyUnknownFeedRange)
+            {
+                guidance.Warnings.Add("One or more containers had an unreadable feed-range count; their parallelism ceiling is unknown — determine it at runtime before scaling out.");
+            }
+            if (containerCount == 0)
+            {
+                guidance.Warnings.Add("No containers were analyzed, so the guidance reflects defaults only.");
+            }
+            if (anyAvad)
+            {
+                guidance.Warnings.Add("All-versions-and-deletes mode applies to Azure Cosmos DB for NoSQL only, requires continuous backup and the AVAD feature enabled on the account, emits changes only within the retention window, cannot start from the beginning or an arbitrary historical time, may be unsupported on accounts with partition-merge history, and needs a recent Microsoft.Azure.Cosmos SDK (verify current support — it has had preview constraints).");
+            }
+        }
+
+        private static void BuildDataFactoryRelationship(ChangeFeedProcessorGuidance guidance)
+        {
+            guidance.RelationshipToDataFactoryWatermarkPipeline.Add("Azure Data Factory _ts-watermark copy (generated by this tool): a scheduled pull that captures visible creates/updates; deletes require a soft-delete pattern or external reconciliation.");
+            guidance.RelationshipToDataFactoryWatermarkPipeline.Add("Latest-version Change Feed Processor: continuous push-style processing of creates/updates with at-least-once delivery; still does not surface deletes.");
+            guidance.RelationshipToDataFactoryWatermarkPipeline.Add("All-versions-and-deletes Change Feed Processor: also captures deletes and intermediate versions within the retention window, subject to continuous-backup/feature/SDK constraints.");
+            guidance.RelationshipToDataFactoryWatermarkPipeline.Add("Choose one incremental path per target table; do not run both the ADF pipeline and a CFP worker into the same SQL target without idempotent upserts and duplicate-boundary handling.");
+        }
+    }
+}

--- a/Services/Migration/CutoverWindowCalculator.cs
+++ b/Services/Migration/CutoverWindowCalculator.cs
@@ -1,0 +1,259 @@
+using CosmosToSqlAssessment.Models.Migration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace CosmosToSqlAssessment.Services.Migration
+{
+    /// <summary>
+    /// Calculates the estimated cutover downtime window for an online (change-feed-based) migration
+    /// (#136 of parent #69). Pure analysis over the #135 <see cref="IncrementalSyncEstimate"/>; performs
+    /// no live Cosmos DB calls.
+    /// </summary>
+    /// <remarks>
+    /// Models the final maintenance window during which the source is quiesced (read-only): a fixed
+    /// quiesce overhead, the final delta-sync drain of the residual change-feed backlog, fixed data
+    /// validation and connection-switch overheads, and a safety buffer. Because the source is quiesced,
+    /// no new changes arrive during cutover, so the residual backlog drains at the estimated incremental
+    /// capacity. All figures are heuristic planning estimates, not guaranteed SLAs.
+    /// </remarks>
+    public sealed class CutoverWindowCalculator
+    {
+        private readonly IConfiguration _configuration;
+        private readonly ILogger<CutoverWindowCalculator> _logger;
+
+        /// <summary>Creates a new <see cref="CutoverWindowCalculator"/>.</summary>
+        /// <param name="configuration">Configuration supplying the <c>IncrementalMigration:Cutover*</c> assumptions.</param>
+        /// <param name="logger">Logger for diagnostic output.</param>
+        public CutoverWindowCalculator(IConfiguration configuration, ILogger<CutoverWindowCalculator> logger)
+        {
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// Calculates the estimated cutover downtime window from the incremental sync estimate.
+        /// </summary>
+        /// <param name="syncEstimate">The #135 incremental sync estimate. Must not be <c>null</c>.</param>
+        /// <returns>A populated <see cref="CutoverWindowEstimate"/>.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="syncEstimate"/> is <c>null</c>.</exception>
+        public CutoverWindowEstimate Calculate(IncrementalSyncEstimate syncEstimate)
+        {
+            ArgumentNullException.ThrowIfNull(syncEstimate);
+
+            var appStopMinutes = Math.Max(0, _configuration.GetValue("IncrementalMigration:CutoverAppStopMinutes", 5.0));
+            var validationMinutes = Math.Max(0, _configuration.GetValue("IncrementalMigration:CutoverValidationMinutes", 15.0));
+            var switchMinutes = Math.Max(0, _configuration.GetValue("IncrementalMigration:CutoverConnectionSwitchMinutes", 5.0));
+            var bufferPercent = Math.Max(0, _configuration.GetValue("IncrementalMigration:CutoverSafetyBufferPercent", 20.0));
+            var targetMinutes = Math.Max(1, _configuration.GetValue("IncrementalMigration:CutoverTargetDowntimeMinutes", 30.0));
+            var parallelismPercent = Math.Clamp(_configuration.GetValue("IncrementalMigration:CutoverDrainParallelismPercent", 100.0), 0, 100);
+
+            var quiesce = TimeSpan.FromMinutes(appStopMinutes);
+            var validation = TimeSpan.FromMinutes(validationMinutes);
+            var connectionSwitch = TimeSpan.FromMinutes(switchMinutes);
+            var fixedOverhead = quiesce + validation + connectionSwitch;
+            var bufferMultiplier = 1.0 + (bufferPercent / 100.0);
+
+            var estimate = new CutoverWindowEstimate
+            {
+                AppQuiesceDuration = quiesce,
+                DataValidationDuration = validation,
+                ConnectionSwitchDuration = connectionSwitch,
+                SafetyBufferPercent = bufferPercent,
+                FixedOverheadDuration = fixedOverhead,
+                MinimumKnownDowntime = Scale(fixedOverhead, bufferMultiplier),
+                TargetDowntime = TimeSpan.FromMinutes(targetMinutes),
+                DrainParallelismPercent = parallelismPercent,
+            };
+
+            AddAssumptions(estimate, targetMinutes, parallelismPercent);
+
+            foreach (var container in syncEstimate.Containers)
+            {
+                estimate.Containers.Add(EstimateContainer(container, syncEstimate.SyncInterval));
+            }
+
+            if (syncEstimate.Containers.Count == 0)
+            {
+                // Nothing to drain: the window is just the fixed overhead.
+                estimate.FinalSyncDrainDuration = TimeSpan.Zero;
+                estimate.ParallelDrainDuration = TimeSpan.Zero;
+                estimate.FullyContendedDrainDuration = TimeSpan.Zero;
+                estimate.DrainBounded = true;
+                estimate.Feasibility = CutoverFeasibility.Feasible;
+                estimate.TotalDowntime = estimate.MinimumKnownDowntime;
+                estimate.Risk = ClassifyRisk(estimate.TotalDowntime.Value, estimate.TargetDowntime);
+                estimate.Notes.Add("No containers to synchronize; the cutover window is limited to fixed overhead.");
+                return estimate;
+            }
+
+            estimate.ContainersRequiringPreCutoverCatchUp = estimate.Containers
+                .Where(c => !c.DrainBounded)
+                .Select(c => c.ContainerName)
+                .ToList();
+
+            if (estimate.ContainersRequiringPreCutoverCatchUp.Count > 0)
+            {
+                estimate.FinalSyncDrainDuration = null;
+                estimate.TotalDowntime = null;
+                estimate.DrainBounded = false;
+                estimate.Feasibility = CutoverFeasibility.RequiresPreCutoverCatchUp;
+                estimate.Risk = CutoverDowntimeRisk.Unknown;
+                estimate.Notes.Add(
+                    $"{estimate.ContainersRequiringPreCutoverCatchUp.Count} container(s) have unbounded pre-cutover " +
+                    "lag or unknown incremental capacity. Achieve zero change-feed lag (catch-up) on these before " +
+                    "cutover, then re-estimate; until then only the fixed-overhead floor is bounded.");
+                _logger.LogInformation(
+                    "Cutover window requires pre-cutover catch-up for {Count} container(s); only fixed overhead is bounded",
+                    estimate.ContainersRequiringPreCutoverCatchUp.Count);
+                return estimate;
+            }
+
+            // Drain bounds: fully-parallel (slowest container) is the best case; fully-contended (serial
+            // sum) is the worst case. The reported drain blends between them by the configured parallelism.
+            var perContainerDrainSeconds = estimate.Containers
+                .Select(c => c.ResidualDrainDuration!.Value.TotalSeconds)
+                .ToList();
+            var parallelSeconds = perContainerDrainSeconds.DefaultIfEmpty(0).Max();
+            var serialSeconds = perContainerDrainSeconds.Sum();
+            var finalDrainSeconds = parallelSeconds + ((serialSeconds - parallelSeconds) * (1.0 - (parallelismPercent / 100.0)));
+
+            var finalDrain = SafeFromSeconds(finalDrainSeconds);
+
+            estimate.ParallelDrainDuration = SafeFromSeconds(parallelSeconds);
+            estimate.FullyContendedDrainDuration = SafeFromSeconds(serialSeconds);
+            estimate.FinalSyncDrainDuration = finalDrain;
+            estimate.DrainBounded = true;
+            estimate.Feasibility = CutoverFeasibility.Feasible;
+            estimate.TotalDowntime = Scale(fixedOverhead + finalDrain, bufferMultiplier);
+            estimate.Risk = ClassifyRisk(estimate.TotalDowntime.Value, estimate.TargetDowntime);
+
+            if (parallelismPercent < 100 && serialSeconds > parallelSeconds)
+            {
+                estimate.Notes.Add(
+                    $"Drain parallelism assumed at {parallelismPercent:0.##}%: target contention pushes the final-sync " +
+                    $"drain toward the fully-contended bound (~{estimate.FullyContendedDrainDuration:hh\\:mm\\:ss}). " +
+                    "Provision additional target throughput to approach the fully-parallel bound.");
+            }
+
+            _logger.LogInformation(
+                "Cutover window estimated: total {Total}, risk {Risk}, feasibility {Feasibility}",
+                estimate.TotalDowntime, estimate.Risk, estimate.Feasibility);
+
+            return estimate;
+        }
+
+        private static ContainerCutoverEstimate EstimateContainer(
+            ContainerIncrementalSyncEstimate container,
+            TimeSpan syncInterval)
+        {
+            var result = new ContainerCutoverEstimate
+            {
+                ContainerName = container.ContainerName,
+                DrainCapacityDocsPerSecond = container.EstimatedIncrementalCapacityDocsPerSecond,
+            };
+
+            // Worst-case residual since the last completed checkpoint: churn over one steady-state sync
+            // lag (interval plus one processing cycle). Falls back to the sync interval when lag is unset.
+            var lag = container.EstimatedSteadyStateSyncLag > TimeSpan.Zero
+                ? container.EstimatedSteadyStateSyncLag
+                : syncInterval;
+            result.ResidualBacklogDocuments =
+                (long)Math.Round(Math.Max(0, container.EstimatedChangedDocumentsPerSecond) * lag.TotalSeconds);
+
+            // Unbounded pre-cutover lag (unsustainable) or unknown capacity ⇒ drain cannot be bounded,
+            // unless there is genuinely nothing to drain.
+            var capacity = container.EstimatedIncrementalCapacityDocsPerSecond;
+            var capacityKnown = container.InitialLoadThroughputKnown && capacity > 0 &&
+                                !double.IsNaN(capacity) && !double.IsInfinity(capacity);
+
+            if (result.ResidualBacklogDocuments <= 0)
+            {
+                result.ResidualDrainDuration = TimeSpan.Zero;
+                result.DrainBounded = true;
+                if (container.DocumentCount == 0)
+                {
+                    result.Notes.Add("Container has no documents; nothing to drain at cutover.");
+                }
+                else
+                {
+                    result.Notes.Add("No estimated residual backlog at cutover.");
+                }
+                return result;
+            }
+
+            if (!container.SteadyStateSustainable)
+            {
+                result.ResidualDrainDuration = null;
+                result.DrainBounded = false;
+                result.Notes.Add(
+                    "Steady-state sync is unsustainable, so change-feed lag grows without bound before cutover; " +
+                    "the residual at quiesce is unbounded. Increase capacity/parallelism to reach zero lag first.");
+                return result;
+            }
+
+            if (!capacityKnown)
+            {
+                result.ResidualDrainDuration = null;
+                result.DrainBounded = false;
+                result.Notes.Add("Incremental capacity is unknown; the residual drain cannot be bounded.");
+                return result;
+            }
+
+            var drainSeconds = result.ResidualBacklogDocuments / capacity;
+            result.ResidualDrainDuration = SafeFromSeconds(drainSeconds);
+            result.DrainBounded = true;
+            return result;
+        }
+
+        private static void AddAssumptions(CutoverWindowEstimate estimate, double targetMinutes, double parallelismPercent)
+        {
+            estimate.Assumptions.Add(
+                "The source is quiesced (read-only / maintenance mode) for the duration of the window, so no new " +
+                "changes arrive and the residual change-feed backlog drains at the estimated incremental capacity.");
+            estimate.Assumptions.Add(
+                "Residual backlog is the worst-case churn accumulated since the last completed sync checkpoint " +
+                "(one steady-state sync lag); it excludes any pre-existing unbounded lag.");
+            estimate.Assumptions.Add(
+                $"Drain parallelism is assumed at {parallelismPercent:0.##}%: the reported final-sync drain blends the " +
+                "fully-parallel bound (slowest container) and the fully-contended bound (serial sum across containers).");
+            estimate.Assumptions.Add(
+                "Target SQL schema and indexes are assumed already provisioned and write-ready before cutover.");
+            estimate.Assumptions.Add(
+                "Excludes application restart/warmup, DNS TTL / connection-pool recycle, validation-failure retries, " +
+                "and the rollback decision point — budget additional operational time for these.");
+            estimate.Assumptions.Add(
+                $"Risk is assessed against a target downtime of {targetMinutes:0.##} minute(s) " +
+                "(Low ≤ target, Moderate ≤ 2× target, High > 2× target).");
+        }
+
+        private static CutoverDowntimeRisk ClassifyRisk(TimeSpan total, TimeSpan target)
+        {
+            if (total <= target)
+            {
+                return CutoverDowntimeRisk.Low;
+            }
+
+            return total <= target + target ? CutoverDowntimeRisk.Moderate : CutoverDowntimeRisk.High;
+        }
+
+        private static TimeSpan Scale(TimeSpan value, double multiplier)
+            => SafeFromSeconds(value.TotalSeconds * multiplier);
+
+        private static TimeSpan SafeFromSeconds(double seconds)
+        {
+            if (double.IsNaN(seconds) || seconds <= 0)
+            {
+                return TimeSpan.Zero;
+            }
+
+            // Guard against TimeSpan overflow for pathological inputs.
+            const double maxSeconds = 365.0 * 24 * 60 * 60 * 1000; // ~1000 years
+            if (double.IsInfinity(seconds) || seconds > maxSeconds)
+            {
+                return TimeSpan.FromSeconds(maxSeconds);
+            }
+
+            return TimeSpan.FromSeconds(seconds);
+        }
+    }
+}

--- a/Services/Migration/IncrementalSyncEstimator.cs
+++ b/Services/Migration/IncrementalSyncEstimator.cs
@@ -1,0 +1,274 @@
+using CosmosToSqlAssessment.Models;
+using CosmosToSqlAssessment.Models.Migration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace CosmosToSqlAssessment.Services.Migration
+{
+    /// <summary>
+    /// Estimates and compares the initial bulk-load duration against change-feed incremental sync time
+    /// and steady-state behavior (#135 of parent #69). Pure analysis over the already-collected
+    /// <see cref="CosmosDbAnalysis"/> and <see cref="DataFactoryEstimate"/>; performs no live Cosmos DB
+    /// calls and reuses the existing Data Factory initial-load estimate as its baseline.
+    /// </summary>
+    /// <remarks>
+    /// All figures are heuristic planning estimates, not guaranteed throughput. Incremental capacity is
+    /// approximated as a configurable multiple of the estimated end-to-end initial-load throughput
+    /// (default ×1.0), deliberately conservative because incremental sync typically performs more
+    /// expensive target-side upserts/merges than the initial insert-only load.
+    /// </remarks>
+    public sealed class IncrementalSyncEstimator
+    {
+        private const int SecondsPerDay = 86_400;
+
+        private readonly IConfiguration _configuration;
+        private readonly ILogger<IncrementalSyncEstimator> _logger;
+
+        /// <summary>Creates a new <see cref="IncrementalSyncEstimator"/>.</summary>
+        /// <param name="configuration">Configuration supplying the <c>IncrementalMigration:*</c> assumptions.</param>
+        /// <param name="logger">Logger for diagnostic output.</param>
+        public IncrementalSyncEstimator(IConfiguration configuration, ILogger<IncrementalSyncEstimator> logger)
+        {
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// Produces a database-level initial-load-versus-incremental-sync estimate.
+        /// </summary>
+        /// <param name="cosmosAnalysis">The collected Cosmos DB analysis. Must not be <c>null</c>.</param>
+        /// <param name="dataFactoryEstimate">The Data Factory estimate providing initial-load durations. Must not be <c>null</c>.</param>
+        /// <returns>A populated <see cref="IncrementalSyncEstimate"/>.</returns>
+        /// <exception cref="ArgumentNullException">If either argument is <c>null</c>.</exception>
+        public IncrementalSyncEstimate Estimate(CosmosDbAnalysis cosmosAnalysis, DataFactoryEstimate dataFactoryEstimate)
+        {
+            ArgumentNullException.ThrowIfNull(cosmosAnalysis);
+            ArgumentNullException.ThrowIfNull(dataFactoryEstimate);
+
+            var changeRatePercent = Math.Max(0, _configuration.GetValue("IncrementalMigration:DailyChangeRatePercent", 5.0));
+            var syncIntervalMinutes = Math.Max(1, _configuration.GetValue("IncrementalMigration:SyncIntervalMinutes", 15));
+            var throughputFactor = Math.Max(0.01, _configuration.GetValue("IncrementalMigration:IncrementalThroughputFactor", 1.0));
+            var syncInterval = TimeSpan.FromMinutes(syncIntervalMinutes);
+
+            var estimate = new IncrementalSyncEstimate
+            {
+                DailyDocumentChangeRatePercent = changeRatePercent,
+                SyncInterval = syncInterval,
+                IncrementalThroughputFactorRelativeToInitialLoad = throughputFactor,
+                InitialLoadDuration = dataFactoryEstimate.EstimatedDuration,
+            };
+
+            estimate.Assumptions.Add(
+                $"Daily change rate is interpreted as document churn: {changeRatePercent:0.##}% of documents changed per day.");
+            estimate.Assumptions.Add(
+                $"Incremental sync capacity is estimated as {throughputFactor:0.##}× the estimated end-to-end " +
+                "initial-load throughput (not raw change-feed read throughput); incremental upserts/merges may be slower.");
+            estimate.Assumptions.Add(
+                $"Steady-state sync lag assumes an incremental trigger cadence of {syncIntervalMinutes} minute(s).");
+            estimate.Assumptions.Add(
+                "Estimates are heuristic planning figures, not guaranteed SLAs, and do not model queueing variance.");
+
+            if (cosmosAnalysis.Containers.Count == 0)
+            {
+                estimate.SteadyStateSustainable = true;
+                estimate.OverallRisk = SyncSustainabilityRisk.Healthy;
+                estimate.EstimatedBacklogCatchUpAfterInitialLoad = TimeSpan.Zero;
+                estimate.EstimatedSteadyStateSyncLag = syncInterval;
+                estimate.Notes.Add("No containers available; nothing to synchronize.");
+                return estimate;
+            }
+
+            var totalInitialSeconds = Math.Max(0, dataFactoryEstimate.EstimatedDuration.TotalSeconds);
+            long totalDocs = cosmosAnalysis.Containers.Sum(c => Math.Max(0, c.DocumentCount));
+
+            foreach (var container in cosmosAnalysis.Containers)
+            {
+                estimate.Containers.Add(EstimateContainer(
+                    container,
+                    dataFactoryEstimate,
+                    totalInitialSeconds,
+                    totalDocs,
+                    changeRatePercent,
+                    throughputFactor,
+                    syncInterval));
+            }
+
+            estimate.TotalDocuments = totalDocs;
+            estimate.EstimatedTotalChangedDocumentsPerDay = estimate.Containers.Sum(c => c.EstimatedChangedDocumentsPerDay);
+            estimate.EstimatedTotalChangedDocumentsPerSecond = estimate.Containers.Sum(c => c.EstimatedChangedDocumentsPerSecond);
+            estimate.EstimatedBacklogDocumentsAfterInitialLoad = estimate.Containers.Sum(c => c.EstimatedBacklogDocumentsAfterInitialLoad);
+            estimate.SteadyStateSustainable = estimate.Containers.All(c => c.SteadyStateSustainable);
+            estimate.OverallRisk = estimate.Containers.Select(c => c.Risk).DefaultIfEmpty(SyncSustainabilityRisk.Unknown).Max();
+            estimate.EstimatedSteadyStateSyncLag = estimate.Containers
+                .Select(c => c.EstimatedSteadyStateSyncLag)
+                .DefaultIfEmpty(syncInterval)
+                .Max();
+
+            // Containers sync in parallel, so the overall catch-up is the slowest container. If any
+            // container cannot drain its backlog (null catch-up), the overall catch-up is undefined.
+            if (estimate.Containers.Any(c => c.EstimatedBacklogCatchUp is null))
+            {
+                estimate.EstimatedBacklogCatchUpAfterInitialLoad = null;
+            }
+            else
+            {
+                estimate.EstimatedBacklogCatchUpAfterInitialLoad = estimate.Containers
+                    .Select(c => c.EstimatedBacklogCatchUp!.Value)
+                    .DefaultIfEmpty(TimeSpan.Zero)
+                    .Max();
+            }
+
+            estimate.HighestRiskContainers = estimate.Containers
+                .Where(c => c.Risk is SyncSustainabilityRisk.High or SyncSustainabilityRisk.Unsustainable)
+                .OrderByDescending(c => c.Risk)
+                .ThenByDescending(c => c.UtilizationPercent)
+                .Select(c => c.ContainerName)
+                .ToList();
+
+            if (!estimate.SteadyStateSustainable)
+            {
+                estimate.Notes.Add(
+                    "One or more containers have an estimated change rate at or above incremental capacity. " +
+                    "Increase provisioned throughput / parallelism, raise the change-feed processing capacity, " +
+                    "or shorten the sync interval before relying on incremental sync for cutover.");
+            }
+
+            _logger.LogInformation(
+                "Incremental sync estimated for {ContainerCount} container(s): overall risk {Risk}, sustainable={Sustainable}",
+                estimate.Containers.Count, estimate.OverallRisk, estimate.SteadyStateSustainable);
+
+            return estimate;
+        }
+
+        private static ContainerIncrementalSyncEstimate EstimateContainer(
+            ContainerAnalysis container,
+            DataFactoryEstimate dataFactoryEstimate,
+            double totalInitialSeconds,
+            long totalDocs,
+            double changeRatePercent,
+            double throughputFactor,
+            TimeSpan syncInterval)
+        {
+            var docs = Math.Max(0, container.DocumentCount);
+            var sizeBytes = Math.Max(0, container.SizeBytes);
+
+            var result = new ContainerIncrementalSyncEstimate
+            {
+                ContainerName = container.ContainerName,
+                DocumentCount = docs,
+                SizeBytes = sizeBytes,
+                AverageDocumentSizeBytes = docs > 0 ? (double)sizeBytes / docs : 0,
+                FeedRangeCount = container.FeedRangeCount,
+                DailyDocumentChangeRatePercent = changeRatePercent,
+            };
+
+            // Initial-load duration: prefer the matching pipeline estimate; otherwise distribute the
+            // overall duration by document-count share.
+            var pipeline = dataFactoryEstimate.PipelineEstimates
+                .FirstOrDefault(p => string.Equals(p.SourceContainer, container.ContainerName, StringComparison.OrdinalIgnoreCase));
+            double initialSeconds;
+            if (pipeline is not null)
+            {
+                initialSeconds = Math.Max(0, pipeline.EstimatedDuration.TotalSeconds);
+                result.InitialLoadDuration = pipeline.EstimatedDuration;
+            }
+            else if (totalDocs > 0)
+            {
+                initialSeconds = totalInitialSeconds * ((double)docs / totalDocs);
+                result.InitialLoadDuration = TimeSpan.FromSeconds(initialSeconds);
+                result.Notes.Add("No matching pipeline estimate; initial-load duration distributed by document share.");
+            }
+            else
+            {
+                initialSeconds = 0;
+                result.InitialLoadDuration = TimeSpan.Zero;
+            }
+
+            // Change-rate figures.
+            var changedPerDay = (long)Math.Round(docs * changeRatePercent / 100.0);
+            result.EstimatedChangedDocumentsPerDay = changedPerDay;
+            result.EstimatedChangedDocumentsPerSecond = changedPerDay / (double)SecondsPerDay;
+            result.EstimatedChangedDataPerDayMB = sizeBytes * (changeRatePercent / 100.0) / (1024.0 * 1024.0);
+
+            if (docs == 0)
+            {
+                // Nothing to load or sync.
+                result.InitialLoadThroughputKnown = true;
+                result.SteadyStateSustainable = true;
+                result.Risk = SyncSustainabilityRisk.Healthy;
+                result.EstimatedBacklogCatchUp = TimeSpan.Zero;
+                result.EstimatedSteadyStateSyncLag = syncInterval;
+                result.Notes.Add("Container has no documents; no incremental sync workload.");
+                return result;
+            }
+
+            if (initialSeconds <= 0)
+            {
+                // Documents exist but no measurable initial-load time → capacity is indeterminate.
+                result.InitialLoadThroughputKnown = false;
+                result.Risk = SyncSustainabilityRisk.Unknown;
+                result.SteadyStateSustainable = false;
+                result.EstimatedBacklogCatchUp = null;
+                result.EstimatedSteadyStateSyncLag = syncInterval;
+                result.Notes.Add("Initial-load duration is unknown (non-positive); incremental capacity cannot be estimated.");
+                AddFeedRangeNote(result);
+                return result;
+            }
+
+            result.InitialLoadThroughputKnown = true;
+            result.InitialLoadDocsPerSecond = docs / initialSeconds;
+            var capacity = result.InitialLoadDocsPerSecond * throughputFactor;
+            result.EstimatedIncrementalCapacityDocsPerSecond = capacity;
+
+            var changedPerSecond = result.EstimatedChangedDocumentsPerSecond;
+            result.UtilizationPercent = capacity > 0 ? changedPerSecond / capacity * 100.0 : 0;
+            result.Risk = ClassifyRisk(result.UtilizationPercent);
+            result.SteadyStateSustainable = changedPerSecond < capacity;
+
+            // Backlog accrued during the initial load.
+            result.EstimatedBacklogDocumentsAfterInitialLoad = (long)Math.Round(changedPerSecond * initialSeconds);
+
+            if (result.SteadyStateSustainable)
+            {
+                var drainRate = capacity - changedPerSecond; // net documents drained per second
+                var catchUpSeconds = drainRate > 0
+                    ? result.EstimatedBacklogDocumentsAfterInitialLoad / drainRate
+                    : 0;
+                result.EstimatedBacklogCatchUp = TimeSpan.FromSeconds(catchUpSeconds);
+
+                var processingPerInterval = capacity > 0
+                    ? changedPerSecond * syncInterval.TotalSeconds / capacity
+                    : 0;
+                result.EstimatedSteadyStateSyncLag = syncInterval + TimeSpan.FromSeconds(processingPerInterval);
+            }
+            else
+            {
+                result.EstimatedBacklogCatchUp = null;
+                result.EstimatedSteadyStateSyncLag = syncInterval;
+                result.Notes.Add(
+                    "Estimated change rate meets or exceeds incremental capacity; the backlog cannot drain at this capacity.");
+            }
+
+            AddFeedRangeNote(result);
+            return result;
+        }
+
+        private static void AddFeedRangeNote(ContainerIncrementalSyncEstimate result)
+        {
+            if (result.FeedRangeCount <= 1 && result.EstimatedChangedDocumentsPerDay > 0)
+            {
+                result.Notes.Add(
+                    "Container has a single feed range (physical partition); change-feed processing cannot be " +
+                    "parallelized across partitions, which can limit incremental sync throughput for high change volumes.");
+            }
+        }
+
+        private static SyncSustainabilityRisk ClassifyRisk(double utilizationPercent) => utilizationPercent switch
+        {
+            < 50.0 => SyncSustainabilityRisk.Healthy,
+            < 80.0 => SyncSustainabilityRisk.Moderate,
+            < 100.0 => SyncSustainabilityRisk.High,
+            _ => SyncSustainabilityRisk.Unsustainable,
+        };
+    }
+}

--- a/Services/Migration/PhasedMigrationPlanGenerator.cs
+++ b/Services/Migration/PhasedMigrationPlanGenerator.cs
@@ -1,0 +1,432 @@
+using CosmosToSqlAssessment.Models.Migration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace CosmosToSqlAssessment.Services.Migration
+{
+    /// <summary>
+    /// Synthesizes a phased incremental (change-feed-based) Cosmos DB → SQL migration plan (#137 of parent
+    /// #69) from the already-computed change-feed availability (#134), incremental sync estimate (#135), and
+    /// cutover window (#136). Pure composition; performs no live Cosmos DB calls.
+    /// </summary>
+    /// <remarks>
+    /// The plan follows the parent #69 phase structure (Initial Bulk Load → Incremental Sync &amp;
+    /// Stabilization → Cutover Preparation → Cutover → Verification &amp; Decommission). Elapsed preparation
+    /// time and business downtime are reported separately so they are never conflated. All durations are
+    /// heuristic planning estimates, not guaranteed SLAs.
+    /// </remarks>
+    public sealed class PhasedMigrationPlanGenerator
+    {
+        private readonly IConfiguration _configuration;
+        private readonly ILogger<PhasedMigrationPlanGenerator> _logger;
+
+        /// <summary>Creates a new <see cref="PhasedMigrationPlanGenerator"/>.</summary>
+        /// <param name="configuration">Configuration supplying the <c>IncrementalMigration:*</c> assumptions.</param>
+        /// <param name="logger">Logger for diagnostic output.</param>
+        public PhasedMigrationPlanGenerator(IConfiguration configuration, ILogger<PhasedMigrationPlanGenerator> logger)
+        {
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// Generates the phased migration plan from the incremental migration analysis.
+        /// </summary>
+        /// <param name="analysis">The aggregate holding the #134/#135/#136 analyses. Must not be <c>null</c>.</param>
+        /// <returns>A populated <see cref="PhasedMigrationPlan"/>.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="analysis"/> is <c>null</c>.</exception>
+        public PhasedMigrationPlan Generate(IncrementalMigrationAnalysis analysis)
+        {
+            ArgumentNullException.ThrowIfNull(analysis);
+
+            var changeFeed = analysis.ChangeFeed;
+            var sync = analysis.SyncEstimate;
+            var cutover = analysis.CutoverWindow;
+
+            var soakIntervals = Math.Max(1, _configuration.GetValue("IncrementalMigration:IncrementalSyncSoakIntervals", 4));
+            var soak = TimeSpan.FromSeconds(sync.SyncInterval.TotalSeconds * soakIntervals);
+
+            var plan = new PhasedMigrationPlan();
+
+            var ttlDeleteContainers = changeFeed.Containers
+                .Where(c => c.KnownServerSideTtlDeletes)
+                .Select(c => c.ContainerName)
+                .ToList();
+
+            // Phase durations (separated: elapsed preparation vs business downtime).
+            var initialLoad = sync.InitialLoadDuration;
+            var catchUp = sync.EstimatedBacklogCatchUpAfterInitialLoad;
+            TimeSpan? phase2 = catchUp.HasValue ? catchUp.Value + soak : null;
+
+            plan.Phases.Add(BuildInitialLoadPhase(initialLoad));
+            plan.Phases.Add(BuildIncrementalSyncPhase(phase2, catchUp, soak, soakIntervals, sync, ttlDeleteContainers));
+            plan.Phases.Add(BuildCutoverPrepPhase(sync, cutover));
+            plan.Phases.Add(BuildCutoverPhase(cutover));
+            plan.Phases.Add(BuildVerificationPhase());
+
+            // Elapsed preparation = initial load + incremental catch-up/stabilization (sequential).
+            plan.EstimatedElapsedPreparationDuration = phase2.HasValue ? initialLoad + phase2.Value : null;
+            plan.EstimatedBusinessDowntime = cutover.TotalDowntime;
+            plan.MinimumBusinessDowntime = cutover.MinimumKnownDowntime;
+
+            EvaluateReadiness(plan, changeFeed, sync, cutover, ttlDeleteContainers);
+            AddWarningsAndAssumptions(plan, changeFeed, sync, cutover, ttlDeleteContainers, soakIntervals);
+
+            _logger.LogInformation(
+                "Phased migration plan generated: readiness {Readiness}, {PhaseCount} phases",
+                plan.OverallReadiness, plan.Phases.Count);
+
+            return plan;
+        }
+
+        private static MigrationPlanPhase BuildInitialLoadPhase(TimeSpan initialLoad) => new()
+        {
+            Order = 1,
+            Name = "Initial Bulk Load",
+            Objective = "Copy the full existing dataset from Cosmos DB to the Azure SQL target.",
+            PrimaryTooling = "Azure Data Factory Copy activity / mapping data flow.",
+            EstimatedDuration = initialLoad,
+            DurationBasis = "Reuses the Data Factory initial-load estimate for the whole database.",
+            Steps =
+            {
+                "Provision the Azure SQL target schema, keys, and indexes so it is write-ready before loading.",
+                "Define a deterministic key mapping from Cosmos item ids / partition keys to SQL primary keys.",
+                "Build ADF pipelines that flatten Cosmos JSON to the SQL schema (type conversions, null handling).",
+                "Run a pilot load on a representative subset; validate mappings and measure throughput.",
+                "Execute the full bulk load, monitoring for errors and throughput bottlenecks.",
+            },
+            EntryCriteria =
+            {
+                "Target Azure SQL database provisioned with approved schema and security.",
+                "Source/target connectivity validated; ADF integration runtime available.",
+                "Key mapping and type-conversion rules agreed.",
+            },
+            ExitCriteria =
+            {
+                "All existing documents loaded into the SQL target.",
+                "Row/record counts reconciled between source and target.",
+                "Spot-check data validation (profiles, sampled entities) passes.",
+            },
+            Risks =
+            {
+                "Schema/type mismatches (Cosmos schema-less → SQL constraints) can fail rows; validate in the pilot.",
+                "Bulk load competes with the source workload for RU/s; schedule for low-traffic periods.",
+            },
+        };
+
+        private static MigrationPlanPhase BuildIncrementalSyncPhase(
+            TimeSpan? phase2,
+            TimeSpan? catchUp,
+            TimeSpan soak,
+            int soakIntervals,
+            IncrementalSyncEstimate sync,
+            IReadOnlyCollection<string> ttlDeleteContainers)
+        {
+            var phase = new MigrationPlanPhase
+            {
+                Order = 2,
+                Name = "Incremental Sync & Stabilization",
+                Objective = "Continuously apply Cosmos DB change-feed changes to the SQL target and reach a stable, low-lag steady state.",
+                PrimaryTooling = "Change Feed Processor (or ADF change-feed data flow) with idempotent SQL upserts.",
+                EstimatedDuration = phase2,
+                DurationBasis = catchUp.HasValue
+                    ? $"Backlog catch-up ({catchUp.Value:hh\\:mm\\:ss}) accrued during the initial load, plus a minimum " +
+                      $"stabilization soak of {soakIntervals} sync interval(s) (~{soak:hh\\:mm\\:ss}). Stabilization also " +
+                      "requires meeting the exit criteria below, so the real duration may be longer."
+                    : "Unavailable: at least one container's steady-state change rate is unsustainable at the estimated " +
+                      "capacity, so the backlog cannot drain. Increase capacity/parallelism before proceeding.",
+                Steps =
+                {
+                    "Start change-feed processing from the initial-load checkpoint (lease/continuation tracked durably).",
+                    "Apply changes as idempotent upserts keyed by the deterministic SQL key (safe to replay duplicates).",
+                    "Implement a delete-handling strategy: hard deletes and TTL expirations are NOT emitted by the latest-version feed.",
+                    "Stand up lag monitoring and alerting (change-feed lag, failed cycles, change rate vs capacity).",
+                    "Run periodic reconciliation (counts, checksums/hashes where feasible, sampled entity comparison).",
+                },
+                EntryCriteria =
+                {
+                    "Initial bulk load complete and reconciled.",
+                    "Change-feed processing host / ADF trigger deployed with durable checkpoints.",
+                    "Lag monitoring and alerting in place.",
+                },
+                ExitCriteria =
+                {
+                    $"Change-feed lag stays below the agreed threshold for at least {soakIntervals} consecutive sync interval(s).",
+                    "No failed sync cycles during the observation window.",
+                    "Steady-state change rate remains below the sustainable incremental capacity.",
+                    "Delete/update handling validated; reconciliation sample passes.",
+                },
+                Risks =
+                {
+                    "Latest-version change feed does not emit deletes; a separate delete-reconciliation mechanism is required.",
+                    "A fixed soak is a minimum only; production traffic patterns may require a longer observation window.",
+                },
+            };
+
+            if (!sync.SteadyStateSustainable)
+            {
+                phase.Risks.Add(
+                    "Steady-state sync is estimated as UNSUSTAINABLE — change rate meets/exceeds capacity. Increase " +
+                    "provisioned throughput/parallelism or shorten the sync interval before relying on incremental sync.");
+            }
+
+            if (ttlDeleteContainers.Count > 0)
+            {
+                phase.Risks.Add(
+                    $"{ttlDeleteContainers.Count} container(s) have TTL-based server-side deletes the latest-version feed " +
+                    "won't surface (" + string.Join(", ", ttlDeleteContainers) + "). Verify all-versions-and-deletes mode " +
+                    "or design an out-of-band delete-reconciliation process.");
+            }
+
+            return phase;
+        }
+
+        private static MigrationPlanPhase BuildCutoverPrepPhase(IncrementalSyncEstimate sync, CutoverWindowEstimate cutover)
+        {
+            var deltaWindow = sync.EstimatedSteadyStateSyncLag > TimeSpan.Zero
+                ? $"~{sync.EstimatedSteadyStateSyncLag:hh\\:mm\\:ss}"
+                : "one sync interval";
+
+            return new MigrationPlanPhase
+            {
+                Order = 3,
+                Name = "Cutover Preparation",
+                Objective = "Rehearse the cutover, prove reconciliation, and stage the rollback plan so the go/no-go decision is data-driven.",
+                PrimaryTooling = "ADF / change-feed pipeline, staging application environment, reconciliation tooling.",
+                EstimatedDuration = null,
+                DurationBasis = $"Operationally scheduled (not modeled). The expected residual delta at quiesce is {deltaWindow}.",
+                Steps =
+                {
+                    "Point a staging/test instance of the application at the SQL target and validate operational semantics.",
+                    "Rehearse the write-freeze and final-sync drill end-to-end; time it.",
+                    "Author and test the rollback runbook (see rollback guidance) including a maximum rollback window.",
+                    "Agree go/no-go criteria and the cutover decision gate with stakeholders.",
+                    "Schedule and communicate the maintenance window.",
+                },
+                EntryCriteria =
+                {
+                    "Incremental sync stable at low lag (Phase 2 exit criteria met).",
+                    "Reconciliation method automated and passing.",
+                },
+                ExitCriteria =
+                {
+                    "Staging application validated against the SQL target.",
+                    "Rollback runbook tested; go/no-go criteria agreed.",
+                    "Maintenance window scheduled and communicated.",
+                },
+                Risks =
+                {
+                    "Skipping a timed dress rehearsal makes the cutover-window estimate unreliable.",
+                    cutover.Feasibility == CutoverFeasibility.RequiresPreCutoverCatchUp
+                        ? "Cutover currently requires pre-cutover catch-up: do not schedule the window until lag is drained to zero."
+                        : "Confirm the estimated cutover window fits the agreed downtime budget before committing.",
+                },
+                RollbackGuidance =
+                    "Prepare rollback BEFORE the cutover. A simple 'repoint to Cosmos' is only safe while writes are still " +
+                    "routed exclusively to Cosmos (i.e. before SQL is made writable). Once the SQL target accepts writes, " +
+                    "rollback requires a documented reverse-sync/compensation plan or must be accepted as 'restore service " +
+                    "to Cosmos with possible data loss and manual reconciliation'. Define a maximum rollback window.",
+            };
+        }
+
+        private static MigrationPlanPhase BuildCutoverPhase(CutoverWindowEstimate cutover)
+        {
+            var bounded = cutover.TotalDowntime.HasValue;
+            return new MigrationPlanPhase
+            {
+                Order = 4,
+                Name = "Cutover",
+                Objective = "Quiesce the source, drain the final residual changes, switch the application to SQL, and validate before resuming writes.",
+                PrimaryTooling = "Application connection/DNS switch, change-feed final drain, validation scripts.",
+                EstimatedDuration = cutover.TotalDowntime,
+                DurationBasis = bounded
+                    ? $"Estimated cutover downtime window {cutover.TotalDowntime:hh\\:mm\\:ss} (risk {cutover.Risk}): quiesce + " +
+                      "final-sync drain + validation + connection switch + safety buffer."
+                    : $"Full window unavailable until pre-cutover catch-up is achieved; the known floor (fixed overhead with " +
+                      $"buffer) is ~{cutover.MinimumKnownDowntime:hh\\:mm\\:ss}.",
+                Steps =
+                {
+                    "Quiesce the application / set the source to read-only so no new changes are generated.",
+                    "Run the final change-feed drain until residual lag reaches zero (verify, do not assume).",
+                    "Run the reconciliation gate (counts/checksums/sample) — this is the go/no-go decision point.",
+                    "Switch the application connection string / DNS to the SQL target.",
+                    "Run smoke and business-validation tests before re-enabling writes.",
+                },
+                EntryCriteria =
+                {
+                    "Cutover preparation complete; rollback runbook ready.",
+                    "Go decision recorded at the decision gate.",
+                },
+                ExitCriteria =
+                {
+                    "Final residual change-feed lag confirmed at zero.",
+                    "Reconciliation gate passed; smoke/business tests green.",
+                    "Application operating against SQL with writes enabled; stakeholder sign-off.",
+                },
+                Risks =
+                {
+                    "Enabling SQL writes makes rollback non-trivial (state can diverge); treat the decision gate as a hard stop.",
+                    bounded
+                        ? "Downtime overruns if the final drain or validation takes longer than estimated; the safety buffer mitigates but does not guarantee."
+                        : "The downtime window is unbounded until lag is drained pre-cutover; do not commit a maintenance window yet.",
+                },
+                RollbackGuidance =
+                    "If the reconciliation gate or smoke tests fail BEFORE writes are enabled on SQL, abort and keep serving " +
+                    "from Cosmos (low risk). If failure is detected AFTER SQL writes are enabled, execute the reverse-sync/" +
+                    "compensation plan or accept restoring service to Cosmos with possible loss of SQL-side writes. Never " +
+                    "silently repoint to Cosmos once SQL has accepted writes.",
+            };
+        }
+
+        private static MigrationPlanPhase BuildVerificationPhase() => new()
+        {
+            Order = 5,
+            Name = "Verification & Decommission",
+            Objective = "Confirm sustained healthy operation on SQL, then retire the migration infrastructure and the source.",
+            PrimaryTooling = "Application monitoring/alerting, reconciliation tooling, Azure resource management.",
+            EstimatedDuration = null,
+            DurationBasis = "Operationally determined (a post-cutover monitoring soak before decommissioning).",
+            Steps =
+            {
+                "Monitor application health, latency, and error rates against SQL for an agreed soak period.",
+                "Run a final full reconciliation between the (now frozen) Cosmos source and SQL.",
+                "Keep the Cosmos source and pipelines available as a fallback until the soak passes.",
+                "Archive Cosmos backups; decommission change-feed processors, ADF pipelines, and interim resources.",
+                "Capture lessons learned and update the runbook.",
+            },
+            EntryCriteria =
+            {
+                "Cutover complete; application live on SQL.",
+            },
+            ExitCriteria =
+            {
+                "Monitoring soak passed with no data-integrity or performance regressions.",
+                "Final reconciliation clean; stakeholder acceptance received.",
+                "Interim resources decommissioned; source retired or archived per policy.",
+            },
+            Risks =
+            {
+                "Decommissioning the source before the soak passes removes the safe fallback — keep it until sign-off.",
+            },
+            RollbackGuidance =
+                "Retain the Cosmos source and pipelines until the monitoring soak passes so a fallback remains possible; " +
+                "after decommission, rollback is no longer a simple option.",
+        };
+
+        private static void EvaluateReadiness(
+            PhasedMigrationPlan plan,
+            ChangeFeedAvailabilityAnalysis changeFeed,
+            IncrementalSyncEstimate sync,
+            CutoverWindowEstimate cutover,
+            IReadOnlyCollection<string> ttlDeleteContainers)
+        {
+            var hasScope = changeFeed.Containers.Count > 0 || sync.Containers.Count > 0;
+            if (!hasScope)
+            {
+                plan.OverallReadiness = MigrationReadiness.Unknown;
+                plan.ReadinessFactors.Add("No containers found in scope; nothing to migrate incrementally.");
+                return;
+            }
+
+            // Blocking conditions ⇒ NotReady (sync infeasibility wins over a feasible cutover).
+            var blocking = new List<string>();
+            if (sync.OverallRisk == SyncSustainabilityRisk.Unsustainable || !sync.SteadyStateSustainable)
+            {
+                blocking.Add("Steady-state incremental sync is estimated as unsustainable at the current capacity/change rate.");
+            }
+
+            if (!changeFeed.AllContainersSupportLatestVersionIncrementalSync)
+            {
+                blocking.Add("One or more containers cannot support latest-version change-feed incremental sync.");
+            }
+
+            if (blocking.Count > 0)
+            {
+                plan.OverallReadiness = MigrationReadiness.NotReady;
+                plan.ReadinessFactors.AddRange(blocking);
+                return;
+            }
+
+            // Caveats ⇒ ReadyWithCaveats.
+            var caveats = new List<string>();
+            if (cutover.Feasibility == CutoverFeasibility.RequiresPreCutoverCatchUp)
+            {
+                caveats.Add("Cutover requires draining change-feed lag to zero before the window can be bounded.");
+            }
+
+            if (ttlDeleteContainers.Count > 0 || changeFeed.AnyContainerHasKnownServerSideDeletes)
+            {
+                caveats.Add("TTL-based server-side deletes are not surfaced by the latest-version feed; delete fidelity needs manual verification/design.");
+            }
+
+            if (sync.OverallRisk == SyncSustainabilityRisk.High ||
+                cutover.Risk is CutoverDowntimeRisk.High or CutoverDowntimeRisk.Moderate)
+            {
+                caveats.Add("Elevated sync and/or cutover risk; validate capacity and downtime budget with a dress rehearsal.");
+            }
+
+            plan.OverallReadiness = caveats.Count > 0 ? MigrationReadiness.ReadyWithCaveats : MigrationReadiness.Ready;
+            plan.ReadinessFactors.AddRange(caveats.Count > 0
+                ? caveats
+                : new List<string> { "Change-feed availability, sync sustainability, and cutover feasibility are all healthy." });
+        }
+
+        private static void AddWarningsAndAssumptions(
+            PhasedMigrationPlan plan,
+            ChangeFeedAvailabilityAnalysis changeFeed,
+            IncrementalSyncEstimate sync,
+            CutoverWindowEstimate cutover,
+            IReadOnlyCollection<string> ttlDeleteContainers,
+            int soakIntervals)
+        {
+            // Consistency diagnostics so the plan cannot be silently misread.
+            if (!sync.SteadyStateSustainable && cutover.Feasibility == CutoverFeasibility.Feasible)
+            {
+                plan.PlanWarnings.Add(
+                    "Inconsistent upstream signals: steady-state sync is unsustainable yet the cutover appears feasible. " +
+                    "Sync infeasibility governs — the plan is treated as NotReady.");
+            }
+
+            if (sync.EstimatedBacklogCatchUpAfterInitialLoad is null)
+            {
+                plan.PlanWarnings.Add("Backlog catch-up is unavailable because at least one container is unsustainable; the preparation duration is unknown.");
+            }
+
+            if (cutover.TotalDowntime is null)
+            {
+                plan.PlanWarnings.Add($"Cutover downtime is unavailable; only the minimum fixed overhead (~{cutover.MinimumKnownDowntime:hh\\:mm\\:ss}) is known.");
+            }
+
+            if (ttlDeleteContainers.Count > 0)
+            {
+                plan.PlanWarnings.Add($"Change-feed delete fidelity requires manual verification for {ttlDeleteContainers.Count} container(s) with TTL deletes.");
+            }
+
+            plan.PlanWarnings.Add("Estimated totals exclude the operationally-scheduled cutover-preparation and verification phases.");
+
+            // Aggregated key risks.
+            plan.KeyRisks.Add("The latest-version change feed never emits deletes (hard or TTL); a delete-reconciliation design is mandatory.");
+            if (!sync.SteadyStateSustainable)
+            {
+                plan.KeyRisks.Add("Unsustainable steady-state sync: incremental sync cannot keep pace at the estimated capacity.");
+            }
+            if (cutover.Feasibility == CutoverFeasibility.RequiresPreCutoverCatchUp)
+            {
+                plan.KeyRisks.Add("Cutover window is unbounded until pre-cutover catch-up is achieved.");
+            }
+            plan.KeyRisks.Add("Post-cutover rollback is non-trivial once SQL accepts writes; the decision gate is a hard stop.");
+
+            // Assumptions.
+            plan.Assumptions.Add("Elapsed preparation and business downtime are reported separately and must not be summed together.");
+            plan.Assumptions.Add($"Stabilization uses a minimum soak of {soakIntervals} sync interval(s) plus lag-threshold exit criteria.");
+            plan.Assumptions.Add("Incremental sync applies idempotent upserts keyed by a deterministic Cosmos→SQL key mapping.");
+            plan.Assumptions.Add("The SQL target schema and indexes are provisioned and write-ready before the initial load.");
+            plan.Assumptions.Add("All duration figures are heuristic planning estimates, not guaranteed SLAs.");
+
+            if (sync.Containers.Count == 1)
+            {
+                plan.Notes.Add("Single-container migration: concentration risk — the whole migration depends on one container's sync behavior.");
+            }
+        }
+    }
+}

--- a/Services/Migration/TimeBasedPartitioningAnalyzer.cs
+++ b/Services/Migration/TimeBasedPartitioningAnalyzer.cs
@@ -1,0 +1,479 @@
+using CosmosToSqlAssessment.Models;
+using CosmosToSqlAssessment.Models.Migration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace CosmosToSqlAssessment.Services.Migration
+{
+    /// <summary>
+    /// Recommends Azure SQL time-based table partitioning strategies and Cosmos <c>_ts</c>-based initial-load
+    /// slicing for each migrated container (#138 of parent #69). Pure analysis over the already-collected
+    /// <see cref="CosmosDbAnalysis"/>; performs no live Cosmos DB calls.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Partitioning in Azure SQL is primarily a manageability feature (sliding-window aging, partition-level
+    /// maintenance) rather than a general query-performance guarantee, so the analyzer is deliberately
+    /// conservative: it shortlists candidate temporal columns with confidence and mutability risk instead of
+    /// confidently picking one, and it defaults to <see cref="PartitioningStrength.NotRecommended"/> unless
+    /// the data volume justifies the added complexity.
+    /// </para>
+    /// <para>
+    /// The Cosmos system <c>_ts</c> field is the last-<em>modified</em> timestamp (mutable), so it must never
+    /// be used as the SQL partition column — updating a partitioning column forces expensive cross-partition
+    /// row movement. <c>_ts</c> is only recommended for read-side initial-load slicing. The SQL partition
+    /// column should be an immutable creation timestamp; when none exists, the analyzer recommends capturing
+    /// the initial <c>_ts</c> as a stable (but not creation-accurate) <c>InitialLoadTimestamp</c> column.
+    /// </para>
+    /// </remarks>
+    public sealed class TimeBasedPartitioningAnalyzer
+    {
+        private const long BytesPerGigabyte = 1024L * 1024L * 1024L;
+        private const double NearUniversalPrevalence = 0.95;
+
+        private readonly IConfiguration _configuration;
+        private readonly ILogger<TimeBasedPartitioningAnalyzer> _logger;
+
+        /// <summary>Creates a new <see cref="TimeBasedPartitioningAnalyzer"/>.</summary>
+        /// <param name="configuration">Configuration supplying the <c>IncrementalMigration:Partitioning*</c> thresholds.</param>
+        /// <param name="logger">Logger for diagnostic output.</param>
+        public TimeBasedPartitioningAnalyzer(IConfiguration configuration, ILogger<TimeBasedPartitioningAnalyzer> logger)
+        {
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// Produces a database-level time-based partitioning analysis from the supplied Cosmos analysis.
+        /// </summary>
+        /// <param name="cosmosAnalysis">The collected Cosmos DB analysis. Must not be <c>null</c>.</param>
+        /// <returns>A populated <see cref="TimeBasedPartitioningAnalysis"/>.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="cosmosAnalysis"/> is <c>null</c>.</exception>
+        public TimeBasedPartitioningAnalysis Analyze(CosmosDbAnalysis cosmosAnalysis)
+        {
+            ArgumentNullException.ThrowIfNull(cosmosAnalysis);
+
+            var monthlyDocs = Math.Max(1L, _configuration.GetValue("IncrementalMigration:PartitioningMonthlyDocumentThreshold", 1_000_000L));
+            var dailyDocs = Math.Max(monthlyDocs, _configuration.GetValue("IncrementalMigration:PartitioningDailyDocumentThreshold", 50_000_000L));
+            var monthlySizeGb = Math.Max(0.0, _configuration.GetValue("IncrementalMigration:PartitioningMonthlySizeGB", 5.0));
+            var dailySizeGb = Math.Max(monthlySizeGb, _configuration.GetValue("IncrementalMigration:PartitioningDailySizeGB", 100.0));
+
+            var analysis = new TimeBasedPartitioningAnalysis();
+
+            foreach (var container in cosmosAnalysis.Containers)
+            {
+                analysis.Containers.Add(AnalyzeContainer(container, monthlyDocs, dailyDocs, monthlySizeGb, dailySizeGb));
+            }
+
+            analysis.ContainersRecommendedForPartitioning =
+                analysis.Containers.Count(c => c.Strength != PartitioningStrength.NotRecommended);
+
+            analysis.Assumptions.Add(
+                $"Granularity thresholds: Day when document count \u2265 {dailyDocs:N0} or size \u2265 {dailySizeGb:N0} GB; " +
+                $"Month when \u2265 {monthlyDocs:N0} documents or \u2265 {monthlySizeGb:N0} GB; Year for smaller-but-substantial " +
+                "volumes; otherwise no partitioning.");
+            analysis.Assumptions.Add(
+                "Temporal column suitability is inferred from field names and detected types only; every candidate " +
+                "requires user validation for immutability, non-null coverage, and query/retention alignment.");
+            analysis.Assumptions.Add(
+                "The Cosmos `_ts` system field is the last-modified timestamp (Unix epoch seconds). It is used only " +
+                "for read-side initial-load slicing, never as the SQL partition column.");
+
+            analysis.Notes.Add(
+                "Azure SQL table partitioning is primarily a manageability feature (sliding-window aging, " +
+                "partition-level maintenance), not a general query-performance optimization. Partition elimination " +
+                "only benefits queries that filter on the partition column; validate against the real workload.");
+
+            _logger.LogInformation(
+                "Time-based partitioning analyzed for {ContainerCount} container(s); {Recommended} recommended/conditional",
+                analysis.Containers.Count,
+                analysis.ContainersRecommendedForPartitioning);
+
+            return analysis;
+        }
+
+        private static ContainerPartitioningRecommendation AnalyzeContainer(
+            ContainerAnalysis container,
+            long monthlyDocs,
+            long dailyDocs,
+            double monthlySizeGb,
+            double dailySizeGb)
+        {
+            var recommendation = new ContainerPartitioningRecommendation
+            {
+                ContainerName = container.ContainerName,
+                DocumentCount = container.DocumentCount,
+                SizeBytes = container.SizeBytes,
+                InitialLoadParallelismUpperBound = container.FeedRangeCount,
+            };
+
+            recommendation.InitialLoadSlicingApproach = BuildSlicingApproach(container.FeedRangeCount);
+
+            // Empty / unknown-volume containers: no partitioning decision.
+            if (container.DocumentCount <= 0)
+            {
+                recommendation.Strength = PartitioningStrength.NotRecommended;
+                recommendation.RecommendedGranularity = PartitionGranularity.None;
+                recommendation.SlidingWindow = SlidingWindowConsideration.NotApplicable;
+                recommendation.Rationale.Add(
+                    "Container is empty or its document count is unknown; partitioning cannot be assessed. " +
+                    "Default to a single non-partitioned table and revisit after the initial load.");
+                return recommendation;
+            }
+
+            var candidates = DetectTemporalCandidates(container);
+            recommendation.TemporalColumnCandidates = candidates;
+
+            var hasImmutableCandidate = candidates.Any(c => c.MutabilityRisk == TemporalColumnMutabilityRisk.ImmutableLikely);
+            if (!hasImmutableCandidate)
+            {
+                recommendation.RequiresSyntheticCreationColumn = true;
+                var synthetic = BuildSyntheticCandidate();
+                recommendation.TemporalColumnCandidates.Add(synthetic);
+            }
+
+            // Single recommended column only when exactly one near-universal, high-confidence immutable candidate exists.
+            var strongImmutable = candidates
+                .Where(c => c.Confidence == TemporalColumnConfidence.High
+                    && c.MutabilityRisk == TemporalColumnMutabilityRisk.ImmutableLikely
+                    && c.SchemaPrevalence >= NearUniversalPrevalence)
+                .ToList();
+            recommendation.RecommendedPartitionColumn = strongImmutable.Count == 1 ? strongImmutable[0].FieldName : null;
+
+            var sizeGb = container.SizeBytes / (double)BytesPerGigabyte;
+            recommendation.RecommendedGranularity = DetermineGranularity(
+                container.DocumentCount, sizeGb, monthlyDocs, dailyDocs, monthlySizeGb, dailySizeGb);
+
+            if (recommendation.RecommendedGranularity == PartitionGranularity.None)
+            {
+                recommendation.Strength = PartitioningStrength.NotRecommended;
+                recommendation.SlidingWindow = SlidingWindowConsideration.NotApplicable;
+                recommendation.Rationale.Add(
+                    $"Container holds {container.DocumentCount:N0} document(s) (~{sizeGb:N2} GB), below the partitioning " +
+                    "thresholds. A single non-partitioned table with appropriate indexing is simpler and sufficient.");
+                return recommendation;
+            }
+
+            // Large enough to consider partitioning.
+            recommendation.Strength =
+                recommendation.RecommendedGranularity == PartitionGranularity.Day && recommendation.RecommendedPartitionColumn is not null
+                    ? PartitioningStrength.Recommended
+                    : PartitioningStrength.ConditionalManageability;
+
+            recommendation.Rationale.Add(
+                $"Container holds {container.DocumentCount:N0} document(s) (~{sizeGb:N2} GB); {recommendation.RecommendedGranularity} " +
+                $"granularity keeps partitions a manageable size. Recommended partition function: {recommendation.PartitionFunctionType} " +
+                "over ascending temporal boundaries.");
+
+            if (recommendation.RecommendedPartitionColumn is not null)
+            {
+                recommendation.Rationale.Add(
+                    $"'{recommendation.RecommendedPartitionColumn}' is a high-confidence immutable temporal column present in " +
+                    "effectively all documents, making it a sound partitioning key.");
+            }
+            else if (recommendation.RequiresSyntheticCreationColumn)
+            {
+                recommendation.Rationale.Add(
+                    "No suitable immutable temporal column was detected. Capture the initial `_ts` as a stable " +
+                    "'InitialLoadTimestamp' column at load time and partition on that. It is NOT the document's true " +
+                    "creation time, and change-feed updates must never mutate it.");
+            }
+            else
+            {
+                recommendation.Rationale.Add(
+                    "Multiple or low-confidence temporal candidates were found; no single partition column is auto-selected. " +
+                    "Validate a candidate from the shortlist for immutability and non-null coverage before adopting it.");
+            }
+
+            AddIndexAlignmentCaveats(recommendation);
+            recommendation.SlidingWindow = DetermineSlidingWindow(container, recommendation);
+            AddPartitioningCaveats(container, recommendation);
+
+            return recommendation;
+        }
+
+        private static string BuildSlicingApproach(int feedRangeCount)
+        {
+            var parallelism = feedRangeCount > 0
+                ? $"Parallelize the initial bulk load across feed ranges (upper bound ~{feedRangeCount} workers, " +
+                  "subject to RU limits, throttling, hot ranges, and feed-range split/merge at runtime)."
+                : "Feed-range count is unknown; discover feed ranges at execution time to bound parallel-load workers.";
+
+            return parallelism +
+                " Within each range, optionally sub-slice by `_ts` time windows for resumability and even-sized batches. " +
+                "Window boundaries cannot be sized from static metadata (the `_ts` min/max range is unknown here); " +
+                "determine the range at execution time using adaptive windowing.";
+        }
+
+        private static TemporalColumnCandidate BuildSyntheticCandidate() => new()
+        {
+            FieldName = "InitialLoadTimestamp",
+            RecommendedSqlType = "datetime2",
+            Confidence = TemporalColumnConfidence.Medium,
+            MutabilityRisk = TemporalColumnMutabilityRisk.ImmutableLikely,
+            SchemaPrevalence = 1.0,
+            IsSyntheticFromInitialLoad = true,
+            Rationale =
+                "Synthetic column derived from the Cosmos `_ts` captured once at initial load. Stable after capture, " +
+                "but it reflects last-modified-at-load time, not the document's original creation time.",
+        };
+
+        private static List<TemporalColumnCandidate> DetectTemporalCandidates(ContainerAnalysis container)
+        {
+            var totalPrevalence = container.DetectedSchemas.Sum(s => s.Prevalence);
+            var useFractionFallback = totalPrevalence <= 0;
+            var schemaCount = container.DetectedSchemas.Count;
+
+            var byField = new Dictionary<string, TemporalFieldAccumulator>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var schema in container.DetectedSchemas)
+            {
+                foreach (var (key, field) in schema.Fields)
+                {
+                    var name = string.IsNullOrWhiteSpace(field.FieldName) ? key : field.FieldName;
+                    if (!IsTemporal(field))
+                    {
+                        continue;
+                    }
+
+                    if (!byField.TryGetValue(name, out var acc))
+                    {
+                        acc = new TemporalFieldAccumulator(name, field);
+                        byField[name] = acc;
+                    }
+
+                    acc.PrevalenceWeight += useFractionFallback ? 1.0 : schema.Prevalence;
+                    acc.SchemaOccurrences++;
+                }
+            }
+
+            var candidates = new List<TemporalColumnCandidate>();
+            foreach (var acc in byField.Values)
+            {
+                var prevalence = useFractionFallback
+                    ? (schemaCount > 0 ? acc.SchemaOccurrences / (double)schemaCount : 0.0)
+                    : Math.Min(1.0, acc.PrevalenceWeight / totalPrevalence);
+
+                candidates.Add(Classify(acc, prevalence));
+            }
+
+            return candidates
+                .OrderByDescending(c => c.Confidence)
+                .ThenByDescending(c => c.MutabilityRisk == TemporalColumnMutabilityRisk.ImmutableLikely)
+                .ThenByDescending(c => c.SchemaPrevalence)
+                .ToList();
+        }
+
+        private static bool IsTemporal(FieldInfo field)
+        {
+            var sqlType = field.RecommendedSqlType?.ToLowerInvariant() ?? string.Empty;
+            if (sqlType.Contains("date") || sqlType.Contains("time"))
+            {
+                return true;
+            }
+
+            if (field.DetectedTypes.Any(t =>
+            {
+                var lower = t.ToLowerInvariant();
+                return lower.Contains("date") || lower.Contains("time");
+            }))
+            {
+                return true;
+            }
+
+            return MatchesTemporalName(Normalize(field.FieldName));
+        }
+
+        private static TemporalColumnCandidate Classify(TemporalFieldAccumulator acc, double prevalence)
+        {
+            var norm = Normalize(acc.Name);
+            var hasDateType = HasDateType(acc.Field);
+
+            TemporalColumnConfidence confidence;
+            TemporalColumnMutabilityRisk mutability;
+            string rationale;
+
+            if (IsMutableName(norm))
+            {
+                confidence = TemporalColumnConfidence.Low;
+                mutability = TemporalColumnMutabilityRisk.MutableLikely;
+                rationale = "Field name suggests a mutable last-modified or business-state timestamp; avoid as a partition key " +
+                    "(updates would force cross-partition row movement).";
+            }
+            else if (IsCreationName(norm))
+            {
+                confidence = hasDateType ? TemporalColumnConfidence.High : TemporalColumnConfidence.Medium;
+                mutability = TemporalColumnMutabilityRisk.ImmutableLikely;
+                rationale = "Field name suggests an immutable creation/insertion timestamp" +
+                    (hasDateType ? " with a date/time type." : " but no date/time type was detected; verify the type.");
+            }
+            else if (IsEventName(norm))
+            {
+                confidence = TemporalColumnConfidence.Medium;
+                mutability = TemporalColumnMutabilityRisk.ImmutableLikely;
+                rationale = "Field name suggests a write-once event/occurrence timestamp; usually immutable but domain-dependent.";
+            }
+            else
+            {
+                confidence = TemporalColumnConfidence.Low;
+                mutability = TemporalColumnMutabilityRisk.Unknown;
+                rationale = "Detected as a temporal field by type, but its name does not indicate whether the value is stable; " +
+                    "validate immutability before using it as a partition key.";
+            }
+
+            if (prevalence < NearUniversalPrevalence && confidence == TemporalColumnConfidence.High)
+            {
+                confidence = TemporalColumnConfidence.Medium;
+                rationale += $" Present in only ~{prevalence:P0} of schema variants, so a partition column built on it could be " +
+                    "nullable/sparse — confirm full coverage.";
+            }
+
+            return new TemporalColumnCandidate
+            {
+                FieldName = acc.Name,
+                RecommendedSqlType = string.IsNullOrWhiteSpace(acc.Field.RecommendedSqlType) ? "datetime2" : acc.Field.RecommendedSqlType,
+                DetectedTypes = new List<string>(acc.Field.DetectedTypes),
+                Confidence = confidence,
+                MutabilityRisk = mutability,
+                SchemaPrevalence = prevalence,
+                Rationale = rationale,
+            };
+        }
+
+        private static PartitionGranularity DetermineGranularity(
+            long documentCount,
+            double sizeGb,
+            long monthlyDocs,
+            long dailyDocs,
+            double monthlySizeGb,
+            double dailySizeGb)
+        {
+            if (documentCount >= dailyDocs || sizeGb >= dailySizeGb)
+            {
+                return PartitionGranularity.Day;
+            }
+
+            if (documentCount >= monthlyDocs || sizeGb >= monthlySizeGb)
+            {
+                return PartitionGranularity.Month;
+            }
+
+            // Year only for a still-substantial volume (a tenth of the monthly threshold or ~1 GB).
+            if (documentCount >= Math.Max(1L, monthlyDocs / 10) || sizeGb >= Math.Min(monthlySizeGb, 1.0))
+            {
+                return PartitionGranularity.Year;
+            }
+
+            return PartitionGranularity.None;
+        }
+
+        private static SlidingWindowConsideration DetermineSlidingWindow(
+            ContainerAnalysis container,
+            ContainerPartitioningRecommendation recommendation)
+        {
+            if (container.DefaultTimeToLiveSeconds is null)
+            {
+                return SlidingWindowConsideration.NotApplicable;
+            }
+
+            var ttlDescription = container.DefaultTimeToLiveSeconds == -1
+                ? "TTL is enabled with no container default (item-level TTL only), so not all documents necessarily expire"
+                : $"TTL has a default of {container.DefaultTimeToLiveSeconds} second(s)";
+
+            recommendation.Caveats.Add(
+                $"{ttlDescription}. Cosmos TTL ages documents by `_ts` (last-modified) time, which differs from a creation-time " +
+                "partition column. Dropping the oldest partition by creation time may delete rows Cosmos would still retain " +
+                "(recently updated) or keep rows Cosmos has already expired. Validate that the SQL retention age basis matches " +
+                "the TTL age basis before using sliding-window partition drops.");
+
+            return SlidingWindowConsideration.ConsiderWithValidation;
+        }
+
+        private static void AddIndexAlignmentCaveats(ContainerPartitioningRecommendation recommendation)
+        {
+            recommendation.IndexAlignmentCaveats.Add(
+                "The partition column must be part of the clustered index key for the table to be partition-aligned.");
+            recommendation.IndexAlignmentCaveats.Add(
+                "Any unique index or primary key must include the partition column to stay aligned and support partition SWITCH.");
+            recommendation.IndexAlignmentCaveats.Add(
+                "Avoid a nullable partition column: NULLs route to the leftmost boundary partition and undermine partition " +
+                "elimination and retention assumptions.");
+            recommendation.IndexAlignmentCaveats.Add(
+                "Plan the partition column together with the primary key, clustered index, and the temporal predicates the " +
+                "workload actually filters on; partitioning is a manageability tool, not an automatic performance win.");
+        }
+
+        private static void AddPartitioningCaveats(ContainerAnalysis container, ContainerPartitioningRecommendation recommendation)
+        {
+            if (container.DetectedSchemas.Count == 0)
+            {
+                recommendation.Caveats.Add(
+                    "No document schema was captured for this container, so temporal column candidates are limited to the " +
+                    "synthetic `_ts`-based column. Validate the target schema manually before partitioning.");
+            }
+
+            if (recommendation.Strength == PartitioningStrength.ConditionalManageability)
+            {
+                recommendation.Caveats.Add(
+                    "Partitioning may help manageability at this scale but should be validated against the expected query " +
+                    "predicates and the retention/archival policy before adoption.");
+            }
+        }
+
+        private static bool HasDateType(FieldInfo field)
+        {
+            var sqlType = field.RecommendedSqlType?.ToLowerInvariant() ?? string.Empty;
+            if (sqlType.Contains("date") || sqlType.Contains("time"))
+            {
+                return true;
+            }
+
+            return field.DetectedTypes.Any(t =>
+            {
+                var lower = t.ToLowerInvariant();
+                return lower.Contains("date") || lower.Contains("time");
+            });
+        }
+
+        private static bool MatchesTemporalName(string norm) =>
+            IsCreationName(norm) || IsEventName(norm) || IsMutableName(norm)
+            || norm.Contains("date") || norm.Contains("time");
+
+        private static bool IsMutableName(string norm) =>
+            norm.Contains("modif") || norm.Contains("updated") || norm.Contains("changed")
+            || norm.StartsWith("last") || norm.Contains("expire") || norm.Contains("expiry")
+            || norm.Contains("due") || norm.Contains("valid") || norm.Contains("deleted")
+            || norm.Contains("processed") || norm.Contains("scheduled") || norm.Contains("effective")
+            || norm.Contains("renew");
+
+        private static bool IsCreationName(string norm) =>
+            norm.Contains("creat") || norm.Contains("inserted") || norm.Contains("dateadded")
+            || norm.Contains("addedon") || norm.Contains("addedat") || norm.Contains("registered");
+
+        private static bool IsEventName(string norm) =>
+            norm.Contains("event") || norm.Contains("occurred") || norm.Contains("occur")
+            || norm.Contains("logged") || norm.Contains("logtime") || norm.Contains("recorded")
+            || norm.Contains("timestamp") || norm.Contains("happened") || norm.Contains("capturedat")
+            || norm.Contains("receivedat") || norm.Contains("sentat") || norm.Contains("postedat");
+
+        private static string Normalize(string? name) =>
+            new string((name ?? string.Empty).Where(char.IsLetterOrDigit).ToArray()).ToLowerInvariant();
+
+        private sealed class TemporalFieldAccumulator
+        {
+            public TemporalFieldAccumulator(string name, FieldInfo field)
+            {
+                Name = name;
+                Field = field;
+            }
+
+            public string Name { get; }
+
+            public FieldInfo Field { get; }
+
+            public double PrevalenceWeight { get; set; }
+
+            public int SchemaOccurrences { get; set; }
+        }
+    }
+}

--- a/appsettings.json
+++ b/appsettings.json
@@ -41,7 +41,9 @@
     "PartitioningMonthlyDocumentThreshold": 1000000,
     "PartitioningDailyDocumentThreshold": 50000000,
     "PartitioningMonthlySizeGB": 5.0,
-    "PartitioningDailySizeGB": 100.0
+    "PartitioningDailySizeGB": 100.0,
+    "ChangeFeedProcessorLeaseBaseRUs": 400,
+    "ChangeFeedProcessorLeaseRUsPerLease": 100
   },
   "Reports": {
     "OutputDirectory": "",

--- a/appsettings.json
+++ b/appsettings.json
@@ -27,6 +27,11 @@
     "SourceRegion": "East US",
     "TargetRegion": "East US"
   },
+  "IncrementalMigration": {
+    "DailyChangeRatePercent": 5.0,
+    "SyncIntervalMinutes": 15,
+    "IncrementalThroughputFactor": 1.0
+  },
   "Reports": {
     "OutputDirectory": "",
     "PromptForOutputDirectory": true,

--- a/appsettings.json
+++ b/appsettings.json
@@ -37,7 +37,11 @@
     "CutoverSafetyBufferPercent": 20,
     "CutoverTargetDowntimeMinutes": 30,
     "CutoverDrainParallelismPercent": 100,
-    "IncrementalSyncSoakIntervals": 4
+    "IncrementalSyncSoakIntervals": 4,
+    "PartitioningMonthlyDocumentThreshold": 1000000,
+    "PartitioningDailyDocumentThreshold": 50000000,
+    "PartitioningMonthlySizeGB": 5.0,
+    "PartitioningDailySizeGB": 100.0
   },
   "Reports": {
     "OutputDirectory": "",

--- a/appsettings.json
+++ b/appsettings.json
@@ -36,7 +36,8 @@
     "CutoverConnectionSwitchMinutes": 5,
     "CutoverSafetyBufferPercent": 20,
     "CutoverTargetDowntimeMinutes": 30,
-    "CutoverDrainParallelismPercent": 100
+    "CutoverDrainParallelismPercent": 100,
+    "IncrementalSyncSoakIntervals": 4
   },
   "Reports": {
     "OutputDirectory": "",

--- a/appsettings.json
+++ b/appsettings.json
@@ -30,7 +30,13 @@
   "IncrementalMigration": {
     "DailyChangeRatePercent": 5.0,
     "SyncIntervalMinutes": 15,
-    "IncrementalThroughputFactor": 1.0
+    "IncrementalThroughputFactor": 1.0,
+    "CutoverAppStopMinutes": 5,
+    "CutoverValidationMinutes": 15,
+    "CutoverConnectionSwitchMinutes": 5,
+    "CutoverSafetyBufferPercent": 20,
+    "CutoverTargetDowntimeMinutes": 30,
+    "CutoverDrainParallelismPercent": 100
   },
   "Reports": {
     "OutputDirectory": "",

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ The application follows enterprise-grade patterns with:
 - **[Usage Guide](usage.md)** - How to run assessments and interpret results
 - **[Real-Time Monitoring and Alerting](monitoring.md)** - Stream migration progress metrics, generate alert-rule ARM templates, the `migration status` CLI, and RU/throughput anomaly detection (parent #133)
 - **[Continuous-Learning Feedback Loop](feedback-loop.md)** - Opt‑in privacy guide: what is/isn't collected, consent, opt in/out, and how refined recommendations are attributed (parent #132)
+- **[Incremental Migration & Sync Process](incremental-migration-sync.md)** - Change-feed-based online migration, sync estimates, cutover window, and partitioning runbook (parent #69)
 - **[SQL Project Generation](sql-project-generation.md)** - Generate SQL Database Projects from assessments
 - **[Transformation Logic](transformation-logic.md)** - Data transformation stored procedures and implementation
 - **[Architecture Overview](architecture.md)** - Technical architecture and design patterns

--- a/docs/incremental-migration-sync.md
+++ b/docs/incremental-migration-sync.md
@@ -79,7 +79,33 @@ Parallelize the initial bulk load across **feed ranges** (physical partitions) a
 
 ## Change Feed Processor
 
-For implementing the continuous sync, see the Change Feed Processor lease-container and mode guidance produced for sub-issue #140.
+For implementing the continuous sync, the assessment produces **Change Feed Processor (CFP)** guidance (sub-issue #140) — an alternative or complement to the generated Data Factory `_ts`-watermark pipeline. CFP is a push-style library that distributes a container's change feed across worker instances using a **lease container** for coordination and checkpointing.
+
+### Lease container
+
+- Provision a **dedicated** lease container (recommended name `leases`, partition key `/id`).
+- The tool suggests a conservative starting throughput of `ChangeFeedProcessorLeaseBaseRUs + ChangeFeedProcessorLeaseRUsPerLease × (total known feed ranges)` RU/s (defaults 400 + 100/lease), clamped to the 400 RU/s minimum, on **autoscale**. This is a starting estimate to monitor (watch for 429s), **not** validated sizing — actual RU is driven by checkpoint frequency, lease renew/acquire cadence, and failovers.
+- One lease is taken per **feed range** (≈ physical partition), so feed-range count is the upper bound on useful parallelism.
+
+### Mode selection and delete handling
+
+- **Latest-version** mode delivers creates/updates **at least once** and never emits deletes. The SQL write path must therefore be **idempotent** (upsert/`MERGE` keyed on document id) to tolerate redelivery after a host restart or lease rebalance.
+- **All-versions-and-deletes (AVAD)** mode also surfaces delete tombstones and intermediate versions **within the continuous-backup retention window**. It applies to Azure Cosmos DB for **NoSQL only**, requires **continuous backup** and the AVAD feature enabled, cannot start from the beginning or an arbitrary historical time, may be unsupported on accounts with partition-merge history, and needs a **recent** `Microsoft.Azure.Cosmos` SDK (verify current support — it has had preview constraints). Use **isolated lease state** for AVAD (a dedicated lease container or a distinct processor name/lease prefix); never reuse a latest-version checkpoint state.
+
+### Compute and scale-out
+
+- Start with **one** instance and scale out based on the change feed **estimator lag**, host CPU/memory, and SQL write throughput.
+- The parallelism ceiling is the feed-range count: the tool reports both a **shared-fleet** ceiling (`max` feed ranges across containers — a single host can run the processors for multiple containers) and an **independent-pools** ceiling (`Σ` feed ranges, one pool per container). When a container's feed-range count is unreadable, its ceiling is **unknown** — determine it at runtime before scaling out.
+
+### Checkpointing
+
+- Default to **automatic per-batch** checkpointing, committed **after** the SQL write succeeds. Combined with at-least-once delivery, idempotent writes make redelivery safe.
+
+### Relationship to the Data Factory pipeline
+
+- The ADF `_ts`-watermark copy is a **scheduled pull** that captures visible creates/updates; deletes need a soft-delete pattern or external reconciliation.
+- A latest-version CFP worker is a **continuous push** of creates/updates (still no deletes); an AVAD CFP worker additionally captures deletes within retention.
+- Pick **one** incremental path per target table. Do **not** run both the ADF pipeline and a CFP worker into the same SQL target without idempotent upserts and duplicate-boundary handling.
 
 ## Operating checklist
 

--- a/docs/incremental-migration-sync.md
+++ b/docs/incremental-migration-sync.md
@@ -1,0 +1,92 @@
+# Incremental Migration & Change Feed Sync Process
+
+This runbook documents how the assessment tool models an **online (near-zero-downtime) migration** from Azure Cosmos DB (SQL/Core API) to Azure SQL using the **Cosmos DB change feed**, and how to operate the sync process the assessment recommends. It corresponds to the *Incremental Migration* worksheet in the Excel report and the *Incremental Migration and Sync Process* section of the Word report.
+
+> All durations the tool produces are **heuristic planning estimates**, not guaranteed SLAs. Validate against a representative test load before committing to a cutover window.
+
+## Why incremental migration
+
+A bulk-only ("lift and shift") migration requires downtime for the entire initial load. For large or write-heavy Cosmos containers that window is often unacceptable. The incremental pattern instead:
+
+1. Performs a **bulk initial load** of existing data while the application keeps running against Cosmos.
+2. Continuously **tails the change feed** to replicate creates/updates that happen during and after the initial load.
+3. Cuts over during a **short maintenance window** that only needs to drain the small residual backlog accumulated since the last sync checkpoint.
+
+## The five phases
+
+The phased plan (rendered in both reports) follows this structure:
+
+| # | Phase | Objective |
+|---|-------|-----------|
+| 1 | Initial Bulk Load | Copy all existing documents to Azure SQL (Azure Data Factory). |
+| 2 | Incremental Sync & Stabilization | Tail the change feed; drain the post-load backlog; soak until lag is stable. |
+| 3 | Cutover Preparation | Freeze schema, finalize validation queries, rehearse the cutover. |
+| 4 | Cutover | Quiesce the source, drain the residual backlog, validate, switch connections. |
+| 5 | Verification & Decommission | Reconcile row counts, monitor the target, decommission the pipeline. |
+
+The tool separates **elapsed preparation time** (wall-clock time to reach a stable, low-lag state — phases 1–2) from **business downtime** (the cutover maintenance window only — phase 4). These are never conflated.
+
+## Change feed modes
+
+| Mode | Emits | Availability | Use when |
+|------|-------|--------------|----------|
+| **Latest-version** (a.k.a. incremental) | Most recent version of each created/updated item | Always available on the SQL API | Creates/updates are sufficient and deletes are handled separately. |
+| **All-versions-and-deletes** (a.k.a. full-fidelity) | Every intermediate version **and delete tombstones**, within a retention window | Requires an explicit container `ChangeFeedPolicy` retention that the public .NET SDK cannot read | You must replicate deletes/intermediate versions through the feed. |
+
+> **Deletes never appear in the latest-version feed.** Application hard deletes and TTL expirations are invisible to it. The assessment always flags `RequiresDeleteHandlingValidation`. Choose one of: a soft-delete pattern, periodic full reconciliation, or all-versions-and-deletes mode (after confirming retention in the portal/ARM).
+
+### TTL and deletes
+
+If a container has TTL enabled (`DefaultTimeToLive` is set), documents expire **server-side** and are deleted without any latest-version change-feed event. Plan an explicit strategy to age out the corresponding SQL rows. The assessment surfaces `KnownServerSideTtlDeletes` per container and downgrades plan readiness to *ReadyWithCaveats* accordingly.
+
+## Initial load vs incremental sync
+
+The assessment compares the estimated **initial bulk-load throughput** (reused from the Data Factory estimate) against the estimated **incremental sync capacity** to produce a sustainability verdict per container:
+
+- **Utilization %** = steady-state change rate ÷ estimated incremental capacity.
+- Risk bands: `Healthy` (<50%), `Moderate` (50–80%), `High` (80–100%), `Unsustainable` (≥100%).
+- **Post-load backlog catch-up**: time to drain the changes that accumulated during the initial load. `Unsustainable` containers have no bounded catch-up — the lag grows without bound and is a blocking issue.
+- **Steady-state sync lag**: the sync interval plus one processing cycle.
+
+Tune assumptions under the `IncrementalMigration` section of `appsettings.json` (`DailyChangeRatePercent`, `SyncIntervalMinutes`, `IncrementalThroughputFactor`).
+
+## Cutover downtime window
+
+The cutover window models the maintenance window during which the source is quiesced (read-only):
+
+```
+downtime = ( app-quiesce + residual-drain + validation + connection-switch ) × (1 + safety-buffer)
+```
+
+- **Residual drain** blends a fully-parallel bound (`max(residualᵢ ÷ capacityᵢ)`) and a fully-contended serial bound (`Σ(residualᵢ ÷ capacityᵢ)`) using `CutoverDrainParallelismPercent`.
+- A **minimum known downtime floor** (fixed overhead + buffer) is always reported, even when the full window cannot be bounded.
+- If any container is unsustainable or has unknown capacity, feasibility is `RequiresPreCutoverCatchUp`: you must drive its lag to zero **before** the window can be bounded.
+- Risk is assessed relative to your target RTO (`CutoverTargetDowntimeMinutes`): `Low` ≤ target, `Moderate` ≤ 2× target, `High` > 2× target.
+
+## Time-based partitioning of the SQL target
+
+For large containers the assessment may recommend **time-based table partitioning** in Azure SQL (for manageability — sliding-window aging and partition-level maintenance — not as a guaranteed query-performance win):
+
+- The partition column must be an **immutable creation timestamp**. The Cosmos `_ts` field is the **last-modified** time (mutable) and must **never** be the SQL partition column — updating a partition column forces expensive cross-partition row movement.
+- The tool **shortlists** candidate temporal columns with a confidence and mutability-risk rating rather than confidently picking one. A single column is auto-recommended only when exactly one near-universal, high-confidence immutable column exists.
+- When no immutable column exists, capture the initial `_ts` once at load time as a stable `InitialLoadTimestamp` column (this is **not** the true creation time; change-feed updates must never mutate it).
+- **Sliding-window** aging is only a *consideration* when TTL is enabled, and carries a caveat: Cosmos TTL ages by `_ts` while the partition column ages by creation time, so the two age bases can disagree. Validate before using partition drops for retention.
+- Remember Azure SQL partition/index alignment rules: the partition column must be in the clustered index key, any unique/primary key must include it, and a nullable partition column routes NULLs to a boundary partition.
+
+### Initial-load slicing
+
+Parallelize the initial bulk load across **feed ranges** (physical partitions) as an upper bound on workers — subject to RU limits, throttling, hot ranges, and feed-range split/merge at runtime. Within each range you can sub-slice by `_ts` time windows for resumability; size the windows at execution time from the actual `_ts` min/max range (it cannot be sized from static metadata).
+
+## Change Feed Processor
+
+For implementing the continuous sync, see the Change Feed Processor lease-container and mode guidance produced for sub-issue #140.
+
+## Operating checklist
+
+1. Confirm the recommended change-feed mode per container; design delete handling.
+2. Run the Data Factory bulk initial load.
+3. Start the change-feed sync; let the post-load backlog drain and soak until lag is stable.
+4. Reconcile counts and validate sample data.
+5. Schedule the cutover window using the estimated downtime (and the minimum floor).
+6. At cutover: quiesce → drain residual → validate → switch connections.
+7. Verify on the target, then decommission the pipeline.

--- a/tests/CosmosToSqlAssessment.Tests/Reporting/IncrementalMigrationReportTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Reporting/IncrementalMigrationReportTests.cs
@@ -1,0 +1,247 @@
+using System.IO.Compression;
+using System.Text;
+using CosmosToSqlAssessment.Models.Migration;
+using CosmosToSqlAssessment.Tests.Infrastructure;
+
+namespace CosmosToSqlAssessment.Tests.Reporting;
+
+/// <summary>
+/// Tests for the incremental (change-feed) migration rendering added to the Excel and Word reports (#139).
+/// Verifies the "Incremental Migration" worksheet and the "Incremental Migration &amp; Sync Process" Word
+/// section are produced when an <see cref="IncrementalMigrationAnalysis"/> is present, and degrade
+/// gracefully when it is absent.
+/// </summary>
+public class IncrementalMigrationReportTests : TestBase, IDisposable
+{
+    private readonly ReportGenerationService _service;
+    private readonly string _tempDirectory;
+
+    /// <summary>
+    /// Initializes the report service and a unique temporary output directory for generated artifacts.
+    /// </summary>
+    public IncrementalMigrationReportTests()
+    {
+        var logger = CreateMockLogger<ReportGenerationService>();
+        _service = new ReportGenerationService(MockConfiguration.Object, logger.Object);
+        _tempDirectory = Path.Combine(Path.GetTempPath(), $"CosmosToSqlIncReport_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    [Fact]
+    public async Task GenerateAssessmentReportAsync_WithIncrementalMigration_ExcelContainsWorksheetAndData()
+    {
+        // Arrange
+        var assessmentResult = CreateSampleAssessmentResult();
+        assessmentResult.IncrementalMigration = BuildSampleIncrementalMigration();
+
+        // Act
+        var (excelPaths, _, _) = await _service.GenerateAssessmentReportAsync(assessmentResult, _tempDirectory);
+
+        // Assert
+        excelPaths.Should().NotBeEmpty();
+        var workbookXml = ReadAllXmlText(excelPaths.First());
+        workbookXml.Should().Contain("Incremental Migration"); // worksheet name in xl/workbook.xml
+        workbookXml.Should().Contain("Change Feed Availability");
+        workbookXml.Should().Contain("Initial Load vs Incremental Sync");
+        workbookXml.Should().Contain("Cutover Downtime Window");
+        workbookXml.Should().Contain("Phased Migration Plan");
+        workbookXml.Should().Contain("Time-Based Partitioning");
+        workbookXml.Should().Contain("orders"); // per-container row rendered
+    }
+
+    [Fact]
+    public async Task GenerateAssessmentReportAsync_WithIncrementalMigration_WordContainsSyncSection()
+    {
+        // Arrange
+        var assessmentResult = CreateSampleAssessmentResult();
+        assessmentResult.IncrementalMigration = BuildSampleIncrementalMigration();
+
+        // Act
+        var (_, wordPath, _) = await _service.GenerateAssessmentReportAsync(assessmentResult, _tempDirectory);
+
+        // Assert
+        File.Exists(wordPath).Should().BeTrue();
+        var documentXml = ReadWordDocumentXml(wordPath);
+        documentXml.Should().Contain("Incremental Migration and Sync Process");
+        documentXml.Should().Contain("Migration Readiness");
+        documentXml.Should().Contain("Change Feed Availability");
+        documentXml.Should().Contain("Initial Load vs Incremental Sync");
+        documentXml.Should().Contain("Cutover Downtime Window");
+        documentXml.Should().Contain("Phased Migration Plan");
+        documentXml.Should().Contain("Time-Based Partitioning");
+    }
+
+    [Fact]
+    public async Task GenerateAssessmentReportAsync_WithoutIncrementalMigration_ExcelShowsNotAvailableAndWordSkipsSection()
+    {
+        // Arrange – the default sample has no IncrementalMigration analysis.
+        var assessmentResult = CreateSampleAssessmentResult();
+        assessmentResult.IncrementalMigration.Should().BeNull();
+
+        // Act
+        var (excelPaths, wordPath, _) = await _service.GenerateAssessmentReportAsync(assessmentResult, _tempDirectory);
+
+        // Assert – worksheet is still added (with an unavailable note); Word section is skipped.
+        var workbookXml = ReadAllXmlText(excelPaths.First());
+        workbookXml.Should().Contain("Incremental Migration");
+        workbookXml.Should().Contain("not available");
+
+        var documentXml = ReadWordDocumentXml(wordPath);
+        documentXml.Should().NotContain("Incremental Migration and Sync Process");
+        documentXml.Should().NotContain("Migration Readiness");
+    }
+
+    private static IncrementalMigrationAnalysis BuildSampleIncrementalMigration()
+    {
+        return new IncrementalMigrationAnalysis
+        {
+            ChangeFeed = new ChangeFeedAvailabilityAnalysis
+            {
+                AllContainersSupportLatestVersionIncrementalSync = true,
+                AnyContainerHasKnownServerSideDeletes = true,
+                DeletePropagationRequiresExternalValidation = true,
+                GlobalWarnings = { "Latest-version change feed never emits hard deletes." },
+                Containers =
+                {
+                    new ContainerChangeFeedReadiness
+                    {
+                        ContainerName = "orders",
+                        LatestVersionChangeFeedAvailable = true,
+                        RecommendedMode = ChangeFeedMode.AllVersionsAndDeletes,
+                        TimeToLiveEnabled = true,
+                        KnownServerSideTtlDeletes = true,
+                        FeedRangeCount = 4
+                    }
+                }
+            },
+            SyncEstimate = new IncrementalSyncEstimate
+            {
+                OverallRisk = SyncSustainabilityRisk.Moderate,
+                SteadyStateSustainable = true,
+                DailyDocumentChangeRatePercent = 5.0,
+                SyncInterval = TimeSpan.FromMinutes(15),
+                InitialLoadDuration = TimeSpan.FromHours(2),
+                EstimatedBacklogCatchUpAfterInitialLoad = TimeSpan.FromMinutes(30),
+                EstimatedSteadyStateSyncLag = TimeSpan.FromMinutes(16),
+                EstimatedTotalChangedDocumentsPerDay = 50_000,
+                HighestRiskContainers = { "orders" },
+                Assumptions = { "Assumed 5% daily churn." },
+                Containers =
+                {
+                    new ContainerIncrementalSyncEstimate
+                    {
+                        ContainerName = "orders",
+                        DocumentCount = 1_000_000,
+                        InitialLoadDuration = TimeSpan.FromHours(2),
+                        InitialLoadThroughputKnown = true,
+                        UtilizationPercent = 60.0,
+                        Risk = SyncSustainabilityRisk.Moderate,
+                        SteadyStateSustainable = true,
+                        EstimatedBacklogCatchUp = TimeSpan.FromMinutes(30),
+                        EstimatedSteadyStateSyncLag = TimeSpan.FromMinutes(16)
+                    }
+                }
+            },
+            CutoverWindow = new CutoverWindowEstimate
+            {
+                Feasibility = CutoverFeasibility.Feasible,
+                Risk = CutoverDowntimeRisk.Low,
+                TotalDowntime = TimeSpan.FromMinutes(25),
+                MinimumKnownDowntime = TimeSpan.FromMinutes(20),
+                FixedOverheadDuration = TimeSpan.FromMinutes(20),
+                ParallelDrainDuration = TimeSpan.FromMinutes(3),
+                FullyContendedDrainDuration = TimeSpan.FromMinutes(5),
+                TargetDowntime = TimeSpan.FromMinutes(30),
+                Assumptions = { "Source quiesced before final drain." }
+            },
+            Plan = new PhasedMigrationPlan
+            {
+                OverallReadiness = MigrationReadiness.ReadyWithCaveats,
+                EstimatedElapsedPreparationDuration = TimeSpan.FromHours(2.5),
+                EstimatedBusinessDowntime = TimeSpan.FromMinutes(25),
+                MinimumBusinessDowntime = TimeSpan.FromMinutes(20),
+                ReadinessFactors = { "TTL deletes require external handling before cutover." },
+                Phases =
+                {
+                    new MigrationPlanPhase
+                    {
+                        Order = 1,
+                        Name = "Initial Bulk Load",
+                        Objective = "Copy existing data to Azure SQL.",
+                        PrimaryTooling = "Azure Data Factory",
+                        EstimatedDuration = TimeSpan.FromHours(2)
+                    }
+                }
+            },
+            Partitioning = new TimeBasedPartitioningAnalysis
+            {
+                ContainersRecommendedForPartitioning = 1,
+                Assumptions = { "Volume thresholds applied per appsettings." },
+                Containers =
+                {
+                    new ContainerPartitioningRecommendation
+                    {
+                        ContainerName = "orders",
+                        Strength = PartitioningStrength.Recommended,
+                        RecommendedGranularity = PartitionGranularity.Day,
+                        RecommendedPartitionColumn = "createdAt",
+                        RequiresSyntheticCreationColumn = false,
+                        SlidingWindow = SlidingWindowConsideration.ConsiderWithValidation,
+                        InitialLoadParallelismUpperBound = 4
+                    }
+                }
+            }
+        };
+    }
+
+    private static string ReadAllXmlText(string xlsxPath)
+    {
+        File.Exists(xlsxPath).Should().BeTrue();
+        var sb = new StringBuilder();
+        using var archive = ZipFile.OpenRead(xlsxPath);
+        foreach (var entry in archive.Entries)
+        {
+            if (!entry.FullName.EndsWith(".xml", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            using var stream = entry.Open();
+            using var reader = new StreamReader(stream);
+            sb.Append(reader.ReadToEnd());
+        }
+
+        return sb.ToString();
+    }
+
+    private static string ReadWordDocumentXml(string docxPath)
+    {
+        File.Exists(docxPath).Should().BeTrue();
+        using var archive = ZipFile.OpenRead(docxPath);
+        var entry = archive.GetEntry("word/document.xml");
+        entry.Should().NotBeNull();
+        using var stream = entry!.Open();
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+
+    /// <summary>
+    /// Removes the temporary output directory created for the test.
+    /// </summary>
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDirectory))
+            {
+                Directory.Delete(_tempDirectory, true);
+            }
+        }
+        catch
+        {
+            // Ignore cleanup errors in tests.
+        }
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Reporting/IncrementalMigrationReportTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Reporting/IncrementalMigrationReportTests.cs
@@ -46,6 +46,7 @@ public class IncrementalMigrationReportTests : TestBase, IDisposable
         workbookXml.Should().Contain("Cutover Downtime Window");
         workbookXml.Should().Contain("Phased Migration Plan");
         workbookXml.Should().Contain("Time-Based Partitioning");
+        workbookXml.Should().Contain("Change Feed Processor Guidance");
         workbookXml.Should().Contain("orders"); // per-container row rendered
     }
 
@@ -69,6 +70,7 @@ public class IncrementalMigrationReportTests : TestBase, IDisposable
         documentXml.Should().Contain("Cutover Downtime Window");
         documentXml.Should().Contain("Phased Migration Plan");
         documentXml.Should().Contain("Time-Based Partitioning");
+        documentXml.Should().Contain("Change Feed Processor Guidance");
     }
 
     [Fact]
@@ -190,6 +192,36 @@ public class IncrementalMigrationReportTests : TestBase, IDisposable
                         InitialLoadParallelismUpperBound = 4
                     }
                 }
+            },
+            ProcessorGuidance = new ChangeFeedProcessorGuidance
+            {
+                SuggestedLeaseContainerStartingRUs = 800,
+                CheckpointStrategy = CheckpointStrategy.AutomaticPerBatch,
+                CheckpointingNote = "At-least-once delivery requires idempotent upsert.",
+                RecommendedInitialComputeInstances = 1,
+                ComputeScaleOutCeilingSharedFleet = 4,
+                ComputeScaleOutCeilingIndependentPools = 4,
+                ScaleOutTrigger = "Scale on estimator lag.",
+                AnyContainerRequiresAllVersionsAndDeletes = true,
+                RequiresContinuousBackupForDeletes = true,
+                Containers =
+                {
+                    new ContainerChangeFeedProcessorGuidance
+                    {
+                        ContainerName = "orders",
+                        RecommendedMode = ChangeFeedMode.AllVersionsAndDeletes,
+                        FeedRangeCount = 4,
+                        FeedRangeCountKnown = true,
+                        MaxUsefulComputeInstances = 4,
+                        RequiresContinuousBackup = true,
+                        RequiresIsolatedLeaseState = true,
+                        DeleteHandlingNote = "AVAD surfaces delete tombstones within retention."
+                    }
+                },
+                ImplementationSteps = { "Provision a dedicated lease container named leases." },
+                Assumptions = { "One lease per feed range." },
+                Warnings = { "AVAD requires continuous backup enabled." },
+                RelationshipToDataFactoryWatermarkPipeline = { "Choose one incremental path per target table." }
             }
         };
     }

--- a/tests/CosmosToSqlAssessment.Tests/Services/Migration/ChangeFeedAvailabilityAnalyzerTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/Migration/ChangeFeedAvailabilityAnalyzerTests.cs
@@ -1,0 +1,166 @@
+using CosmosToSqlAssessment.Models.Migration;
+using CosmosToSqlAssessment.Services.Migration;
+using CosmosToSqlAssessment.Tests.Infrastructure;
+
+namespace CosmosToSqlAssessment.Tests.Services.Migration;
+
+public class ChangeFeedAvailabilityAnalyzerTests : TestBase
+{
+    private ChangeFeedAvailabilityAnalyzer CreateAnalyzer()
+        => new(CreateMockLogger<ChangeFeedAvailabilityAnalyzer>().Object);
+
+    private static CosmosDbAnalysis AnalysisWith(params ContainerAnalysis[] containers)
+        => new() { Containers = containers.ToList() };
+
+    [Fact]
+    public void Constructor_WithNullLogger_Throws()
+    {
+        var act = () => new ChangeFeedAvailabilityAnalyzer(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Analyze_WithNullAnalysis_Throws()
+    {
+        var analyzer = CreateAnalyzer();
+        var act = () => analyzer.Analyze(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Analyze_WithNoContainers_ReturnsEmptyWithGlobalWarnings()
+    {
+        var analyzer = CreateAnalyzer();
+
+        var result = analyzer.Analyze(AnalysisWith());
+
+        result.Containers.Should().BeEmpty();
+        result.AllContainersSupportLatestVersionIncrementalSync.Should().BeTrue();
+        result.AnyContainerHasKnownServerSideDeletes.Should().BeFalse();
+        result.DeletePropagationRequiresExternalValidation.Should().BeTrue();
+        // The "latest-version never emits deletes" and "all-versions requires manual verification"
+        // global warnings are always present.
+        result.GlobalWarnings.Should().HaveCountGreaterThan(1);
+    }
+
+    [Fact]
+    public void Analyze_ContainerWithoutTtl_RecommendsLatestVersion()
+    {
+        var analyzer = CreateAnalyzer();
+        var container = new ContainerAnalysis
+        {
+            ContainerName = "orders",
+            PartitionKey = "/customerId",
+            DefaultTimeToLiveSeconds = null,
+            FeedRangeCount = 4,
+        };
+
+        var readiness = analyzer.Analyze(AnalysisWith(container)).Containers.Single();
+
+        readiness.LatestVersionChangeFeedAvailable.Should().BeTrue();
+        readiness.RecommendedMode.Should().Be(ChangeFeedMode.LatestVersion);
+        readiness.TimeToLiveEnabled.Should().BeFalse();
+        readiness.DefaultTtlExpirationEnabled.Should().BeFalse();
+        readiness.ItemLevelTtlPossible.Should().BeFalse();
+        readiness.KnownServerSideTtlDeletes.Should().BeFalse();
+        readiness.DeletePropagationSupportedByLatestVersion.Should().BeFalse();
+        readiness.RequiresDeleteHandlingValidation.Should().BeTrue();
+        readiness.AllVersionsAndDeletesAvailability.Should().Be(ChangeFeedModeAvailability.RequiresManualVerification);
+        readiness.FeedRangeCount.Should().Be(4);
+        readiness.Warnings.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Analyze_ContainerWithDefaultTtl_RecommendsAllVersionsAndWarns()
+    {
+        var analyzer = CreateAnalyzer();
+        var container = new ContainerAnalysis
+        {
+            ContainerName = "sessions",
+            PartitionKey = "/sessionId",
+            DefaultTimeToLiveSeconds = 3600,
+        };
+
+        var result = analyzer.Analyze(AnalysisWith(container));
+        var readiness = result.Containers.Single();
+
+        readiness.TimeToLiveEnabled.Should().BeTrue();
+        readiness.DefaultTtlExpirationEnabled.Should().BeTrue();
+        readiness.ItemLevelTtlPossible.Should().BeFalse();
+        readiness.KnownServerSideTtlDeletes.Should().BeTrue();
+        readiness.RecommendedMode.Should().Be(ChangeFeedMode.AllVersionsAndDeletes);
+        readiness.Warnings.Should().ContainSingle(w => w.Contains("TTL"));
+        result.AnyContainerHasKnownServerSideDeletes.Should().BeTrue();
+        result.GlobalWarnings.Should().Contain(w => w.Contains("TTL enabled"));
+    }
+
+    [Fact]
+    public void Analyze_ContainerWithItemLevelTtl_FlagsItemLevelTtlPossible()
+    {
+        var analyzer = CreateAnalyzer();
+        var container = new ContainerAnalysis
+        {
+            ContainerName = "events",
+            PartitionKey = "/deviceId",
+            DefaultTimeToLiveSeconds = -1,
+        };
+
+        var readiness = analyzer.Analyze(AnalysisWith(container)).Containers.Single();
+
+        readiness.TimeToLiveEnabled.Should().BeTrue();
+        readiness.DefaultTtlExpirationEnabled.Should().BeFalse();
+        readiness.ItemLevelTtlPossible.Should().BeTrue();
+        readiness.KnownServerSideTtlDeletes.Should().BeTrue();
+        readiness.RecommendedMode.Should().Be(ChangeFeedMode.AllVersionsAndDeletes);
+    }
+
+    [Fact]
+    public void Analyze_HierarchicalPartitionKey_IsDetected()
+    {
+        var analyzer = CreateAnalyzer();
+        var container = new ContainerAnalysis
+        {
+            ContainerName = "telemetry",
+            PartitionKey = "/tenantId",
+            PartitionKeyPaths = new List<string> { "/tenantId", "/deviceId" },
+        };
+
+        var readiness = analyzer.Analyze(AnalysisWith(container)).Containers.Single();
+
+        readiness.IsHierarchicalPartitionKey.Should().BeTrue();
+        readiness.PartitionKeyPathCount.Should().Be(2);
+        readiness.PartitionKeyPaths.Should().BeEquivalentTo(new[] { "/tenantId", "/deviceId" });
+    }
+
+    [Fact]
+    public void Analyze_SinglePartitionKey_FallsBackToPartitionKeyPath()
+    {
+        var analyzer = CreateAnalyzer();
+        var container = new ContainerAnalysis
+        {
+            ContainerName = "products",
+            PartitionKey = "/categoryId",
+            PartitionKeyPaths = new List<string>(),
+        };
+
+        var readiness = analyzer.Analyze(AnalysisWith(container)).Containers.Single();
+
+        readiness.IsHierarchicalPartitionKey.Should().BeFalse();
+        readiness.PartitionKeyPathCount.Should().Be(1);
+        readiness.PartitionKeyPaths.Should().ContainSingle().Which.Should().Be("/categoryId");
+    }
+
+    [Fact]
+    public void Analyze_MixedContainers_AggregatesFlags()
+    {
+        var analyzer = CreateAnalyzer();
+        var noTtl = new ContainerAnalysis { ContainerName = "a", PartitionKey = "/id", DefaultTimeToLiveSeconds = null };
+        var ttl = new ContainerAnalysis { ContainerName = "b", PartitionKey = "/id", DefaultTimeToLiveSeconds = 600 };
+
+        var result = analyzer.Analyze(AnalysisWith(noTtl, ttl));
+
+        result.Containers.Should().HaveCount(2);
+        result.AllContainersSupportLatestVersionIncrementalSync.Should().BeTrue();
+        result.AnyContainerHasKnownServerSideDeletes.Should().BeTrue();
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/Migration/ChangeFeedProcessorGuidanceGeneratorTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/Migration/ChangeFeedProcessorGuidanceGeneratorTests.cs
@@ -1,0 +1,214 @@
+using CosmosToSqlAssessment.Models.Migration;
+using CosmosToSqlAssessment.Services.Migration;
+using CosmosToSqlAssessment.Tests.Infrastructure;
+using Microsoft.Extensions.Configuration;
+
+namespace CosmosToSqlAssessment.Tests.Services.Migration;
+
+public class ChangeFeedProcessorGuidanceGeneratorTests : TestBase
+{
+    private ChangeFeedProcessorGuidanceGenerator CreateGenerator(int baseRUs = 400, int perLeaseRUs = 100)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["IncrementalMigration:ChangeFeedProcessorLeaseBaseRUs"] = baseRUs.ToString(),
+                ["IncrementalMigration:ChangeFeedProcessorLeaseRUsPerLease"] = perLeaseRUs.ToString(),
+            })
+            .Build();
+        return new ChangeFeedProcessorGuidanceGenerator(config, CreateMockLogger<ChangeFeedProcessorGuidanceGenerator>().Object);
+    }
+
+    private static IncrementalMigrationAnalysis AnalysisWith(params ContainerChangeFeedReadiness[] containers)
+        => new()
+        {
+            ChangeFeed = new ChangeFeedAvailabilityAnalysis
+            {
+                Containers = containers.ToList(),
+            },
+        };
+
+    private static ContainerChangeFeedReadiness Container(
+        string name,
+        ChangeFeedMode mode = ChangeFeedMode.LatestVersion,
+        int feedRanges = 4)
+        => new()
+        {
+            ContainerName = name,
+            RecommendedMode = mode,
+            FeedRangeCount = feedRanges,
+        };
+
+    [Fact]
+    public void Constructor_WithNullArguments_Throws()
+    {
+        var config = new ConfigurationBuilder().Build();
+        var actConfig = () => new ChangeFeedProcessorGuidanceGenerator(null!, CreateMockLogger<ChangeFeedProcessorGuidanceGenerator>().Object);
+        var actLogger = () => new ChangeFeedProcessorGuidanceGenerator(config, null!);
+        actConfig.Should().Throw<ArgumentNullException>();
+        actLogger.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Generate_WithNullAnalysis_Throws()
+    {
+        var generator = CreateGenerator();
+        var act = () => generator.Generate(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Generate_LatestVersionContainers_RecommendsAutomaticCheckpointAndNoContinuousBackup()
+    {
+        var generator = CreateGenerator();
+        var analysis = AnalysisWith(
+            Container("orders", ChangeFeedMode.LatestVersion, feedRanges: 4),
+            Container("customers", ChangeFeedMode.LatestVersion, feedRanges: 2));
+
+        var guidance = generator.Generate(analysis);
+
+        guidance.AnyContainerRequiresAllVersionsAndDeletes.Should().BeFalse();
+        guidance.RequiresContinuousBackupForDeletes.Should().BeFalse();
+        guidance.CheckpointStrategy.Should().Be(CheckpointStrategy.AutomaticPerBatch);
+        guidance.RecommendedLeaseContainerName.Should().Be("leases");
+        guidance.LeaseContainerPartitionKeyPath.Should().Be("/id");
+        guidance.RecommendedInitialComputeInstances.Should().Be(1);
+        guidance.Containers.Should().HaveCount(2);
+        guidance.Containers.Should().OnlyContain(c => !c.RequiresContinuousBackup && !c.RequiresIsolatedLeaseState);
+    }
+
+    [Fact]
+    public void Generate_LeaseRUs_UsesBasePlusPerLeaseTimesKnownRanges()
+    {
+        var generator = CreateGenerator(baseRUs: 400, perLeaseRUs: 100);
+        var analysis = AnalysisWith(
+            Container("a", feedRanges: 4),
+            Container("b", feedRanges: 2));
+
+        var guidance = generator.Generate(analysis);
+
+        // 400 + 100 * (4 + 2) = 1000
+        guidance.SuggestedLeaseContainerStartingRUs.Should().Be(1000);
+        guidance.LeaseContainerUsesAutoscale.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Generate_LeaseRUs_NeverBelowMinimum()
+    {
+        var generator = CreateGenerator(baseRUs: 100, perLeaseRUs: 0);
+        var analysis = AnalysisWith(Container("a", feedRanges: 1));
+
+        var guidance = generator.Generate(analysis);
+
+        guidance.SuggestedLeaseContainerStartingRUs.Should().BeGreaterThanOrEqualTo(400);
+    }
+
+    [Fact]
+    public void Generate_ComputeCeilings_ReflectSharedFleetAndIndependentPools()
+    {
+        var generator = CreateGenerator();
+        var analysis = AnalysisWith(
+            Container("big", feedRanges: 8),
+            Container("small", feedRanges: 3));
+
+        var guidance = generator.Generate(analysis);
+
+        // Shared fleet = max(8, 3) = 8; independent pools = 8 + 3 = 11
+        guidance.ComputeScaleOutCeilingSharedFleet.Should().Be(8);
+        guidance.ComputeScaleOutCeilingIndependentPools.Should().Be(11);
+        guidance.Containers.Single(c => c.ContainerName == "big").MaxUsefulComputeInstances.Should().Be(8);
+        guidance.Containers.Single(c => c.ContainerName == "small").MaxUsefulComputeInstances.Should().Be(3);
+    }
+
+    [Fact]
+    public void Generate_AllVersionsAndDeletesContainer_SetsContinuousBackupAndIsolatedLeaseFlags()
+    {
+        var generator = CreateGenerator();
+        var analysis = AnalysisWith(
+            Container("ttl-container", ChangeFeedMode.AllVersionsAndDeletes, feedRanges: 4),
+            Container("plain", ChangeFeedMode.LatestVersion, feedRanges: 2));
+
+        var guidance = generator.Generate(analysis);
+
+        guidance.AnyContainerRequiresAllVersionsAndDeletes.Should().BeTrue();
+        guidance.RequiresContinuousBackupForDeletes.Should().BeTrue();
+
+        var avad = guidance.Containers.Single(c => c.ContainerName == "ttl-container");
+        avad.RequiresContinuousBackup.Should().BeTrue();
+        avad.RequiresIsolatedLeaseState.Should().BeTrue();
+        avad.DeleteHandlingNote.Should().Contain("delete");
+
+        var plain = guidance.Containers.Single(c => c.ContainerName == "plain");
+        plain.RequiresContinuousBackup.Should().BeFalse();
+        plain.RequiresIsolatedLeaseState.Should().BeFalse();
+
+        guidance.Warnings.Should().Contain(w => w.Contains("continuous backup", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Generate_UnknownFeedRangeCount_TreatedAsUnknownNotZero()
+    {
+        var generator = CreateGenerator(baseRUs: 400, perLeaseRUs: 100);
+        var analysis = AnalysisWith(Container("unknown", feedRanges: 0));
+
+        var guidance = generator.Generate(analysis);
+
+        var container = guidance.Containers.Single();
+        container.FeedRangeCountKnown.Should().BeFalse();
+        container.MaxUsefulComputeInstances.Should().BeNull();
+        container.Notes.Should().Contain(n => n.Contains("runtime", StringComparison.OrdinalIgnoreCase));
+
+        // No known ranges -> ceilings unknown, lease RUs fall back to base only (never base + perLease*0 changes nothing here, but never negative)
+        guidance.ComputeScaleOutCeilingSharedFleet.Should().BeNull();
+        guidance.ComputeScaleOutCeilingIndependentPools.Should().BeNull();
+        guidance.SuggestedLeaseContainerStartingRUs.Should().Be(400);
+        guidance.RecommendedInitialComputeInstances.Should().Be(1);
+        guidance.Warnings.Should().Contain(w => w.Contains("unreadable", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Generate_MixedKnownAndUnknownRanges_CountsOnlyKnownRanges()
+    {
+        var generator = CreateGenerator(baseRUs: 400, perLeaseRUs: 100);
+        var analysis = AnalysisWith(
+            Container("known", feedRanges: 5),
+            Container("unknown", feedRanges: 0));
+
+        var guidance = generator.Generate(analysis);
+
+        // Only the known 5 ranges count: 400 + 100*5 = 900
+        guidance.SuggestedLeaseContainerStartingRUs.Should().Be(900);
+        guidance.ComputeScaleOutCeilingSharedFleet.Should().Be(5);
+        guidance.ComputeScaleOutCeilingIndependentPools.Should().Be(5);
+    }
+
+    [Fact]
+    public void Generate_EmptyContainerList_ProducesDefaultsWithWarning()
+    {
+        var generator = CreateGenerator();
+        var analysis = AnalysisWith();
+
+        var guidance = generator.Generate(analysis);
+
+        guidance.Containers.Should().BeEmpty();
+        guidance.SuggestedLeaseContainerStartingRUs.Should().Be(400);
+        guidance.ComputeScaleOutCeilingSharedFleet.Should().BeNull();
+        guidance.ComputeScaleOutCeilingIndependentPools.Should().BeNull();
+        guidance.Warnings.Should().Contain(w => w.Contains("No containers", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Generate_AlwaysPopulatesGuidanceNarrative()
+    {
+        var generator = CreateGenerator();
+        var analysis = AnalysisWith(Container("orders", feedRanges: 4));
+
+        var guidance = generator.Generate(analysis);
+
+        guidance.ImplementationSteps.Should().NotBeEmpty();
+        guidance.Assumptions.Should().NotBeEmpty();
+        guidance.RelationshipToDataFactoryWatermarkPipeline.Should().NotBeEmpty();
+        guidance.CheckpointingNote.Should().NotBeNullOrWhiteSpace();
+        guidance.ScaleOutTrigger.Should().NotBeNullOrWhiteSpace();
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/Migration/CutoverWindowCalculatorTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/Migration/CutoverWindowCalculatorTests.cs
@@ -1,0 +1,229 @@
+using System.Globalization;
+using CosmosToSqlAssessment.Models.Migration;
+using CosmosToSqlAssessment.Services.Migration;
+using CosmosToSqlAssessment.Tests.Infrastructure;
+using Microsoft.Extensions.Configuration;
+
+namespace CosmosToSqlAssessment.Tests.Services.Migration;
+
+public class CutoverWindowCalculatorTests : TestBase
+{
+    private CutoverWindowCalculator CreateCalculator(
+        double appStop = 5,
+        double validation = 15,
+        double connectionSwitch = 5,
+        double buffer = 20,
+        double target = 30,
+        double parallelism = 100)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["IncrementalMigration:CutoverAppStopMinutes"] = appStop.ToString(CultureInfo.InvariantCulture),
+                ["IncrementalMigration:CutoverValidationMinutes"] = validation.ToString(CultureInfo.InvariantCulture),
+                ["IncrementalMigration:CutoverConnectionSwitchMinutes"] = connectionSwitch.ToString(CultureInfo.InvariantCulture),
+                ["IncrementalMigration:CutoverSafetyBufferPercent"] = buffer.ToString(CultureInfo.InvariantCulture),
+                ["IncrementalMigration:CutoverTargetDowntimeMinutes"] = target.ToString(CultureInfo.InvariantCulture),
+                ["IncrementalMigration:CutoverDrainParallelismPercent"] = parallelism.ToString(CultureInfo.InvariantCulture),
+            })
+            .Build();
+        return new CutoverWindowCalculator(config, CreateMockLogger<CutoverWindowCalculator>().Object);
+    }
+
+    private static IncrementalSyncEstimate SyncWith(TimeSpan syncInterval, params ContainerIncrementalSyncEstimate[] containers)
+        => new() { SyncInterval = syncInterval, Containers = containers.ToList() };
+
+    private static ContainerIncrementalSyncEstimate SustainableContainer(
+        string name,
+        double changedPerSecond,
+        double capacity,
+        TimeSpan lag)
+        => new()
+        {
+            ContainerName = name,
+            DocumentCount = 1_000_000,
+            EstimatedChangedDocumentsPerSecond = changedPerSecond,
+            EstimatedIncrementalCapacityDocsPerSecond = capacity,
+            EstimatedSteadyStateSyncLag = lag,
+            InitialLoadThroughputKnown = true,
+            SteadyStateSustainable = true,
+        };
+
+    [Fact]
+    public void Calculate_NullArgument_Throws()
+    {
+        var act = () => CreateCalculator().Calculate(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Calculate_NoContainers_IsFixedOverheadOnly()
+    {
+        var result = CreateCalculator(appStop: 5, validation: 15, connectionSwitch: 5, buffer: 20).Calculate(
+            SyncWith(TimeSpan.FromMinutes(15)));
+
+        result.FixedOverheadDuration.Should().Be(TimeSpan.FromMinutes(25));
+        result.MinimumKnownDowntime.Should().Be(TimeSpan.FromMinutes(30)); // 25 * 1.2
+        result.FinalSyncDrainDuration.Should().Be(TimeSpan.Zero);
+        result.TotalDowntime.Should().Be(TimeSpan.FromMinutes(30));
+        result.DrainBounded.Should().BeTrue();
+        result.Feasibility.Should().Be(CutoverFeasibility.Feasible);
+        result.Risk.Should().Be(CutoverDowntimeRisk.Low); // 30 <= target 30
+        result.Notes.Should().Contain(n => n.Contains("No containers"));
+    }
+
+    [Fact]
+    public void Calculate_SustainableContainer_ComputesBoundedWindow()
+    {
+        // capacity 100/s, churn 5/s, lag 900s ⇒ residual 4500 docs, drain 45s.
+        var calc = CreateCalculator(appStop: 1, validation: 2, connectionSwitch: 1, buffer: 0, target: 30);
+        var container = SustainableContainer("c1", changedPerSecond: 5, capacity: 100, lag: TimeSpan.FromSeconds(900));
+
+        var result = calc.Calculate(SyncWith(TimeSpan.FromMinutes(15), container));
+        var c = result.Containers.Single();
+
+        c.ResidualBacklogDocuments.Should().Be(4500);
+        c.DrainBounded.Should().BeTrue();
+        c.ResidualDrainDuration!.Value.TotalSeconds.Should().BeApproximately(45, 0.5);
+        result.FinalSyncDrainDuration!.Value.TotalSeconds.Should().BeApproximately(45, 0.5);
+        result.ParallelDrainDuration!.Value.TotalSeconds.Should().BeApproximately(45, 0.5);
+        result.FullyContendedDrainDuration!.Value.TotalSeconds.Should().BeApproximately(45, 0.5);
+        // fixed overhead 4 min = 240s + 45s = 285s, buffer 0 ⇒ 285s.
+        result.TotalDowntime!.Value.TotalSeconds.Should().BeApproximately(285, 1.0);
+        result.Feasibility.Should().Be(CutoverFeasibility.Feasible);
+        result.Risk.Should().Be(CutoverDowntimeRisk.Low);
+    }
+
+    [Fact]
+    public void Calculate_BufferIsApplied()
+    {
+        var calc = CreateCalculator(appStop: 10, validation: 0, connectionSwitch: 0, buffer: 50, target: 30);
+        var container = SustainableContainer("c1", changedPerSecond: 0, capacity: 100, lag: TimeSpan.FromSeconds(900));
+
+        var result = calc.Calculate(SyncWith(TimeSpan.FromMinutes(15), container));
+
+        // No churn ⇒ residual 0 ⇒ drain 0. Fixed 10 min × 1.5 = 15 min.
+        result.FinalSyncDrainDuration.Should().Be(TimeSpan.Zero);
+        result.TotalDowntime.Should().Be(TimeSpan.FromMinutes(15));
+        result.MinimumKnownDowntime.Should().Be(TimeSpan.FromMinutes(15));
+    }
+
+    [Fact]
+    public void Calculate_RiskBands_DerivedFromTarget()
+    {
+        // fixed 50 min, no drain, target 30 ⇒ 50 > 30 and <= 60 ⇒ Moderate.
+        var moderate = CreateCalculator(appStop: 50, validation: 0, connectionSwitch: 0, buffer: 0, target: 30)
+            .Calculate(SyncWith(TimeSpan.FromMinutes(15)));
+        moderate.TotalDowntime.Should().Be(TimeSpan.FromMinutes(50));
+        moderate.Risk.Should().Be(CutoverDowntimeRisk.Moderate);
+
+        // fixed 90 min, target 30 ⇒ 90 > 60 ⇒ High.
+        var high = CreateCalculator(appStop: 90, validation: 0, connectionSwitch: 0, buffer: 0, target: 30)
+            .Calculate(SyncWith(TimeSpan.FromMinutes(15)));
+        high.Risk.Should().Be(CutoverDowntimeRisk.High);
+    }
+
+    [Fact]
+    public void Calculate_UnsustainableContainer_RequiresPreCutoverCatchUp()
+    {
+        var calc = CreateCalculator();
+        var hot = new ContainerIncrementalSyncEstimate
+        {
+            ContainerName = "hot",
+            DocumentCount = 1_000_000,
+            EstimatedChangedDocumentsPerSecond = 200,
+            EstimatedIncrementalCapacityDocsPerSecond = 100,
+            EstimatedSteadyStateSyncLag = TimeSpan.FromMinutes(15),
+            InitialLoadThroughputKnown = true,
+            SteadyStateSustainable = false,
+        };
+
+        var result = calc.Calculate(SyncWith(TimeSpan.FromMinutes(15), hot));
+
+        result.Feasibility.Should().Be(CutoverFeasibility.RequiresPreCutoverCatchUp);
+        result.TotalDowntime.Should().BeNull();
+        result.FinalSyncDrainDuration.Should().BeNull();
+        result.DrainBounded.Should().BeFalse();
+        result.Risk.Should().Be(CutoverDowntimeRisk.Unknown);
+        result.ContainersRequiringPreCutoverCatchUp.Should().Contain("hot");
+        // The fixed floor is still surfaced.
+        result.MinimumKnownDowntime.Should().BeGreaterThan(TimeSpan.Zero);
+        result.Containers.Single().Notes.Should().Contain(n => n.Contains("unsustainable"));
+    }
+
+    [Fact]
+    public void Calculate_UnknownCapacityWithChurn_RequiresPreCutoverCatchUp()
+    {
+        var calc = CreateCalculator();
+        var unknown = new ContainerIncrementalSyncEstimate
+        {
+            ContainerName = "x",
+            DocumentCount = 1_000,
+            EstimatedChangedDocumentsPerSecond = 1,
+            EstimatedIncrementalCapacityDocsPerSecond = 0,
+            EstimatedSteadyStateSyncLag = TimeSpan.FromMinutes(15),
+            InitialLoadThroughputKnown = false,
+            SteadyStateSustainable = true,
+        };
+
+        var result = calc.Calculate(SyncWith(TimeSpan.FromMinutes(15), unknown));
+
+        result.Feasibility.Should().Be(CutoverFeasibility.RequiresPreCutoverCatchUp);
+        result.Containers.Single().DrainBounded.Should().BeFalse();
+        result.Containers.Single().Notes.Should().Contain(n => n.Contains("capacity is unknown"));
+    }
+
+    [Fact]
+    public void Calculate_ZeroResidualWithUnknownCapacity_IsBounded()
+    {
+        // No churn ⇒ residual 0 ⇒ drain 0 regardless of unknown capacity.
+        var calc = CreateCalculator();
+        var idle = new ContainerIncrementalSyncEstimate
+        {
+            ContainerName = "idle",
+            DocumentCount = 1_000,
+            EstimatedChangedDocumentsPerSecond = 0,
+            EstimatedIncrementalCapacityDocsPerSecond = 0,
+            EstimatedSteadyStateSyncLag = TimeSpan.FromMinutes(15),
+            InitialLoadThroughputKnown = false,
+            SteadyStateSustainable = true,
+        };
+
+        var result = calc.Calculate(SyncWith(TimeSpan.FromMinutes(15), idle));
+
+        result.Containers.Single().DrainBounded.Should().BeTrue();
+        result.Containers.Single().ResidualDrainDuration.Should().Be(TimeSpan.Zero);
+        result.Feasibility.Should().Be(CutoverFeasibility.Feasible);
+        result.TotalDowntime.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Calculate_FullContention_UsesSerialSum()
+    {
+        // parallelism 0 ⇒ final drain = serial sum of per-container drains.
+        // c1: residual 4500/100 = 45s; c2: residual 9000/100 = 90s. parallel max = 90s, serial = 135s.
+        var calc = CreateCalculator(appStop: 0, validation: 0, connectionSwitch: 0, buffer: 0, target: 30, parallelism: 0);
+        var c1 = SustainableContainer("c1", changedPerSecond: 5, capacity: 100, lag: TimeSpan.FromSeconds(900));
+        var c2 = SustainableContainer("c2", changedPerSecond: 10, capacity: 100, lag: TimeSpan.FromSeconds(900));
+
+        var result = calc.Calculate(SyncWith(TimeSpan.FromMinutes(15), c1, c2));
+
+        result.ParallelDrainDuration!.Value.TotalSeconds.Should().BeApproximately(90, 1.0);
+        result.FullyContendedDrainDuration!.Value.TotalSeconds.Should().BeApproximately(135, 1.0);
+        result.FinalSyncDrainDuration!.Value.TotalSeconds.Should().BeApproximately(135, 1.0);
+        result.Notes.Should().Contain(n => n.Contains("contention"));
+    }
+
+    [Fact]
+    public void Calculate_FullParallel_UsesSlowestContainer()
+    {
+        var calc = CreateCalculator(appStop: 0, validation: 0, connectionSwitch: 0, buffer: 0, target: 30, parallelism: 100);
+        var c1 = SustainableContainer("c1", changedPerSecond: 5, capacity: 100, lag: TimeSpan.FromSeconds(900));
+        var c2 = SustainableContainer("c2", changedPerSecond: 10, capacity: 100, lag: TimeSpan.FromSeconds(900));
+
+        var result = calc.Calculate(SyncWith(TimeSpan.FromMinutes(15), c1, c2));
+
+        // Fully parallel ⇒ slowest container (90s), not the serial sum.
+        result.FinalSyncDrainDuration!.Value.TotalSeconds.Should().BeApproximately(90, 1.0);
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/Migration/IncrementalSyncEstimatorTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/Migration/IncrementalSyncEstimatorTests.cs
@@ -1,0 +1,210 @@
+using System.Globalization;
+using CosmosToSqlAssessment.Models.Migration;
+using CosmosToSqlAssessment.Services.Migration;
+using CosmosToSqlAssessment.Tests.Infrastructure;
+using Microsoft.Extensions.Configuration;
+
+namespace CosmosToSqlAssessment.Tests.Services.Migration;
+
+public class IncrementalSyncEstimatorTests : TestBase
+{
+    private IncrementalSyncEstimator CreateEstimator(double rate = 5.0, int intervalMinutes = 15, double factor = 1.0)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["IncrementalMigration:DailyChangeRatePercent"] = rate.ToString(CultureInfo.InvariantCulture),
+                ["IncrementalMigration:SyncIntervalMinutes"] = intervalMinutes.ToString(CultureInfo.InvariantCulture),
+                ["IncrementalMigration:IncrementalThroughputFactor"] = factor.ToString(CultureInfo.InvariantCulture),
+            })
+            .Build();
+        return new IncrementalSyncEstimator(config, CreateMockLogger<IncrementalSyncEstimator>().Object);
+    }
+
+    private static CosmosDbAnalysis CosmosWith(params ContainerAnalysis[] containers)
+        => new() { Containers = containers.ToList() };
+
+    private static DataFactoryEstimate DfWith(TimeSpan overall, params PipelineEstimate[] pipelines)
+        => new() { EstimatedDuration = overall, PipelineEstimates = pipelines.ToList() };
+
+    [Fact]
+    public void Estimate_NullArguments_Throw()
+    {
+        var estimator = CreateEstimator();
+        var actCosmos = () => estimator.Estimate(null!, DfWith(TimeSpan.Zero));
+        var actDf = () => estimator.Estimate(CosmosWith(), null!);
+        actCosmos.Should().Throw<ArgumentNullException>();
+        actDf.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Estimate_NoContainers_IsHealthyAndSustainable()
+    {
+        var estimator = CreateEstimator();
+
+        var result = estimator.Estimate(CosmosWith(), DfWith(TimeSpan.FromHours(1)));
+
+        result.Containers.Should().BeEmpty();
+        result.SteadyStateSustainable.Should().BeTrue();
+        result.OverallRisk.Should().Be(SyncSustainabilityRisk.Healthy);
+        result.EstimatedBacklogCatchUpAfterInitialLoad.Should().Be(TimeSpan.Zero);
+        result.Notes.Should().Contain(n => n.Contains("No containers"));
+        result.Assumptions.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void Estimate_HealthyContainer_ComputesThroughputAndCatchUp()
+    {
+        // 8,640,000 docs over 86,400s initial load = 100 docs/sec capacity (factor 1.0).
+        // 5%/day churn = 432,000/day = 5 docs/sec → utilization 5% → Healthy.
+        var estimator = CreateEstimator(rate: 5.0, factor: 1.0);
+        var container = new ContainerAnalysis
+        {
+            ContainerName = "c1",
+            DocumentCount = 8_640_000,
+            SizeBytes = 8_640_000L * 1024,
+            FeedRangeCount = 4,
+        };
+        var df = DfWith(TimeSpan.FromSeconds(86_400),
+            new PipelineEstimate { SourceContainer = "c1", EstimatedDuration = TimeSpan.FromSeconds(86_400) });
+
+        var result = estimator.Estimate(CosmosWith(container), df);
+        var c = result.Containers.Single();
+
+        c.InitialLoadDocsPerSecond.Should().BeApproximately(100.0, 0.001);
+        c.EstimatedIncrementalCapacityDocsPerSecond.Should().BeApproximately(100.0, 0.001);
+        c.EstimatedChangedDocumentsPerSecond.Should().BeApproximately(5.0, 0.001);
+        c.UtilizationPercent.Should().BeApproximately(5.0, 0.001);
+        c.Risk.Should().Be(SyncSustainabilityRisk.Healthy);
+        c.SteadyStateSustainable.Should().BeTrue();
+        c.EstimatedBacklogDocumentsAfterInitialLoad.Should().Be(432_000);
+        c.EstimatedBacklogCatchUp.Should().NotBeNull();
+        c.EstimatedBacklogCatchUp!.Value.TotalSeconds.Should().BeApproximately(432_000 / 95.0, 1.0);
+        result.SteadyStateSustainable.Should().BeTrue();
+        result.OverallRisk.Should().Be(SyncSustainabilityRisk.Healthy);
+        result.HighestRiskContainers.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Estimate_ChangeRateAboveCapacity_IsUnsustainable()
+    {
+        // 200%/day churn ⇒ 200 docs/sec > 100 docs/sec capacity ⇒ unsustainable.
+        var estimator = CreateEstimator(rate: 200.0, factor: 1.0);
+        var container = new ContainerAnalysis
+        {
+            ContainerName = "hot",
+            DocumentCount = 8_640_000,
+            SizeBytes = 8_640_000L * 512,
+            FeedRangeCount = 8,
+        };
+        var df = DfWith(TimeSpan.FromSeconds(86_400),
+            new PipelineEstimate { SourceContainer = "hot", EstimatedDuration = TimeSpan.FromSeconds(86_400) });
+
+        var result = estimator.Estimate(CosmosWith(container), df);
+        var c = result.Containers.Single();
+
+        c.Risk.Should().Be(SyncSustainabilityRisk.Unsustainable);
+        c.SteadyStateSustainable.Should().BeFalse();
+        c.EstimatedBacklogCatchUp.Should().BeNull();
+        c.UtilizationPercent.Should().BeApproximately(200.0, 0.001);
+        result.SteadyStateSustainable.Should().BeFalse();
+        result.OverallRisk.Should().Be(SyncSustainabilityRisk.Unsustainable);
+        result.EstimatedBacklogCatchUpAfterInitialLoad.Should().BeNull();
+        result.HighestRiskContainers.Should().Contain("hot");
+        result.Notes.Should().Contain(n => n.Contains("at or above incremental capacity"));
+    }
+
+    [Fact]
+    public void Estimate_ZeroDocuments_IsHealthyWithZeroBacklog()
+    {
+        var estimator = CreateEstimator();
+        var container = new ContainerAnalysis { ContainerName = "empty", DocumentCount = 0, SizeBytes = 0 };
+        var df = DfWith(TimeSpan.Zero,
+            new PipelineEstimate { SourceContainer = "empty", EstimatedDuration = TimeSpan.Zero });
+
+        var c = estimator.Estimate(CosmosWith(container), df).Containers.Single();
+
+        c.InitialLoadThroughputKnown.Should().BeTrue();
+        c.SteadyStateSustainable.Should().BeTrue();
+        c.Risk.Should().Be(SyncSustainabilityRisk.Healthy);
+        c.EstimatedBacklogCatchUp.Should().Be(TimeSpan.Zero);
+    }
+
+    [Fact]
+    public void Estimate_UnknownInitialLoadDuration_MarksCapacityUnknown()
+    {
+        var estimator = CreateEstimator();
+        var container = new ContainerAnalysis { ContainerName = "x", DocumentCount = 1000, SizeBytes = 1024 };
+        // Pipeline present but zero duration while docs exist ⇒ capacity indeterminate.
+        var df = DfWith(TimeSpan.Zero,
+            new PipelineEstimate { SourceContainer = "x", EstimatedDuration = TimeSpan.Zero });
+
+        var c = estimator.Estimate(CosmosWith(container), df).Containers.Single();
+
+        c.InitialLoadThroughputKnown.Should().BeFalse();
+        c.Risk.Should().Be(SyncSustainabilityRisk.Unknown);
+        c.SteadyStateSustainable.Should().BeFalse();
+        c.EstimatedBacklogCatchUp.Should().BeNull();
+        c.Notes.Should().Contain(n => n.Contains("unknown"));
+    }
+
+    [Fact]
+    public void Estimate_NoMatchingPipeline_DistributesByDocShare()
+    {
+        var estimator = CreateEstimator();
+        var a = new ContainerAnalysis { ContainerName = "a", DocumentCount = 3000, SizeBytes = 3000 };
+        var b = new ContainerAnalysis { ContainerName = "b", DocumentCount = 1000, SizeBytes = 1000 };
+        // No pipeline estimates ⇒ overall 4000s distributed: a→3000s, b→1000s.
+        var df = DfWith(TimeSpan.FromSeconds(4000));
+
+        var result = estimator.Estimate(CosmosWith(a, b), df);
+        var ca = result.Containers.Single(c => c.ContainerName == "a");
+        var cb = result.Containers.Single(c => c.ContainerName == "b");
+
+        ca.InitialLoadDuration.TotalSeconds.Should().BeApproximately(3000, 0.5);
+        cb.InitialLoadDuration.TotalSeconds.Should().BeApproximately(1000, 0.5);
+        ca.Notes.Should().Contain(n => n.Contains("distributed by document share"));
+    }
+
+    [Fact]
+    public void Estimate_SingleFeedRangeWithChanges_AddsParallelismNote()
+    {
+        var estimator = CreateEstimator(rate: 10.0);
+        var container = new ContainerAnalysis
+        {
+            ContainerName = "single",
+            DocumentCount = 100_000,
+            SizeBytes = 100_000 * 1024,
+            FeedRangeCount = 1,
+        };
+        var df = DfWith(TimeSpan.FromSeconds(1000),
+            new PipelineEstimate { SourceContainer = "single", EstimatedDuration = TimeSpan.FromSeconds(1000) });
+
+        var c = estimator.Estimate(CosmosWith(container), df).Containers.Single();
+
+        c.Notes.Should().Contain(n => n.Contains("single feed range"));
+    }
+
+    [Fact]
+    public void Estimate_MixedRisk_AggregatesWorstCase()
+    {
+        var estimator = CreateEstimator(rate: 5.0, factor: 1.0);
+        var healthy = new ContainerAnalysis { ContainerName = "ok", DocumentCount = 8_640_000, SizeBytes = 1, FeedRangeCount = 4 };
+        var hot = new ContainerAnalysis { ContainerName = "hot", DocumentCount = 8_640_000, SizeBytes = 1, FeedRangeCount = 4 };
+        var df = DfWith(TimeSpan.FromSeconds(86_400),
+            new PipelineEstimate { SourceContainer = "ok", EstimatedDuration = TimeSpan.FromSeconds(86_400) },
+            // "hot" gets a tiny initial load ⇒ very high docs/sec capacity is NOT what we want;
+            // instead give it a long load so capacity is low relative to churn.
+            new PipelineEstimate { SourceContainer = "hot", EstimatedDuration = TimeSpan.FromSeconds(86_400 * 100) });
+
+        var result = estimator.Estimate(CosmosWith(healthy, hot), df);
+
+        // hot: 8.64M docs / 8.64M s = 1 doc/sec capacity; churn 5 docs/sec ⇒ unsustainable.
+        var hotEstimate = result.Containers.Single(c => c.ContainerName == "hot");
+        hotEstimate.SteadyStateSustainable.Should().BeFalse();
+        result.OverallRisk.Should().Be(SyncSustainabilityRisk.Unsustainable);
+        result.SteadyStateSustainable.Should().BeFalse();
+        result.EstimatedBacklogCatchUpAfterInitialLoad.Should().BeNull();
+        result.HighestRiskContainers.Should().Contain("hot");
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/Migration/PhasedMigrationPlanGeneratorTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/Migration/PhasedMigrationPlanGeneratorTests.cs
@@ -1,0 +1,172 @@
+using CosmosToSqlAssessment.Models.Migration;
+using CosmosToSqlAssessment.Services.Migration;
+using CosmosToSqlAssessment.Tests.Infrastructure;
+
+namespace CosmosToSqlAssessment.Tests.Services.Migration;
+
+public class PhasedMigrationPlanGeneratorTests : TestBase
+{
+    private PhasedMigrationPlanGenerator CreateGenerator()
+        => new(MockConfiguration.Object, CreateMockLogger<PhasedMigrationPlanGenerator>().Object);
+
+    private static IncrementalMigrationAnalysis HealthyAnalysis()
+    {
+        var analysis = new IncrementalMigrationAnalysis
+        {
+            ChangeFeed = new ChangeFeedAvailabilityAnalysis
+            {
+                Containers =
+                {
+                    new ContainerChangeFeedReadiness { ContainerName = "c1", KnownServerSideTtlDeletes = false },
+                },
+                AllContainersSupportLatestVersionIncrementalSync = true,
+                AnyContainerHasKnownServerSideDeletes = false,
+            },
+            SyncEstimate = new IncrementalSyncEstimate
+            {
+                SyncInterval = TimeSpan.FromMinutes(15),
+                InitialLoadDuration = TimeSpan.FromHours(4),
+                EstimatedBacklogCatchUpAfterInitialLoad = TimeSpan.FromMinutes(30),
+                EstimatedSteadyStateSyncLag = TimeSpan.FromMinutes(16),
+                OverallRisk = SyncSustainabilityRisk.Healthy,
+                SteadyStateSustainable = true,
+                Containers = { new ContainerIncrementalSyncEstimate { ContainerName = "c1" } },
+            },
+            CutoverWindow = new CutoverWindowEstimate
+            {
+                TotalDowntime = TimeSpan.FromMinutes(20),
+                MinimumKnownDowntime = TimeSpan.FromMinutes(18),
+                Feasibility = CutoverFeasibility.Feasible,
+                Risk = CutoverDowntimeRisk.Low,
+            },
+        };
+        return analysis;
+    }
+
+    [Fact]
+    public void Generate_NullArgument_Throws()
+    {
+        var act = () => CreateGenerator().Generate(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Generate_HealthyAnalysis_IsReadyWithFiveOrderedPhases()
+    {
+        var plan = CreateGenerator().Generate(HealthyAnalysis());
+
+        plan.OverallReadiness.Should().Be(MigrationReadiness.Ready);
+        plan.Phases.Should().HaveCount(5);
+        plan.Phases.Select(p => p.Order).Should().BeInAscendingOrder().And.Equal(1, 2, 3, 4, 5);
+        plan.Phases.Should().OnlyContain(p => p.EntryCriteria.Count > 0 && p.ExitCriteria.Count > 0 && p.Steps.Count > 0);
+    }
+
+    [Fact]
+    public void Generate_SeparatesPreparationFromDowntime()
+    {
+        var analysis = HealthyAnalysis();
+        var plan = CreateGenerator().Generate(analysis);
+
+        // Default soak = 4 × 15 min = 60 min. Prep = 4h initial + 30m catch-up + 60m soak = 5h30m.
+        plan.EstimatedElapsedPreparationDuration.Should().Be(TimeSpan.FromHours(4) + TimeSpan.FromMinutes(90));
+        // Business downtime is the cutover window only — not summed with preparation.
+        plan.EstimatedBusinessDowntime.Should().Be(TimeSpan.FromMinutes(20));
+        plan.MinimumBusinessDowntime.Should().Be(TimeSpan.FromMinutes(18));
+        plan.PlanWarnings.Should().Contain(w => w.Contains("exclude"));
+    }
+
+    [Fact]
+    public void Generate_TtlDeleteContainers_IsReadyWithCaveats()
+    {
+        var analysis = HealthyAnalysis();
+        analysis.ChangeFeed.Containers[0].KnownServerSideTtlDeletes = true;
+        analysis.ChangeFeed.AnyContainerHasKnownServerSideDeletes = true;
+
+        var plan = CreateGenerator().Generate(analysis);
+
+        plan.OverallReadiness.Should().Be(MigrationReadiness.ReadyWithCaveats);
+        plan.ReadinessFactors.Should().Contain(f => f.Contains("TTL"));
+        plan.PlanWarnings.Should().Contain(w => w.Contains("delete fidelity"));
+    }
+
+    [Fact]
+    public void Generate_CutoverRequiresCatchUp_IsReadyWithCaveats()
+    {
+        var analysis = HealthyAnalysis();
+        analysis.CutoverWindow.Feasibility = CutoverFeasibility.RequiresPreCutoverCatchUp;
+        analysis.CutoverWindow.TotalDowntime = null;
+
+        var plan = CreateGenerator().Generate(analysis);
+
+        plan.OverallReadiness.Should().Be(MigrationReadiness.ReadyWithCaveats);
+        plan.EstimatedBusinessDowntime.Should().BeNull();
+        plan.MinimumBusinessDowntime.Should().Be(TimeSpan.FromMinutes(18));
+        plan.PlanWarnings.Should().Contain(w => w.Contains("Cutover downtime is unavailable"));
+        plan.ReadinessFactors.Should().Contain(f => f.Contains("draining change-feed lag"));
+    }
+
+    [Fact]
+    public void Generate_UnsustainableSync_IsNotReady()
+    {
+        var analysis = HealthyAnalysis();
+        analysis.SyncEstimate.SteadyStateSustainable = false;
+        analysis.SyncEstimate.OverallRisk = SyncSustainabilityRisk.Unsustainable;
+        analysis.SyncEstimate.EstimatedBacklogCatchUpAfterInitialLoad = null;
+        analysis.CutoverWindow.Feasibility = CutoverFeasibility.RequiresPreCutoverCatchUp;
+        analysis.CutoverWindow.TotalDowntime = null;
+
+        var plan = CreateGenerator().Generate(analysis);
+
+        plan.OverallReadiness.Should().Be(MigrationReadiness.NotReady);
+        plan.ReadinessFactors.Should().Contain(f => f.Contains("unsustainable"));
+        // Catch-up unavailable ⇒ preparation duration unknown.
+        plan.EstimatedElapsedPreparationDuration.Should().BeNull();
+        plan.Phases[1].EstimatedDuration.Should().BeNull();
+        plan.PlanWarnings.Should().Contain(w => w.Contains("Backlog catch-up is unavailable"));
+    }
+
+    [Fact]
+    public void Generate_UnsustainableSyncButCutoverFeasible_FlagsInconsistency()
+    {
+        var analysis = HealthyAnalysis();
+        analysis.SyncEstimate.SteadyStateSustainable = false;
+        analysis.SyncEstimate.OverallRisk = SyncSustainabilityRisk.Unsustainable;
+        // Contradictory: cutover claims feasible.
+        analysis.CutoverWindow.Feasibility = CutoverFeasibility.Feasible;
+
+        var plan = CreateGenerator().Generate(analysis);
+
+        plan.OverallReadiness.Should().Be(MigrationReadiness.NotReady);
+        plan.PlanWarnings.Should().Contain(w => w.Contains("Inconsistent upstream signals"));
+    }
+
+    [Fact]
+    public void Generate_NoContainers_IsUnknown()
+    {
+        var analysis = new IncrementalMigrationAnalysis();
+
+        var plan = CreateGenerator().Generate(analysis);
+
+        plan.OverallReadiness.Should().Be(MigrationReadiness.Unknown);
+        plan.ReadinessFactors.Should().Contain(f => f.Contains("No containers"));
+    }
+
+    [Fact]
+    public void Generate_AlwaysIncludesDeleteAndRollbackRisks()
+    {
+        var plan = CreateGenerator().Generate(HealthyAnalysis());
+
+        plan.KeyRisks.Should().Contain(r => r.Contains("never emits deletes"));
+        plan.KeyRisks.Should().Contain(r => r.Contains("rollback"));
+        plan.Phases.Single(p => p.Name == "Cutover").RollbackGuidance.Should().NotBeNullOrEmpty();
+        plan.Phases.Single(p => p.Name == "Cutover Preparation").RollbackGuidance.Should().Contain("reverse-sync");
+    }
+
+    [Fact]
+    public void Generate_SingleContainer_AddsConcentrationNote()
+    {
+        var plan = CreateGenerator().Generate(HealthyAnalysis());
+
+        plan.Notes.Should().Contain(n => n.Contains("concentration risk"));
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Services/Migration/TimeBasedPartitioningAnalyzerTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Services/Migration/TimeBasedPartitioningAnalyzerTests.cs
@@ -1,0 +1,297 @@
+using CosmosToSqlAssessment.Models;
+using CosmosToSqlAssessment.Models.Migration;
+using CosmosToSqlAssessment.Services.Migration;
+using CosmosToSqlAssessment.Tests.Infrastructure;
+using Microsoft.Extensions.Configuration;
+
+namespace CosmosToSqlAssessment.Tests.Services.Migration;
+
+public class TimeBasedPartitioningAnalyzerTests : TestBase
+{
+    private TimeBasedPartitioningAnalyzer CreateAnalyzer()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["IncrementalMigration:PartitioningMonthlyDocumentThreshold"] = "1000000",
+                ["IncrementalMigration:PartitioningDailyDocumentThreshold"] = "50000000",
+                ["IncrementalMigration:PartitioningMonthlySizeGB"] = "5.0",
+                ["IncrementalMigration:PartitioningDailySizeGB"] = "100.0",
+            })
+            .Build();
+        return new TimeBasedPartitioningAnalyzer(config, CreateMockLogger<TimeBasedPartitioningAnalyzer>().Object);
+    }
+
+    private static CosmosDbAnalysis CosmosWith(params ContainerAnalysis[] containers)
+        => new() { Containers = containers.ToList() };
+
+    private static ContainerAnalysis Container(
+        string name,
+        long docs,
+        long sizeBytes,
+        int feedRanges = 4,
+        int? ttl = null,
+        params DocumentSchema[] schemas)
+        => new()
+        {
+            ContainerName = name,
+            DocumentCount = docs,
+            SizeBytes = sizeBytes,
+            FeedRangeCount = feedRanges,
+            DefaultTimeToLiveSeconds = ttl,
+            DetectedSchemas = schemas.ToList(),
+        };
+
+    private static DocumentSchema Schema(double prevalence, params (string name, string sqlType)[] fields)
+    {
+        var schema = new DocumentSchema { SchemaName = "s", Prevalence = prevalence, SampleCount = 100 };
+        foreach (var (n, t) in fields)
+        {
+            schema.Fields[n] = new FieldInfo
+            {
+                FieldName = n,
+                RecommendedSqlType = t,
+                DetectedTypes = new List<string> { "string" },
+            };
+        }
+
+        return schema;
+    }
+
+    private const long GB = 1024L * 1024L * 1024L;
+
+    [Fact]
+    public void Constructor_WithNullArguments_Throws()
+    {
+        var config = new ConfigurationBuilder().Build();
+        var actConfig = () => new TimeBasedPartitioningAnalyzer(null!, CreateMockLogger<TimeBasedPartitioningAnalyzer>().Object);
+        var actLogger = () => new TimeBasedPartitioningAnalyzer(config, null!);
+        actConfig.Should().Throw<ArgumentNullException>();
+        actLogger.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Analyze_WithNullAnalysis_Throws()
+    {
+        var analyzer = CreateAnalyzer();
+        var act = () => analyzer.Analyze(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Analyze_WithNoContainers_ReturnsEmptyWithAssumptions()
+    {
+        var analyzer = CreateAnalyzer();
+
+        var result = analyzer.Analyze(CosmosWith());
+
+        result.Containers.Should().BeEmpty();
+        result.ContainersRecommendedForPartitioning.Should().Be(0);
+        result.Assumptions.Should().NotBeEmpty();
+        result.Notes.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void Analyze_EmptyContainer_IsNotRecommended()
+    {
+        var analyzer = CreateAnalyzer();
+
+        var rec = analyzer.Analyze(CosmosWith(Container("empty", docs: 0, sizeBytes: 0))).Containers.Single();
+
+        rec.Strength.Should().Be(PartitioningStrength.NotRecommended);
+        rec.RecommendedGranularity.Should().Be(PartitionGranularity.None);
+        rec.Rationale.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void Analyze_SmallContainer_IsNotRecommended()
+    {
+        var analyzer = CreateAnalyzer();
+        var container = Container("small", docs: 50_000, sizeBytes: 100L * 1024 * 1024,
+            schemas: Schema(1.0, ("createdAt", "datetime2")));
+
+        var rec = analyzer.Analyze(CosmosWith(container)).Containers.Single();
+
+        rec.Strength.Should().Be(PartitioningStrength.NotRecommended);
+        rec.RecommendedGranularity.Should().Be(PartitionGranularity.None);
+    }
+
+    [Fact]
+    public void Analyze_VeryLargeContainerWithImmutableColumn_IsRecommendedDailyWithColumn()
+    {
+        var analyzer = CreateAnalyzer();
+        var container = Container("events", docs: 60_000_000, sizeBytes: 10L * GB, feedRanges: 16,
+            schemas: Schema(1.0, ("createdAt", "datetime2"), ("status", "nvarchar(50)")));
+
+        var rec = analyzer.Analyze(CosmosWith(container)).Containers.Single();
+
+        rec.RecommendedGranularity.Should().Be(PartitionGranularity.Day);
+        rec.Strength.Should().Be(PartitioningStrength.Recommended);
+        rec.RecommendedPartitionColumn.Should().Be("createdAt");
+        rec.RequiresSyntheticCreationColumn.Should().BeFalse();
+        rec.IndexAlignmentCaveats.Should().NotBeEmpty();
+        rec.InitialLoadParallelismUpperBound.Should().Be(16);
+        rec.InitialLoadSlicingApproach.Should().Contain("_ts");
+    }
+
+    [Fact]
+    public void Analyze_MonthlyVolumeWithImmutableColumn_IsConditionalNotRecommendedStrength()
+    {
+        var analyzer = CreateAnalyzer();
+        var container = Container("orders", docs: 2_000_000, sizeBytes: 2L * GB,
+            schemas: Schema(1.0, ("createdAt", "datetime2")));
+
+        var rec = analyzer.Analyze(CosmosWith(container)).Containers.Single();
+
+        rec.RecommendedGranularity.Should().Be(PartitionGranularity.Month);
+        // Has a recommended column, but only Day granularity earns the strong "Recommended" verdict.
+        rec.Strength.Should().Be(PartitioningStrength.ConditionalManageability);
+        rec.RecommendedPartitionColumn.Should().Be("createdAt");
+    }
+
+    [Fact]
+    public void Analyze_YearVolume_IsConditional()
+    {
+        var analyzer = CreateAnalyzer();
+        var container = Container("logs", docs: 200_000, sizeBytes: 200L * 1024 * 1024,
+            schemas: Schema(1.0, ("createdAt", "datetime2")));
+
+        var rec = analyzer.Analyze(CosmosWith(container)).Containers.Single();
+
+        rec.RecommendedGranularity.Should().Be(PartitionGranularity.Year);
+        rec.Strength.Should().Be(PartitioningStrength.ConditionalManageability);
+    }
+
+    [Fact]
+    public void Analyze_NoImmutableColumn_RecommendsSyntheticColumn()
+    {
+        var analyzer = CreateAnalyzer();
+        var container = Container("audit", docs: 60_000_000, sizeBytes: 10L * GB,
+            schemas: Schema(1.0, ("lastModified", "datetime2")));
+
+        var rec = analyzer.Analyze(CosmosWith(container)).Containers.Single();
+
+        rec.RequiresSyntheticCreationColumn.Should().BeTrue();
+        rec.RecommendedPartitionColumn.Should().BeNull();
+        rec.TemporalColumnCandidates.Should().Contain(c => c.IsSyntheticFromInitialLoad);
+
+        var mutable = rec.TemporalColumnCandidates.Single(c => c.FieldName == "lastModified");
+        mutable.MutabilityRisk.Should().Be(TemporalColumnMutabilityRisk.MutableLikely);
+        mutable.Confidence.Should().Be(TemporalColumnConfidence.Low);
+    }
+
+    [Fact]
+    public void Analyze_EmptySchemaLargeContainer_RecommendsSyntheticAndCaveats()
+    {
+        var analyzer = CreateAnalyzer();
+        var container = Container("nodata", docs: 60_000_000, sizeBytes: 10L * GB);
+
+        var rec = analyzer.Analyze(CosmosWith(container)).Containers.Single();
+
+        rec.RequiresSyntheticCreationColumn.Should().BeTrue();
+        rec.TemporalColumnCandidates.Should().ContainSingle().Which.IsSyntheticFromInitialLoad.Should().BeTrue();
+        rec.Caveats.Should().Contain(c => c.Contains("No document schema"));
+    }
+
+    [Fact]
+    public void Analyze_TtlEnabled_FlagsSlidingWindowWithCaveat()
+    {
+        var analyzer = CreateAnalyzer();
+        var container = Container("ttl", docs: 60_000_000, sizeBytes: 10L * GB, ttl: 3600,
+            schemas: Schema(1.0, ("createdAt", "datetime2")));
+
+        var rec = analyzer.Analyze(CosmosWith(container)).Containers.Single();
+
+        rec.SlidingWindow.Should().Be(SlidingWindowConsideration.ConsiderWithValidation);
+        rec.Caveats.Should().Contain(c => c.Contains("TTL"));
+    }
+
+    [Fact]
+    public void Analyze_ItemLevelTtl_MentionsNoContainerDefault()
+    {
+        var analyzer = CreateAnalyzer();
+        var container = Container("itemttl", docs: 60_000_000, sizeBytes: 10L * GB, ttl: -1,
+            schemas: Schema(1.0, ("createdAt", "datetime2")));
+
+        var rec = analyzer.Analyze(CosmosWith(container)).Containers.Single();
+
+        rec.SlidingWindow.Should().Be(SlidingWindowConsideration.ConsiderWithValidation);
+        rec.Caveats.Should().Contain(c => c.Contains("item-level"));
+    }
+
+    [Fact]
+    public void Analyze_NoTtl_SlidingWindowNotApplicable()
+    {
+        var analyzer = CreateAnalyzer();
+        var container = Container("nottl", docs: 60_000_000, sizeBytes: 10L * GB, ttl: null,
+            schemas: Schema(1.0, ("createdAt", "datetime2")));
+
+        var rec = analyzer.Analyze(CosmosWith(container)).Containers.Single();
+
+        rec.SlidingWindow.Should().Be(SlidingWindowConsideration.NotApplicable);
+    }
+
+    [Fact]
+    public void Analyze_TwoHighConfidenceColumns_DoesNotAutoSelectColumn()
+    {
+        var analyzer = CreateAnalyzer();
+        var container = Container("ambiguous", docs: 60_000_000, sizeBytes: 10L * GB,
+            schemas: Schema(1.0, ("createdAt", "datetime2"), ("creationTime", "datetime2")));
+
+        var rec = analyzer.Analyze(CosmosWith(container)).Containers.Single();
+
+        rec.RecommendedPartitionColumn.Should().BeNull();
+        rec.RequiresSyntheticCreationColumn.Should().BeFalse();
+        rec.Strength.Should().Be(PartitioningStrength.ConditionalManageability);
+    }
+
+    [Fact]
+    public void Analyze_SparseImmutableColumn_IsNotAutoSelected()
+    {
+        var analyzer = CreateAnalyzer();
+        // createdAt appears in only one of two equally-prevalent schema variants => ~50% prevalence.
+        var container = Container("sparse", docs: 60_000_000, sizeBytes: 10L * GB,
+            schemas: new[]
+            {
+                Schema(0.5, ("createdAt", "datetime2")),
+                Schema(0.5, ("name", "nvarchar(100)")),
+            });
+
+        var rec = analyzer.Analyze(CosmosWith(container)).Containers.Single();
+
+        rec.RecommendedPartitionColumn.Should().BeNull();
+        var createdAt = rec.TemporalColumnCandidates.Single(c => c.FieldName == "createdAt");
+        createdAt.Confidence.Should().Be(TemporalColumnConfidence.Medium);
+        createdAt.SchemaPrevalence.Should().BeApproximately(0.5, 0.01);
+    }
+
+    [Fact]
+    public void Analyze_EventColumn_IsMediumImmutable()
+    {
+        var analyzer = CreateAnalyzer();
+        var container = Container("telemetry", docs: 60_000_000, sizeBytes: 10L * GB,
+            schemas: Schema(1.0, ("eventTime", "datetime2")));
+
+        var rec = analyzer.Analyze(CosmosWith(container)).Containers.Single();
+
+        var candidate = rec.TemporalColumnCandidates.Single(c => c.FieldName == "eventTime");
+        candidate.Confidence.Should().Be(TemporalColumnConfidence.Medium);
+        candidate.MutabilityRisk.Should().Be(TemporalColumnMutabilityRisk.ImmutableLikely);
+        // Medium (not High) => not auto-selected as the single partition column.
+        rec.RecommendedPartitionColumn.Should().BeNull();
+    }
+
+    [Fact]
+    public void Analyze_AggregatesRecommendedCount()
+    {
+        var analyzer = CreateAnalyzer();
+        var big = Container("big", docs: 60_000_000, sizeBytes: 10L * GB,
+            schemas: Schema(1.0, ("createdAt", "datetime2")));
+        var small = Container("small", docs: 10, sizeBytes: 1024);
+
+        var result = analyzer.Analyze(CosmosWith(big, small));
+
+        result.Containers.Should().HaveCount(2);
+        result.ContainersRecommendedForPartitioning.Should().Be(1);
+    }
+}


### PR DESCRIPTION
Closes #69

Supports phased migrations with incremental sync using the Cosmos DB change feed. This parent enhances the existing ADF pipeline generation (#70) and Cosmos analysis with change-feed availability detection, initial-load vs incremental-sync estimation, cutover-window calculation, a phased migration plan, time-based partitioning strategies, report/runbook documentation, and Change Feed Processor implementation guidance.

## Sub-issues
- [x] #134 Detect change feed availability on containers
- [x] #135 Estimate initial load vs incremental sync time
- [x] #136 Calculate cutover downtime window
- [x] #137 Generate phased migration plan
- [x] #138 Time-based partitioning strategies
- [x] #139 Document sync process in reports
- [x] #140 Change feed processor implementation guidance

## Implementation approach
A new optional aggregate `AssessmentResult.IncrementalMigration` (`Models/Migration/IncrementalMigrationAnalysis`) is populated by pure `Services/Migration/` services that consume the already-collected `CosmosDbAnalysis`/`SqlMigrationAssessment`/`DataFactoryEstimate` (no live Cosmos calls → testable, streaming-safe). A single failure-isolated orchestrator helper attaches it in both the single-pass and `--agentic` paths. Reports (#139) render from the aggregate. Change-feed/ADF work integrates with the existing `Services/DataFactory/` incremental-copy infrastructure from #70.

- **#134**: `ChangeFeedAvailabilityAnalyzer` detects per-container change-feed readiness. Latest-version feed is always available on the SQL API; TTL-enabled containers are flagged for server-side deletes the latest-version feed won't surface (recommends all-versions-and-deletes, whose retention can't be read via the public SDK → `RequiresManualVerification`). Captures `DefaultTimeToLive`, partition-key paths (incl. hierarchical), and `FeedRangeCount` (live `GetFeedRangesAsync`) during container analysis to feed later sub-issues.
- **#135**: `IncrementalSyncEstimator` compares estimated initial bulk-load duration vs change-feed incremental sync capacity, reusing the ADF initial-load estimate as its throughput baseline. Produces utilization risk bands (Healthy/Moderate/High/Unsustainable), nullable post-load backlog catch-up (slowest container under parallel sync), per-day churn doc/data-size figures, and a single-feed-range parallelism signal. Config under `IncrementalMigration:*`.
- **#136**: `CutoverWindowCalculator` estimates the final maintenance-window downtime by blending a fully-parallel residual-drain bound (`max(Ri/Ci)`) with a fully-contended serial bound (`Σ(Ri/Ci)`) via `CutoverDrainParallelismPercent`, plus fixed app-stop/validation/switch overhead and a safety buffer. Surfaces a `MinimumKnownDowntime` floor, `RequiresPreCutoverCatchUp` feasibility when any container has unbounded pre-cutover lag, and an RTO-relative downtime risk.
- **#137**: `PhasedMigrationPlanGenerator` synthesizes the parent #69 phase structure (Initial Load → Incremental Sync & Stabilization → Cutover Prep → Cutover → Verification) with an overall readiness verdict. Separates elapsed preparation time from business downtime, treats change-feed availability as a first-class readiness input, downgrades known-TTL-delete containers to ReadyWithCaveats, and emits safety-critical steps, key risks, assumptions, and consistency-diagnostic plan warnings.
- **#138**: `TimeBasedPartitioningAnalyzer` recommends Azure SQL target-table time-based partitioning and `_ts`-based initial-load slicing per container. Conservative by design: shortlists temporal column candidates with Confidence + MutabilityRisk + schema prevalence (auto-selecting a single column only when one near-universal high-confidence immutable column exists); defaults to NotRecommended unless data volume justifies it; treats `_ts` (mutable last-modified) as load-slicing only, never the SQL partition key; downgrades TTL sliding-window to a caveated *consideration* (age-basis mismatch); includes SQL index-alignment caveats; and falls back to a caveated synthetic `InitialLoadTimestamp` column. Config under `IncrementalMigration:Partitioning*`.
- **#139**: Renders the incremental aggregate into both generated reports — a new Excel `Incremental Migration` worksheet (readiness, change feed, sync, cutover, phased plan, partitioning, assumptions) and a Word *Incremental Migration and Sync Process* section (readiness/sync/cutover tables plus phased-plan and partitioning detail) — and adds a standalone `docs/incremental-migration-sync.md` operating runbook linked from `docs/README.md`. The Word section is null-guarded so existing assessments are unaffected; the Excel worksheet shows a graceful "not available" note when the analysis is absent.
- **#140**: `ChangeFeedProcessorGuidanceGenerator` derives Change Feed Processor (CFP) worker guidance from the #134 analysis as an alternative/complement to the generated ADF `_ts`-watermark pipeline: a dedicated `leases` container with a conservative `base + perLease × Σ(known feed ranges)` autoscale starting throughput (400 RU/s floor, monitor-and-adjust — not validated sizing); per-container parallelism ceilings (`max(1, FeedRangeCount)`) plus db-level shared-fleet (`max`) and independent-pools (`Σ`) ceilings; unknown feed-range counts treated as unknown (null ceiling, base-only RU, start at 1 instance + warning) rather than zero; mode-specific handling (latest-version at-least-once idempotent upsert; AVAD continuous-backup/isolated-lease flags + NoSQL-only/retention/preview-SDK caveats); and an explicit 3-way relationship to the ADF watermark pipeline (don't dual-write the same SQL target without idempotency). Rendered into Excel + Word reports and the docs runbook CFP section. Config keys `IncrementalMigration:ChangeFeedProcessorLeaseBaseRUs`/`ChangeFeedProcessorLeaseRUsPerLease`.

## Testing
- Baseline: build green, 717 tests.
- After #134: build green, **726 tests passing** (+9 `ChangeFeedAvailabilityAnalyzerTests`).
- After #135: build green, **735 tests passing** (+9 `IncrementalSyncEstimatorTests`).
- After #136: build green, **745 tests passing** (+10 `CutoverWindowCalculatorTests`).
- After #137: build green (0 warnings in main project), **755 tests passing** (+10 `PhasedMigrationPlanGeneratorTests`).
- After #138: build green (0 warnings in main project), **772 tests passing** (+17 `TimeBasedPartitioningAnalyzerTests`).
- After #139: build green (0 warnings in main project), **775 tests passing** (+3 `IncrementalMigrationReportTests`).
- After #140: build green (0 warnings in main project), **786 tests passing** (+11 `ChangeFeedProcessorGuidanceGeneratorTests` + report-section assertions).

## Branch-protection changes
_None; will note here if any new required check is introduced._