### PR TITLE
docs(api): surface architecture overview as a DocFX conceptual article

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,6 +49,13 @@ jobs:
       - name: Build project (Release)
         run: dotnet build CosmosToSqlAssessment.csproj --configuration Release --no-restore
 
+      # Surface the hand-written architecture overview (docs/architecture.md — the source of
+      # truth, kept current by the multi-agent work in parent #131) inside the API site as a
+      # conceptual article. Copied at build time so it always reflects the latest docs/ content
+      # and is never committed as a stale duplicate (the copy target is gitignored).
+      - name: Sync architecture overview into DocFX articles
+        run: cp docs/architecture.md docfx/articles/architecture.md
+
       # --warningsAsErrors makes broken xrefs / links / malformed metadata fail CI, so
       # "automated API doc generation in CI" genuinely enforces a clean reference site.
       - name: Generate API reference site

--- a/.gitignore
+++ b/.gitignore
@@ -330,4 +330,6 @@ RELEASE_NOTES.md
 docfx/_site/
 docfx/reference/
 docfx/api/
+# Conceptual article synced from docs/architecture.md at build time (never committed)
+docfx/articles/architecture.md
 api/.manifest

--- a/docfx/articles/toc.yml
+++ b/docfx/articles/toc.yml
@@ -1,2 +1,4 @@
 - name: Extension points
   href: extension-points.md
+- name: Architecture overview
+  href: architecture.md

--- a/docfx/index.md
+++ b/docfx/index.md
@@ -31,3 +31,4 @@ See the [API Reference](xref:CosmosToSqlAssessment) for full type, member, param
 ## Guides
 
 - [Extension points](articles/extension-points.md) — how to extend, customize, and integrate the assessment engine (custom Data Factory generation, options, configuration, streaming, and authentication seams).
+- [Architecture overview](articles/architecture.md) — the layered, service-oriented architecture and the multi-agent orchestration layer, with diagrams. (Rendered from [`docs/architecture.md`](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/blob/main/docs/architecture.md).)


### PR DESCRIPTION
## Summary

Follow-up to parent #78 (API reference docs). Renders the hand-written `docs/architecture.md` **inside** the published `/api/` DocFX site as an **"Architecture overview"** conceptual article (next to *Extension points*), so the architecture + multi-agent orchestration diagrams sit alongside the generated API reference.

This addresses the orchestrator's request that parent #131's `docs/architecture.md` "slot into the API site automatically."

## How it works

- A build-time step copies `docs/architecture.md` → `docfx/articles/architecture.md` before DocFX runs.
- The copy target is **gitignored** (never committed) so the API site always reflects the current source-of-truth doc and picks up #131's edits automatically — no stale duplicate.
- The existing `articles/**/*.md` content glob + TOC entry pick it up; `index.md` links it from the Guides section.

## Why not a blanket `docs/*.md` glob

The orchestrator suggested globbing all of `docs/*.md`. I verified that would **break the now-required `build-docs` check**: the other `docs/` guides link to `.cs`/`.json`/`.sql` source files (e.g. `../Services/ReportGenerationService.cs`, `security/rbac/sql-schema-deployer.sql`), which `docfx --warningsAsErrors` rejects as broken file links. `architecture.md` is clean (no relative file links, no images — only mermaid), so it's the one doc that imports safely. Additional clean docs can be added to the sync step later.

## Verification

- `dotnet build -warnaserror`: **0 warnings / 0 errors**
- `docfx --warningsAsErrors`: **0 warnings / 0 errors** (153 models; `articles/architecture.html` 42 KB)
- Mermaid renders: the modern template ships the mermaid diagram bundles, and all 7 `mermaid` blocks are present in the output.
- Docs/CI-only change — zero source files touched, so the unit suite is unaffected.

## Coexistence / safety

No change to the `publish-docs` job, the `gh-pages` `/api/` vs `/dev/bench/` split, or the benchmark dashboard. The published site simply gains one extra article page under `/api/articles/architecture.html`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>