### PR TITLE
perf(#234): categorical sub-us mean noise floor to stop microbenchmark gate flapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,8 @@ Shipped defaults:
 |---|---|---|
 | `defaultToleranceFactor` | `1.10` | 10% headroom on both the mean and allocation axes for every benchmark, unless a per-axis override widens it. Satisfies the parent #79 ">10% degradation fails CI" criterion. |
 | `defaultAllocationFloorBytes` | `1024` | Protects near-zero baselines from brittle alarms — an absolute +1 KB is always allowed on top of the percentage. |
+| `meanNoiseFloorNs` | `1000` | Sub-microsecond **mean noise floor**: any benchmark whose baseline mean is below this (i.e. nanosecond-scale micros) gets a wider mean-only tolerance unless it has an explicit per-benchmark mean override. Set to `0` to disable. Allocation is unaffected. |
+| `meanNoiseFloorToleranceFactor` | `1.30` | The mean tolerance applied to benchmarks under the noise floor. |
 
 Tolerances can be overridden per benchmark and, since #234, **independently per
 axis** in `baselines/baseline.json`:
@@ -450,15 +452,18 @@ axis** in `baselines/baseline.json`:
 - `allocationToleranceFactor` — widens only the allocation budget.
 - `toleranceFactor` — legacy shared override applied to both axes when an
   axis-specific value is absent.
+- the **sub-µs mean noise floor** (`meanNoiseFloorNs` /
+  `meanNoiseFloorToleranceFactor`) — a mean-only fallback for any benchmark below
+  the floor that has no explicit mean override; never touches allocation.
 
 Allocations are effectively deterministic on the runner (observed run-to-run
 drift < 0.01%), so allocation stays pinned at the strict `1.10` default for
 **every** benchmark — including the ones below. Only the noisier **mean** axis is
 widened, for the I/O-bound macro-benchmarks, the GC-heavy memory-profile
 patterns whose meaningful signal is allocation rather than wall-clock, and the
-sub-200 ns string/type micro-benchmarks whose tiny absolute runtimes make
-relative wall-clock jitter (GC/runner scheduling) large enough to flap a 1.10×
-mean gate on byte-identical code:
+nanosecond-scale micro-benchmarks whose tiny absolute runtimes make relative
+wall-clock jitter (GC/runner scheduling) large enough to flap a 1.10× mean gate
+on byte-identical code:
 
 | Benchmark (all sizes) | `meanToleranceFactor` | Why |
 |---|---|---|
@@ -468,6 +473,16 @@ mean gate on byte-identical code:
 | `SqlAssessmentBenchmarks.SanitizeName_Bank` | `1.50` | ~150 ns string micro-benchmark; pure GC/runner jitter observed at +14–18% mean on byte-identical code. Allocation stays strict at `1.10`. |
 | `ReportGenerationBenchmarks.SanitizeFileName_Bank` | `1.50` | ~48 ns string micro-benchmark — the smallest in the suite, with the widest measured relative mean spread (≈ 1.13–1.14×). Allocation stays strict at `1.10`. |
 | `CosmosAnalysisBenchmarks.MapJsonTypeToSqlTypeEnhanced_Primitives` | `1.50` | ~134 ns type-mapping micro-benchmark; sub-200 ns runtime makes relative wall-clock jitter large. Allocation stays strict at `1.10`. |
+| _every other benchmark with baseline mean `< 1 µs`_ | `1.30` (noise floor) | Covered categorically by `meanNoiseFloorNs` instead of a hand-maintained list — e.g. `CosmosAnalysisBenchmarks.AnalyzeArrayStructure_Objects` (≈ 560 ns, observed up to 1.13×) and `SqlAssessmentBenchmarks.GetRecommendedSqlType_Mixed` (≈ 835 ns) which a fixed name list would otherwise miss. Allocation stays strict at `1.10`. |
+
+The mean noise floor is categorical on purpose: sub-microsecond wall-clock times
+on shared CI runners have a jitter floor that routinely swamps a sub-10 % signal,
+so a `1.10×` mean gate there only produces false positives. Rather than enumerate
+every tiny benchmark (and re-flap each time a new one is added), the floor widens
+the mean axis for the whole `< 1 µs` class while the deterministic allocation axis
+stays strict at `1.10` to catch the real regressions. Explicit per-benchmark mean
+overrides always win over the floor; benchmarks at or above `1 µs` keep the `1.10`
+default.
 
 Per-benchmark overrides are preserved across `--update` runs. The baseline is
 seeded from the slower of two consecutive CI runs of the same commit

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/README.md
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/README.md
@@ -68,6 +68,8 @@ local-only at present; CI integration arrives in #178.
   "captureCommand": "<command used to produce the report>",
   "defaultToleranceFactor": 1.10,
   "defaultAllocationFloorBytes": 1024,
+  "meanNoiseFloorNs": 1000,
+  "meanNoiseFloorToleranceFactor": 1.30,
   "benchmarks": {
     "Namespace.Class.Method(Size: Small)": {
       "meanNs": 12345.6,
@@ -91,21 +93,35 @@ allocation budgets can be tuned separately:
 - `allocationToleranceFactor` overrides only the allocation axis.
 - `toleranceFactor` is a legacy shared override used for an axis only when its
   axis-specific value is absent.
+- The **sub-microsecond mean noise floor** (`meanNoiseFloorNs` /
+  `meanNoiseFloorToleranceFactor`) applies a wider *mean-only* tolerance to any
+  benchmark whose baseline mean is below `meanNoiseFloorNs`, when no explicit
+  per-benchmark mean override is present. It never affects the allocation axis.
+  Set `meanNoiseFloorNs: 0` to disable it.
 - Anything still unset falls back to `defaultToleranceFactor`.
 
-All per-benchmark overrides are preserved across `--update` runs. The shipped
-baseline keeps allocation pinned at the strict `1.10` default everywhere
-(allocations are deterministic) and widens only the mean axis for the
-I/O-bound macro-benchmarks (`GenerateAssessmentReportAsync_EndToEnd` → `1.50`,
-`AssessMigrationAsync_EndToEnd` → `1.20`), the GC-heavy
-`StreamingMemoryProfileBenchmarks.BufferedRetainAllPattern` (1000 & 10000 docs)
-→ `1.30`, and the sub-200 ns string/type micro-benchmarks
-(`SqlAssessmentBenchmarks.SanitizeName_Bank`,
-`ReportGenerationBenchmarks.SanitizeFileName_Bank`,
-`CosmosAnalysisBenchmarks.MapJsonTypeToSqlTypeEnhanced_Primitives` → `1.50`)
-whose tiny absolute runtimes make relative wall-clock jitter large enough to
-flap a 1.10× gate. In every case the real signal — allocation — stays strict at
-`1.10`.
+The shipped baseline uses a **tiered mean policy** (allocation always stays strict
+at the `1.10` default — allocations are deterministic, so a real allocation
+regression is always a true signal):
+
+| Tier | Mean tolerance | Applies to |
+| --- | --- | --- |
+| Macro I/O benchmarks | explicit `1.50` / `1.20` | `GenerateAssessmentReportAsync_EndToEnd` (`1.50`, 4.4 MB→343 MB disk I/O), `AssessMigrationAsync_EndToEnd` (`1.20`) |
+| GC-heavy buffered pattern | explicit `1.30` | `StreamingMemoryProfileBenchmarks.BufferedRetainAllPattern` (1000 & 10000 docs) |
+| Sub-200 ns string/type micros | explicit `1.50` | `SqlAssessmentBenchmarks.SanitizeName_Bank`, `ReportGenerationBenchmarks.SanitizeFileName_Bank`, `CosmosAnalysisBenchmarks.MapJsonTypeToSqlTypeEnhanced_Primitives` |
+| **Other sub-µs micros (`< 1000 ns`)** | **noise floor `1.30`** | every remaining nanosecond-scale benchmark — covered automatically by `meanNoiseFloorNs`, no per-entry list to maintain |
+| Everything `≥ 1 µs` | `1.10` default | all macro/streaming benchmarks; their wall-clock signal is large enough to trust at 10 % |
+
+The noise floor exists because sub-microsecond wall-clock times on shared CI
+runners have a jitter floor (GC, scheduler, thermal) that routinely swamps a
+sub-10 % signal — a `1.10×` mean gate produces only false positives there. Rather
+than hand-listing every tiny benchmark (and missing newly added ones such as
+`CosmosAnalysisBenchmarks.AnalyzeArrayStructure_Objects` or
+`SqlAssessmentBenchmarks.GetRecommendedSqlType_Mixed`), the floor covers the whole
+class categorically while keeping the allocation axis — the deterministic, real
+signal — strict at `1.10` everywhere. Explicit per-benchmark mean overrides still
+win over the floor. All per-benchmark overrides are preserved across `--update`
+runs.
 
 ### Seeding / refreshing the baseline
 

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/Tracking/BaselineComparer.cs
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/Tracking/BaselineComparer.cs
@@ -212,6 +212,17 @@ public static class BaselineComparer
         return entries;
     }
 
+    /// <summary>
+    /// Resolves the mean-axis "noise floor" tolerance for a benchmark whose baseline mean falls below
+    /// <see cref="BaselineFile.MeanNoiseFloorNs"/>. Returns <c>null</c> when the floor is disabled
+    /// (<see cref="BaselineFile.MeanNoiseFloorNs"/> is <c>0</c>) or the benchmark is at or above it, so
+    /// callers fall through to <see cref="BaselineFile.DefaultToleranceFactor"/>.
+    /// </summary>
+    internal static double? MeanNoiseFloorFactor(BaselineFile baseline, double baselineMeanNs) =>
+        baseline.MeanNoiseFloorNs > 0 && baselineMeanNs < baseline.MeanNoiseFloorNs
+            ? baseline.MeanNoiseFloorToleranceFactor
+            : null;
+
     internal static ComparisonOutcome Compare(BaselineFile baseline, Dictionary<string, ReportEntry> report)
     {
         var outcome = new ComparisonOutcome();
@@ -242,6 +253,7 @@ public static class BaselineComparer
 
             double meanTolerance = baselineRow.MeanToleranceFactor
                 ?? baselineRow.ToleranceFactor
+                ?? MeanNoiseFloorFactor(baseline, baselineRow.MeanNs)
                 ?? baseline.DefaultToleranceFactor;
             double allocTolerance = baselineRow.AllocationToleranceFactor
                 ?? baselineRow.ToleranceFactor

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/Tracking/BaselineRecord.cs
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/Tracking/BaselineRecord.cs
@@ -20,6 +20,23 @@ public sealed class BaselineFile
 
     public long DefaultAllocationFloorBytes { get; set; } = 1024;
 
+    /// <summary>
+    /// Mean-axis "noise floor" for nanosecond-scale micro-benchmarks. When a benchmark's recorded
+    /// baseline mean is below <see cref="MeanNoiseFloorNs"/> and it carries no explicit mean override,
+    /// the mean axis is compared at <see cref="MeanNoiseFloorToleranceFactor"/> instead of
+    /// <see cref="DefaultToleranceFactor"/>. Sub-microsecond wall-clock timings have a jitter floor on
+    /// shared CI runners that swamps any sub-10% signal, so the strict default produces false positives
+    /// on byte-identical code. The allocation axis is unaffected (allocations are deterministic), so
+    /// real algorithmic regressions are still caught. Set to <c>0</c> (the default) to disable.
+    /// </summary>
+    public double MeanNoiseFloorNs { get; set; }
+
+    /// <summary>
+    /// Mean tolerance applied to benchmarks below <see cref="MeanNoiseFloorNs"/> that have no explicit
+    /// mean override. Ignored when <see cref="MeanNoiseFloorNs"/> is <c>0</c>.
+    /// </summary>
+    public double MeanNoiseFloorToleranceFactor { get; set; } = 1.30;
+
     public Dictionary<string, BenchmarkBaseline> Benchmarks { get; set; } = new(StringComparer.Ordinal);
 }
 

--- a/tests/Performance/CosmosToSqlAssessment.Benchmarks/baselines/baseline.json
+++ b/tests/Performance/CosmosToSqlAssessment.Benchmarks/baselines/baseline.json
@@ -5,6 +5,8 @@
   "captureCommand": "Performance Regression workflow_dispatch (update_baseline=true) x2; per-benchmark meanNs/allocatedBytes = max(run1, run2)",
   "defaultToleranceFactor": 1.1,
   "defaultAllocationFloorBytes": 1024,
+  "meanNoiseFloorNs": 1000,
+  "meanNoiseFloorToleranceFactor": 1.3,
   "benchmarks": {
     "CosmosToSqlAssessment.Benchmarks.Benchmarks.CosmosAnalysisBenchmarks.MapJsonTypeToSqlTypeEnhanced_Primitives(Size: Small)": {
       "meanNs": 134.02137163335627,


### PR DESCRIPTION
## What & why

Hardening for the benchmark regression gate (post-#234). Nanosecond-scale microbenchmarks have a wall-clock **jitter floor** on shared CI runners that swamps any sub-10% signal, so the strict `1.10x` mean gate produces only false positives on byte-identical code. `SqlAssessmentBenchmarks.SanitizeName_Bank` (~150 ns) recently flapped at **+14–18% mean** on a docs-only sibling PR.

Hand-listing each tiny benchmark is brittle. My seed-run data showed the originally-named micros (`CreateValidWorksheetName_Bank` ~375 ns, `GenerateIndexScript_Bank` ~436 ns) were actually quiet (≤1.03x), while two that **no** hand-picked list covered were genuinely noisy:
- `CosmosAnalysisBenchmarks.AnalyzeArrayStructure_Objects(Large)` ~560 ns → **1.128x** (already over the 1.10 gate)
- `SqlAssessmentBenchmarks.GetRecommendedSqlType_Mixed` ~835 ns → 1.08–1.09x

## The mechanism

A config-driven **categorical sub-µs mean noise floor** instead of an ever-growing name list:

- `BaselineFile` gains `meanNoiseFloorNs` (`0` = disabled) and `meanNoiseFloorToleranceFactor` (default `1.30`).
- `BaselineComparer` resolves the **mean** axis as: explicit `meanToleranceFactor` → legacy `toleranceFactor` → **noise floor** (when baseline mean `< meanNoiseFloorNs`) → `defaultToleranceFactor`.
- `baseline.json` sets `meanNoiseFloorNs: 1000`, `meanNoiseFloorToleranceFactor: 1.30`.

The **allocation axis is untouched** — it stays strict at `1.10x` (+1024 B floor) everywhere because allocations are deterministic, so real memory regressions are still caught. Explicit per-benchmark mean overrides (the `1.50`/`1.20`/`1.30` macros and sub-200 ns micros) still win over the floor; benchmarks `≥ 1 µs` keep the `1.10` default.

### Tiered mean policy (allocation always strict 1.10)
| Tier | Mean tol | Applies to |
| --- | --- | --- |
| Macro I/O | `1.50` / `1.20` | `GenerateAssessmentReportAsync_EndToEnd`, `AssessMigrationAsync_EndToEnd` |
| GC-heavy buffered | `1.30` | `BufferedRetainAllPattern` (1000 & 10000) |
| Sub-200 ns string/type | `1.50` | `SanitizeName_Bank`, `SanitizeFileName_Bank`, `MapJsonTypeToSqlTypeEnhanced_Primitives` |
| **Other `< 1 µs` micros** | **`1.30` (noise floor)** | every remaining nanosecond benchmark — categorical, no list to maintain |
| `≥ 1 µs` | `1.10` default | all macro/streaming benchmarks |

## Validation

- **6 synthetic cases** against the committed baseline: sub-µs no-override +25% → PASS, +35% → FAIL (mean); allocation +2000 B → FAIL (axis untouched); explicit-`1.50` +40% → PASS; `≥1 µs` +20% → FAIL (default 1.10); `≥1 µs` +5% → PASS.
- **All 58 real benchmarks** from a clean main run compare clean (0 regressions) with the floor active.
- Full solution builds Release with 0 errors.

## Scope

Hardening only — issues **#234** and **#252** remain **closed** (this is not a reopen). Supersedes the closed #258. Documents the new keys + tiered policy in both the root README and the benchmarks README.
