### PR TITLE
perf(benchmarks): widen mean tolerance for sub-200ns microbenchmarks (Closes #252)

### DIFF
--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/baselines/baseline.json
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/baselines/baseline.json
@@ -8,7 +8,8 @@
   "benchmarks": {
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.CosmosAnalysisBenchmarks.MapJsonTypeToSqlTypeEnhanced_Primitives(Size: Small)": {
       "meanNs": 134.02137163335627,
-      "allocatedBytes": 68
+      "allocatedBytes": 68,
+      "meanToleranceFactor": 1.5
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.CosmosAnalysisBenchmarks.ExtractFieldsFlat_Document(Size: Small)": {
       "meanNs": 2251.24538269043,
@@ -28,7 +29,8 @@
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.CosmosAnalysisBenchmarks.MapJsonTypeToSqlTypeEnhanced_Primitives(Size: Medium)": {
       "meanNs": 134.34394064816564,
-      "allocatedBytes": 68
+      "allocatedBytes": 68,
+      "meanToleranceFactor": 1.5
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.CosmosAnalysisBenchmarks.ExtractFieldsFlat_Document(Size: Medium)": {
       "meanNs": 11828.099891662598,
@@ -48,7 +50,8 @@
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.CosmosAnalysisBenchmarks.MapJsonTypeToSqlTypeEnhanced_Primitives(Size: Large)": {
       "meanNs": 134.11707933847006,
-      "allocatedBytes": 68
+      "allocatedBytes": 68,
+      "meanToleranceFactor": 1.5
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.CosmosAnalysisBenchmarks.ExtractFieldsFlat_Document(Size: Large)": {
       "meanNs": 20197.383283342635,
@@ -68,7 +71,8 @@
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.ReportGenerationBenchmarks.SanitizeFileName_Bank(Size: Small)": {
       "meanNs": 48.543820991516114,
-      "allocatedBytes": 78
+      "allocatedBytes": 78,
+      "meanToleranceFactor": 1.5
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.ReportGenerationBenchmarks.CreateValidWorksheetName_Bank(Size: Small)": {
       "meanNs": 375.7633336639405,
@@ -81,7 +85,8 @@
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.ReportGenerationBenchmarks.SanitizeFileName_Bank(Size: Medium)": {
       "meanNs": 48.556215356191,
-      "allocatedBytes": 78
+      "allocatedBytes": 78,
+      "meanToleranceFactor": 1.5
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.ReportGenerationBenchmarks.CreateValidWorksheetName_Bank(Size: Medium)": {
       "meanNs": 378.48888871256503,
@@ -94,7 +99,8 @@
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.ReportGenerationBenchmarks.SanitizeFileName_Bank(Size: Large)": {
       "meanNs": 48.73688116891043,
-      "allocatedBytes": 78
+      "allocatedBytes": 78,
+      "meanToleranceFactor": 1.5
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.ReportGenerationBenchmarks.CreateValidWorksheetName_Bank(Size: Large)": {
       "meanNs": 380.1769623209635,
@@ -120,7 +126,8 @@
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.SqlAssessmentBenchmarks.SanitizeName_Bank(Size: Small)": {
       "meanNs": 149.7092420450846,
-      "allocatedBytes": 270
+      "allocatedBytes": 270,
+      "meanToleranceFactor": 1.5
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.SqlAssessmentBenchmarks.AssessMigrationAsync_EndToEnd(Size: Medium)": {
       "meanNs": 339773.4574544271,
@@ -133,7 +140,8 @@
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.SqlAssessmentBenchmarks.SanitizeName_Bank(Size: Medium)": {
       "meanNs": 150.64176888529457,
-      "allocatedBytes": 270
+      "allocatedBytes": 270,
+      "meanToleranceFactor": 1.5
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.SqlAssessmentBenchmarks.AssessMigrationAsync_EndToEnd(Size: Large)": {
       "meanNs": 2066417.763671875,
@@ -146,7 +154,8 @@
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.SqlAssessmentBenchmarks.SanitizeName_Bank(Size: Large)": {
       "meanNs": 154.11902781895228,
-      "allocatedBytes": 270
+      "allocatedBytes": 270,
+      "meanToleranceFactor": 1.5
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingMemoryProfileBenchmarks.StreamingClonePattern(DocumentCount: 1000)": {
       "meanNs": 2737613.898995536,


### PR DESCRIPTION
## Summary
Closes #252.

The nanosecond-scale microbenchmarks flap on the required **Benchmark regression** check because hosted-runner measurement noise (timer resolution, JIT, cache effects) routinely exceeds the `1.10x` (+10%) mean gate. `SqlAssessmentBenchmarks.SanitizeName_Bank` (~150ns) is the one #252 reported; its sub-200ns siblings (`SanitizeFileName_Bank` ~48ns, `MapJsonTypeToSqlTypeEnhanced_Primitives` ~134ns) are even smaller and unguarded by luck.

## Change
Mean-only `meanToleranceFactor=1.5` on the 9 sub-200ns entries (3 size variants each), mirroring the per-benchmark pattern from #247 (`BufferedRetainAllPattern`).

- **Allocations stay STRICT at the default 1.10x** for every benchmark — allocated bytes are byte-deterministic on the runner, so the real regression signal is preserved (a >10% allocation regression still fails CI everywhere).
- Larger micros (>=375ns: `CreateValidWorksheetName_Bank`, `GenerateIndexScript_Bank`, `AnalyzeArrayStructure_*`, `GetRecommendedSqlType_Mixed`) are left strict — they have headroom and have not flapped.

## Validation
- JSON well-formed (58 entries parse); diff is exactly +9 `meanToleranceFactor` lines, no allocation or other values touched.
- Data-only change consumed by the CI Benchmark-regression comparer (`meanToleranceFactor` already exists in the schema — used by ReportGen/SqlAssessment/BufferedRetainAllPattern overrides); no source/unit-test impact.