### PR TITLE
Revert "docs(api): surface architecture overview as a DocFX conceptual article" (#253)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,13 +49,6 @@ jobs:
       - name: Build project (Release)
         run: dotnet build CosmosToSqlAssessment.csproj --configuration Release --no-restore
 
-      # Surface the hand-written architecture overview (docs/architecture.md — the source of
-      # truth, kept current by the multi-agent work in parent #131) inside the API site as a
-      # conceptual article. Copied at build time so it always reflects the latest docs/ content
-      # and is never committed as a stale duplicate (the copy target is gitignored).
-      - name: Sync architecture overview into DocFX articles
-        run: cp docs/architecture.md docfx/articles/architecture.md
-
       # --warningsAsErrors makes broken xrefs / links / malformed metadata fail CI, so
       # "automated API doc generation in CI" genuinely enforces a clean reference site.
       - name: Generate API reference site

--- a/.gitignore
+++ b/.gitignore
@@ -330,6 +330,4 @@ RELEASE_NOTES.md
 docfx/_site/
 docfx/reference/
 docfx/api/
-# Conceptual article synced from docs/architecture.md at build time (never committed)
-docfx/articles/architecture.md
 api/.manifest

--- a/docfx/articles/toc.yml
+++ b/docfx/articles/toc.yml
@@ -1,4 +1,2 @@
 - name: Extension points
   href: extension-points.md
-- name: Architecture overview
-  href: architecture.md

--- a/docfx/index.md
+++ b/docfx/index.md
@@ -31,4 +31,3 @@ See the [API Reference](xref:CosmosToSqlAssessment) for full type, member, param
 ## Guides
 
 - [Extension points](articles/extension-points.md) — how to extend, customize, and integrate the assessment engine (custom Data Factory generation, options, configuration, streaming, and authentication seams).
-- [Architecture overview](articles/architecture.md) — the layered, service-oriented architecture and the multi-agent orchestration layer, with diagrams. (Rendered from [`docs/architecture.md`](https://github.com/JoshLuedeman/cosmosdb-to-sql-migration-tool/blob/main/docs/architecture.md).)


### PR DESCRIPTION
## Summary

Reverts #253 (commit `b0ee4cb`), which mirrored `docs/architecture.md` into the published `/api/` DocFX site as an "Architecture overview" article.

Per the parent-#78 orchestrator's decision: **`docs/architecture.md` stays a standalone repo doc linked from README and is *not* mirrored into `/api/`** for now, because (1) it still contains stale pre-#126 sections and (2) parents #69 (change-feed phases), #132 (feedback loop), and #133 (monitoring) are each actively extending the architecture narrative. A single consolidated `architecture.md` accuracy/refresh pass will happen at the end of that milestone; the `/api/` conceptual section stays curated (extension-points + targeted articles) until then.

## Why revert rather than leave it

Beyond honoring that decision, the mirror coupled a **frequently-edited narrative doc to the required `build-docs` gate** (`docfx --warningsAsErrors`). With #69/#132/#133 actively editing `docs/architecture.md`, any future edit that adds a relative link to source (`.cs`/`.json`/`.sql`) or a DocFX-incompatible construct would break the required check on **every** PR. Decoupling removes that fragility.

## What this restores

- `.github/workflows/docs.yml` — removes the "Sync architecture overview" copy step.
- `docfx/articles/toc.yml`, `docfx/index.md` — remove the Architecture overview nav/link entries.
- `.gitignore` — removes the now-unneeded `docfx/articles/architecture.md` ignore.

The `/api/` site returns to its curated content (API reference + Extension points). No change to publishing, the `gh-pages` `/api/` ↔ `/dev/bench/` split, or the benchmark dashboard.

## Verification

- `dotnet build -c Release`: succeeds.
- `docfx --warningsAsErrors`: **0 warnings / 0 errors** (back to 147 reference pages, extension-points the sole conceptual article).
- Docs/CI-only change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>