### PR TITLE
perf(#234): widen mean tolerance for jittery Sanitize* microbenchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,14 +454,18 @@ axis** in `baselines/baseline.json`:
 Allocations are effectively deterministic on the runner (observed run-to-run
 drift < 0.01%), so allocation stays pinned at the strict `1.10` default for
 **every** benchmark — including the ones below. Only the noisier **mean** axis is
-widened, for the I/O-bound macro-benchmarks and the GC-heavy memory-profile
-patterns whose meaningful signal is allocation rather than wall-clock:
+widened, for the I/O-bound macro-benchmarks, the GC-heavy memory-profile
+patterns whose meaningful signal is allocation rather than wall-clock, and the
+sub-200 ns string micro-benchmarks whose tiny absolute runtimes make relative
+wall-clock jitter (GC/runner scheduling) large enough to flap a 1.10× mean gate:
 
 | Benchmark (all sizes) | `meanToleranceFactor` | Why |
 |---|---|---|
 | `ReportGenerationBenchmarks.GenerateAssessmentReportAsync_EndToEnd` | `1.50` | Writes 4.4 MB → 343 MB to disk; wall-clock swings with runner I/O contention (observed spread ≈ 1.19×). |
 | `SqlAssessmentBenchmarks.AssessMigrationAsync_EndToEnd` | `1.20` | 8-phase orchestration macro; moderate timing variance (observed spread ≈ 1.13×). |
 | `StreamingMemoryProfileBenchmarks.BufferedRetainAllPattern` (1000 & 10000 docs) | `1.30` | Deliberately buffers every document in memory as the allocation contrast to streaming; GC pressure makes wall-clock noisy (observed spread ≈ 1.13×). Allocation — the point of this benchmark — stays strict at `1.10`. |
+| `SqlAssessmentBenchmarks.SanitizeName_Bank` | `1.30` | ~150 ns string micro-benchmark; pure GC/runner jitter has been observed at +14–18% mean on byte-identical code. Allocation stays strict at `1.10`. |
+| `ReportGenerationBenchmarks.SanitizeFileName_Bank` | `1.30` | ~48 ns string micro-benchmark — the smallest in the suite, with the widest measured relative mean spread (≈ 1.13–1.14×). Allocation stays strict at `1.10`. |
 
 Per-benchmark overrides are preserved across `--update` runs. The baseline is
 seeded from the slower of two consecutive CI runs of the same commit

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/README.md
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/README.md
@@ -97,10 +97,13 @@ All per-benchmark overrides are preserved across `--update` runs. The shipped
 baseline keeps allocation pinned at the strict `1.10` default everywhere
 (allocations are deterministic) and widens only the mean axis for the
 I/O-bound macro-benchmarks (`GenerateAssessmentReportAsync_EndToEnd` → `1.50`,
-`AssessMigrationAsync_EndToEnd` → `1.20`) and the GC-heavy
+`AssessMigrationAsync_EndToEnd` → `1.20`), the GC-heavy
 `StreamingMemoryProfileBenchmarks.BufferedRetainAllPattern` (1000 & 10000 docs)
-→ `1.30`, whose buffer-everything pattern is noisy on wall-clock but whose real
-signal — allocation — stays strict at `1.10`.
+→ `1.30`, and the sub-200 ns string micro-benchmarks
+(`SqlAssessmentBenchmarks.SanitizeName_Bank` → `1.30`,
+`ReportGenerationBenchmarks.SanitizeFileName_Bank` → `1.30`) whose tiny absolute
+runtimes make relative wall-clock jitter large enough to flap a 1.10× gate. In
+every case the real signal — allocation — stays strict at `1.10`.
 
 ### Seeding / refreshing the baseline
 

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/baselines/baseline.json
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/baselines/baseline.json
@@ -68,7 +68,8 @@
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.ReportGenerationBenchmarks.SanitizeFileName_Bank(Size: Small)": {
       "meanNs": 48.543820991516114,
-      "allocatedBytes": 78
+      "allocatedBytes": 78,
+      "meanToleranceFactor": 1.3
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.ReportGenerationBenchmarks.CreateValidWorksheetName_Bank(Size: Small)": {
       "meanNs": 375.7633336639405,
@@ -81,7 +82,8 @@
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.ReportGenerationBenchmarks.SanitizeFileName_Bank(Size: Medium)": {
       "meanNs": 48.556215356191,
-      "allocatedBytes": 78
+      "allocatedBytes": 78,
+      "meanToleranceFactor": 1.3
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.ReportGenerationBenchmarks.CreateValidWorksheetName_Bank(Size: Medium)": {
       "meanNs": 378.48888871256503,
@@ -94,7 +96,8 @@
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.ReportGenerationBenchmarks.SanitizeFileName_Bank(Size: Large)": {
       "meanNs": 48.73688116891043,
-      "allocatedBytes": 78
+      "allocatedBytes": 78,
+      "meanToleranceFactor": 1.3
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.ReportGenerationBenchmarks.CreateValidWorksheetName_Bank(Size: Large)": {
       "meanNs": 380.1769623209635,
@@ -120,7 +123,8 @@
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.SqlAssessmentBenchmarks.SanitizeName_Bank(Size: Small)": {
       "meanNs": 149.7092420450846,
-      "allocatedBytes": 270
+      "allocatedBytes": 270,
+      "meanToleranceFactor": 1.3
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.SqlAssessmentBenchmarks.AssessMigrationAsync_EndToEnd(Size: Medium)": {
       "meanNs": 339773.4574544271,
@@ -133,7 +137,8 @@
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.SqlAssessmentBenchmarks.SanitizeName_Bank(Size: Medium)": {
       "meanNs": 150.64176888529457,
-      "allocatedBytes": 270
+      "allocatedBytes": 270,
+      "meanToleranceFactor": 1.3
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.SqlAssessmentBenchmarks.AssessMigrationAsync_EndToEnd(Size: Large)": {
       "meanNs": 2066417.763671875,
@@ -146,7 +151,8 @@
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.SqlAssessmentBenchmarks.SanitizeName_Bank(Size: Large)": {
       "meanNs": 154.11902781895228,
-      "allocatedBytes": 270
+      "allocatedBytes": 270,
+      "meanToleranceFactor": 1.3
     },
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.StreamingMemoryProfileBenchmarks.StreamingClonePattern(DocumentCount: 1000)": {
       "meanNs": 2737613.898995536,


### PR DESCRIPTION
## Summary

Follow-up hardening to the #234 benchmark regression gate. Two sub-200 ns string micro-benchmarks flap the strict `1.10×` mean gate on **byte-identical code** due to pure GC/runner scheduling jitter:

- **`SqlAssessmentBenchmarks.SanitizeName_Bank`** (~150 ns) — observed at **+14–18% mean** on a sibling docs-only PR whose production code is identical to `main`. Flagged by the orchestrator as a known false-positive source for upcoming merges.
- **`ReportGenerationBenchmarks.SanitizeFileName_Bank`** (~48 ns) — the smallest benchmark in the suite, with the **widest measured relative mean spread (≈1.13–1.14×)** across my two seed runs. Added proactively from measured data since it is strictly noisier than `SanitizeName_Bank` and will flap next.

Both get a **mean-only** `meanToleranceFactor: 1.30` override (all three `Size` variants each), matching the `BufferedRetainAllPattern` treatment from #247. **Allocation stays strict at the `1.10` default** so genuine allocation regressions are still caught — allocations on these are byte-deterministic on the runner.

## Why this is the right call

Sub-200 ns benchmarks have tiny absolute runtimes, so a few ns of GC/scheduler jitter is a large *relative* swing. A 1.10× mean gate is below the noise floor for them — it catches jitter, not regressions. Widening only the noisy mean axis (not allocation) keeps the contract conservative.

## Validation

Synthetic 3-variant test on `SanitizeName_Bank(Small)` against the committed baseline:

| Variant | Injected | Result |
|---|---|---|
| A | +18% mean, alloc unchanged | ✅ exit 0 (pass — within 1.30×) |
| B | +40% mean | ❌ exit 1 (mean regression caught) |
| C | +2000 B allocation | ❌ exit 1 (allocation regression caught despite mean override) |

Real run3-main reports re-checked against the updated baseline: **58 compared, 0 regressions**.

## Docs

Both `README.md` (root, "Regression detection" override table) and `tests/Performance/CosmosToSqlAssessment.Benchmarks/README.md` updated to list the two new overrides alongside `BufferedRetainAllPattern` / the EndToEnd macros.

## Scope note

Issue #234 itself remains **CLOSED/COMPLETED** — this is hardening to remove the last known microbenchmark false positive from the gate before the #131/#132/#133/#69 merges. Could not fold into #247 because #247 already merged.

Refs #234. Follow-up to #247.