### PR TITLE
docs(#234): document Sanitize*/MapJsonType micro mean-tolerance overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,14 +454,20 @@ axis** in `baselines/baseline.json`:
 Allocations are effectively deterministic on the runner (observed run-to-run
 drift < 0.01%), so allocation stays pinned at the strict `1.10` default for
 **every** benchmark — including the ones below. Only the noisier **mean** axis is
-widened, for the I/O-bound macro-benchmarks and the GC-heavy memory-profile
-patterns whose meaningful signal is allocation rather than wall-clock:
+widened, for the I/O-bound macro-benchmarks, the GC-heavy memory-profile
+patterns whose meaningful signal is allocation rather than wall-clock, and the
+sub-200 ns string/type micro-benchmarks whose tiny absolute runtimes make
+relative wall-clock jitter (GC/runner scheduling) large enough to flap a 1.10×
+mean gate on byte-identical code:
 
 | Benchmark (all sizes) | `meanToleranceFactor` | Why |
 |---|---|---|
 | `ReportGenerationBenchmarks.GenerateAssessmentReportAsync_EndToEnd` | `1.50` | Writes 4.4 MB → 343 MB to disk; wall-clock swings with runner I/O contention (observed spread ≈ 1.19×). |
 | `SqlAssessmentBenchmarks.AssessMigrationAsync_EndToEnd` | `1.20` | 8-phase orchestration macro; moderate timing variance (observed spread ≈ 1.13×). |
 | `StreamingMemoryProfileBenchmarks.BufferedRetainAllPattern` (1000 & 10000 docs) | `1.30` | Deliberately buffers every document in memory as the allocation contrast to streaming; GC pressure makes wall-clock noisy (observed spread ≈ 1.13×). Allocation — the point of this benchmark — stays strict at `1.10`. |
+| `SqlAssessmentBenchmarks.SanitizeName_Bank` | `1.50` | ~150 ns string micro-benchmark; pure GC/runner jitter observed at +14–18% mean on byte-identical code. Allocation stays strict at `1.10`. |
+| `ReportGenerationBenchmarks.SanitizeFileName_Bank` | `1.50` | ~48 ns string micro-benchmark — the smallest in the suite, with the widest measured relative mean spread (≈ 1.13–1.14×). Allocation stays strict at `1.10`. |
+| `CosmosAnalysisBenchmarks.MapJsonTypeToSqlTypeEnhanced_Primitives` | `1.50` | ~134 ns type-mapping micro-benchmark; sub-200 ns runtime makes relative wall-clock jitter large. Allocation stays strict at `1.10`. |
 
 Per-benchmark overrides are preserved across `--update` runs. The baseline is
 seeded from the slower of two consecutive CI runs of the same commit

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/README.md
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/README.md
@@ -97,10 +97,15 @@ All per-benchmark overrides are preserved across `--update` runs. The shipped
 baseline keeps allocation pinned at the strict `1.10` default everywhere
 (allocations are deterministic) and widens only the mean axis for the
 I/O-bound macro-benchmarks (`GenerateAssessmentReportAsync_EndToEnd` → `1.50`,
-`AssessMigrationAsync_EndToEnd` → `1.20`) and the GC-heavy
+`AssessMigrationAsync_EndToEnd` → `1.20`), the GC-heavy
 `StreamingMemoryProfileBenchmarks.BufferedRetainAllPattern` (1000 & 10000 docs)
-→ `1.30`, whose buffer-everything pattern is noisy on wall-clock but whose real
-signal — allocation — stays strict at `1.10`.
+→ `1.30`, and the sub-200 ns string/type micro-benchmarks
+(`SqlAssessmentBenchmarks.SanitizeName_Bank`,
+`ReportGenerationBenchmarks.SanitizeFileName_Bank`,
+`CosmosAnalysisBenchmarks.MapJsonTypeToSqlTypeEnhanced_Primitives` → `1.50`)
+whose tiny absolute runtimes make relative wall-clock jitter large enough to
+flap a 1.10× gate. In every case the real signal — allocation — stays strict at
+`1.10`.
 
 ### Seeding / refreshing the baseline
 


### PR DESCRIPTION
## Summary

Docs-only sync. A sibling merge added **mean-only** `meanToleranceFactor: 1.50` overrides to `baselines/baseline.json` for three sub-200 ns micro-benchmarks, but the override tables in both READMEs were never updated to list them — they still document only the original three overrides. This closes that doc-drift.

Newly-documented overrides (already live in `baseline.json` on `main`):

| Benchmark (all sizes) | meanToleranceFactor | Runtime |
|---|---|---|
| `SqlAssessmentBenchmarks.SanitizeName_Bank` | `1.50` | ~150 ns |
| `ReportGenerationBenchmarks.SanitizeFileName_Bank` | `1.50` | ~48 ns |
| `CosmosAnalysisBenchmarks.MapJsonTypeToSqlTypeEnhanced_Primitives` | `1.50` | ~134 ns |

All three are **mean-only** — allocation stays strict at the `1.10` default, so real allocation regressions are still caught. Rationale: sub-200 ns runtimes make relative wall-clock jitter (GC/runner scheduling) large enough to flap a 1.10x mean gate on byte-identical code (SanitizeName_Bank was observed at +14-18% mean on a sibling docs-only PR).

## Why docs-only

The `baseline.json` overrides are already on `main` (added at 1.50, more conservative than the 1.30 originally drafted — left as-is). The only missing piece was documentation, so this PR touches **only the two READMEs**. The `.md` paths are excluded from the perf workflow paths filter, so it won't trigger or cancel any in-flight benchmark runs.

## Scope note

Issue #234 remains **CLOSED/COMPLETED**. Documentation hardening so the override tables match the live baseline before the upcoming #131/#132/#133/#69 merges. Supersedes the now-redundant PR #258. Refs #234.
