### PR TITLE
fix: AssessmentOrchestrator robustness bugs (#237, #238, #239)

### DIFF
--- a/Orchestration/AssessmentOrchestrator.cs
+++ b/Orchestration/AssessmentOrchestrator.cs
@@ -37,13 +37,13 @@ namespace CosmosToSqlAssessment.Orchestration;
 /// </para>
 ///
 /// <para>
-/// Three pre-existing bugs were observed during the extraction and preserved
-/// intentionally (filed as follow-up issues for separate fixes):
+/// Three pre-existing bugs observed during the extraction (#187 / parent #126) were
+/// subsequently fixed as dedicated follow-up issues:
 /// </para>
 /// <list type="bullet">
-///   <item>Per-database override-configuration provider ordering reverses the intended endpoint override (later providers win).</item>
-///   <item>Broad <c>catch (Exception)</c> blocks in <see cref="RunAssessmentAsync"/> swallow <see cref="OperationCanceledException"/> as <c>InvalidOperationException</c>, defeating Main's Ctrl+C exit-code 130 mapping.</item>
-///   <item>Override <see cref="ServiceProvider"/> isn't disposed inside a <c>try/finally</c>, so mid-loop failures leak it.</item>
+///   <item>#238: per-database override-configuration provider ordering reversed the intended endpoint override (later providers win); the in-memory override is now added last via <see cref="BuildOverrideConfiguration"/> so it takes effect.</item>
+///   <item>#237: broad <c>catch (Exception)</c> blocks in <see cref="RunDatabaseAssessmentAsync"/> swallowed <see cref="OperationCanceledException"/> as <c>InvalidOperationException</c>, defeating Main's Ctrl+C exit-code 130 mapping; each phase now re-throws <see cref="OperationCanceledException"/> before the broad catch.</item>
+///   <item>#239: the override <see cref="ServiceProvider"/> wasn't disposed on a mid-loop failure; it is now disposed deterministically via <c>await using</c>.</item>
 /// </list>
 /// </summary>
 internal sealed class AssessmentOrchestrator
@@ -223,28 +223,24 @@ internal sealed class AssessmentOrchestrator
             if (!string.IsNullOrEmpty(userInputs.AccountEndpoint) &&
                 userInputs.AccountEndpoint != _configuration["CosmosDb:AccountEndpoint"])
             {
-                var configDict = new Dictionary<string, string>
-                {
-                    ["CosmosDb:AccountEndpoint"] = userInputs.AccountEndpoint
-                };
-                var overrideConfig = new ConfigurationBuilder()
-                    .AddInMemoryCollection(configDict!)
-                    .AddConfiguration(_configuration)
-                    .Build();
-
+                var overrideConfig = BuildOverrideConfiguration(userInputs.AccountEndpoint);
                 var overrideServices = new ServiceCollection().AddCosmosAssessment(overrideConfig);
                 overrideServiceProvider = overrideServices.BuildServiceProvider();
                 activeServiceProvider = overrideServiceProvider;
             }
 
-            var assessmentResult = await RunDatabaseAssessmentAsync(activeServiceProvider, userInputs, databaseName, cancellationToken);
-            await AttachRecommendationRefinementAsync(activeServiceProvider, assessmentResult, cancellationToken);
-            assessmentResults.Add(assessmentResult);
+            // Dispose the per-database override provider deterministically - even when the
+            // assessment throws mid-iteration - so it can never leak (fixes #239). A null
+            // provider (no override) makes this a no-op.
+            await using (overrideServiceProvider)
+            {
+                var assessmentResult = await RunDatabaseAssessmentAsync(activeServiceProvider, userInputs, databaseName, cancellationToken);
+                await AttachRecommendationRefinementAsync(activeServiceProvider, assessmentResult, cancellationToken);
+                assessmentResults.Add(assessmentResult);
 
-            Console.WriteLine($"✅ Completed assessment for database: {databaseName}");
-            Console.WriteLine();
-
-            overrideServiceProvider?.Dispose();
+                Console.WriteLine($"✅ Completed assessment for database: {databaseName}");
+                Console.WriteLine();
+            }
         }
 
         if (assessmentResults.Count == 1)
@@ -268,6 +264,31 @@ internal sealed class AssessmentOrchestrator
         };
 
         return combinedResult;
+    }
+
+    /// <summary>
+    /// Builds the per-database configuration used when a CLI/user-supplied Cosmos DB account
+    /// endpoint overrides the value from the outer application configuration. The in-memory
+    /// override is added after the outer configuration so that, per
+    /// <see cref="ConfigurationBuilder"/> precedence (the last provider added wins), the override
+    /// actually takes effect. Adding it first made the override a silent no-op (fixes #238).
+    /// </summary>
+    /// <param name="accountEndpoint">The overriding Cosmos DB account endpoint.</param>
+    /// <returns>
+    /// A configuration identical to the outer one except that <c>CosmosDb:AccountEndpoint</c>
+    /// resolves to <paramref name="accountEndpoint"/>.
+    /// </returns>
+    internal IConfiguration BuildOverrideConfiguration(string accountEndpoint)
+    {
+        var configDict = new Dictionary<string, string>
+        {
+            ["CosmosDb:AccountEndpoint"] = accountEndpoint
+        };
+
+        return new ConfigurationBuilder()
+            .AddConfiguration(_configuration)
+            .AddInMemoryCollection(configDict!)
+            .Build();
     }
 
     /// <summary>
@@ -310,7 +331,7 @@ internal sealed class AssessmentOrchestrator
         }
     }
 
-    private async Task<AssessmentResult> RunDatabaseAssessmentAsync(
+    internal async Task<AssessmentResult> RunDatabaseAssessmentAsync(
         IServiceProvider activeServiceProvider,
         UserInputs userInputs,
         string databaseName,
@@ -342,6 +363,10 @@ internal sealed class AssessmentOrchestrator
                 Console.WriteLine($"   ⚠️  {assessmentResult.CosmosAnalysis.MonitoringLimitations.Count} monitoring limitations detected");
             }
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to analyze Cosmos DB");
@@ -359,6 +384,10 @@ internal sealed class AssessmentOrchestrator
             Console.WriteLine($"   ✅ Recommended platform: {assessmentResult.SqlAssessment.RecommendedPlatform}");
             Console.WriteLine($"   ✅ Generated {assessmentResult.SqlAssessment.IndexRecommendations.Count} index recommendations");
             Console.WriteLine($"   ✅ Migration complexity: {assessmentResult.SqlAssessment.Complexity.OverallComplexity}");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -382,6 +411,10 @@ internal sealed class AssessmentOrchestrator
             Console.WriteLine($"   ✅ Found {assessmentResult.DataQualityAnalysis.WarningIssuesCount} warnings");
             Console.WriteLine($"   ✅ Quality score: {assessmentResult.DataQualityAnalysis.Summary.OverallQualityScore:F1}/100 ({assessmentResult.DataQualityAnalysis.Summary.QualityRating})");
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to perform data quality analysis - continuing without it");
@@ -402,6 +435,10 @@ internal sealed class AssessmentOrchestrator
             Console.WriteLine($"   ✅ Estimated migration time: {assessmentResult.DataFactoryEstimate.EstimatedDuration:hh\\:mm\\:ss}");
             Console.WriteLine($"   ✅ Estimated cost: ${assessmentResult.DataFactoryEstimate.EstimatedCostUSD:F2}");
             Console.WriteLine($"   ✅ Recommended DIUs: {assessmentResult.DataFactoryEstimate.RecommendedDIUs}");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/Services/CosmosDbAnalysisService.cs
+++ b/Services/CosmosDbAnalysisService.cs
@@ -334,7 +334,7 @@ namespace CosmosToSqlAssessment.Services
         /// Console.WriteLine($"Reports written under {analysisFolder}");
         /// ]]></code>
         /// </example>
-        public async Task<CosmosDbAnalysis> AnalyzeDatabaseAsync(string databaseName, CancellationToken cancellationToken = default)
+        public virtual async Task<CosmosDbAnalysis> AnalyzeDatabaseAsync(string databaseName, CancellationToken cancellationToken = default)
         {
             var analysis = new CosmosDbAnalysis();
 

--- a/tests/CosmosToSqlAssessment.Tests/Orchestration/AssessmentOrchestratorTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Orchestration/AssessmentOrchestratorTests.cs
@@ -73,4 +73,88 @@ public class AssessmentOrchestratorTests
 
         exitCode.Should().Be(1);
     }
+
+    [Fact]
+    public async Task RunDatabaseAssessmentAsync_WhenCancelledMidPhase_PropagatesOperationCanceledException()
+    {
+        // Regression test for #237: the per-phase broad catch blocks must not swallow
+        // OperationCanceledException (Ctrl+C) by wrapping it in InvalidOperationException -
+        // otherwise Program.Main's OperationCanceledException -> exit-code-130 mapping never fires.
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["CosmosDb:AccountEndpoint"] = "https://fake.documents.azure.com:443/"
+            })
+            .Build();
+
+        var services = new ServiceCollection().AddCosmosAssessment(configuration);
+
+        // Replace the real Cosmos analysis service with one that observes cancellation and throws
+        // OperationCanceledException, simulating Ctrl+C during Phase 1. The last registration wins.
+        services.AddScoped<CosmosDbAnalysisService>(sp =>
+            new CancellingCosmosDbAnalysisService(
+                configuration,
+                sp.GetRequiredService<ILogger<CosmosDbAnalysisService>>()));
+
+        using var provider = services.BuildServiceProvider();
+        var logger = provider.GetRequiredService<ILogger<AssessmentOrchestrator>>();
+        var orchestrator = new AssessmentOrchestrator(provider, configuration, logger);
+
+        var userInputs = new UserInputs
+        {
+            AccountEndpoint = "https://fake.documents.azure.com:443/",
+            DatabaseNames = new List<string> { "db" }
+        };
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Func<Task> act = () => orchestrator.RunDatabaseAssessmentAsync(provider, userInputs, "db", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public void BuildOverrideConfiguration_OverridesOuterAccountEndpoint_AndPreservesOtherKeys()
+    {
+        // Regression test for #238: the per-database in-memory endpoint override must win over the
+        // outer configuration (it is added last). The previous ordering made the override a no-op.
+        var outer = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["CosmosDb:AccountEndpoint"] = "https://outer.documents.azure.com:443/",
+                ["CosmosDb:DatabaseName"] = "OuterDb"
+            })
+            .Build();
+
+        var services = new ServiceCollection().AddCosmosAssessment(outer);
+        using var provider = services.BuildServiceProvider();
+        var logger = provider.GetRequiredService<ILogger<AssessmentOrchestrator>>();
+        var orchestrator = new AssessmentOrchestrator(provider, outer, logger);
+
+        var overrideConfig = orchestrator.BuildOverrideConfiguration("https://override.documents.azure.com:443/");
+
+        overrideConfig["CosmosDb:AccountEndpoint"].Should().Be("https://override.documents.azure.com:443/");
+        // Keys absent from the override still resolve from the outer configuration.
+        overrideConfig["CosmosDb:DatabaseName"].Should().Be("OuterDb");
+    }
+
+    /// <summary>
+    /// Test double whose <see cref="AnalyzeDatabaseAsync(string, CancellationToken)"/> override
+    /// honours cancellation and throws <see cref="OperationCanceledException"/>, standing in for a
+    /// Ctrl+C during the first assessment phase.
+    /// </summary>
+    private sealed class CancellingCosmosDbAnalysisService : CosmosDbAnalysisService
+    {
+        public CancellingCosmosDbAnalysisService(IConfiguration configuration, ILogger<CosmosDbAnalysisService> logger)
+            : base(configuration, logger)
+        {
+        }
+
+        public override Task<CosmosDbAnalysis> AnalyzeDatabaseAsync(string databaseName, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            throw new OperationCanceledException();
+        }
+    }
 }


### PR DESCRIPTION
Surgical fixes for three tightly-coupled follow-up bugs in `Orchestration/AssessmentOrchestrator.cs`, all preserved verbatim from the #126 refactor. Done in one branch/PR because they touch the same file/method and would self-conflict if split.

## Bugs

**#237 — `OperationCanceledException` swallowed by broad catch.** The per-phase `try`/`catch (Exception)` blocks (Phases 1, 2, 4) in `RunDatabaseAssessmentAsync` wrap `OperationCanceledException` (Ctrl+C) into `InvalidOperationException`, defeating `Program.Main`'s exit-code-130 mapping. Each phase catch now re-throws `OperationCanceledException` before the broad catch.

**#238 — per-database override endpoint silently ignored.** The override `ConfigurationBuilder` added `AddInMemoryCollection` before `AddConfiguration(_configuration)`, so the outer config won (last provider wins) and the override was a no-op. Provider order flipped so the in-memory override is added last.

**#239 — override `ServiceProvider` leaks on exception.** The per-database override `ServiceProvider` was disposed by an explicit `.Dispose()` never reached when the iteration threw. Now disposed via `await using`.

## Closes

Closes #237

Closes #238

Closes #239