### PR TITLE
ci(perf): queue consecutive main runs instead of cancelling (#263)

### DIFF
--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -31,7 +31,12 @@ on:
 
 concurrency:
   group: perf-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Cancel redundant in-progress runs only for pull_request events (a newer push to the same
+  # PR supersedes the older run). For push/workflow_dispatch on `main`, do NOT cancel: the
+  # `main` group is shared across consecutive runs, and cancelling them breaks the
+  # "N consecutive clean baseline runs" validation (and forced a manual merge-freeze dance).
+  # Letting main-ref runs queue instead keeps every main commit's regression check intact.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   DOTNET_VERSION: '8.0.x'


### PR DESCRIPTION
## Summary

Fixes the Performance Regression workflow concurrency so that **consecutive `main`-ref runs queue instead of cancelling each other**.

### Problem (#263)
The workflow set `cancel-in-progress: true` unconditionally. The concurrency group for `push`/`workflow_dispatch` on `main` resolves to a single shared key (`github.ref` = `refs/heads/main`), so a new main commit (or dispatch) **cancelled** the in-flight regression run for the previous main commit. This:
- left main commits without a completed regression check, and
- forced a manual "merge-freeze + serial dispatch" dance whenever we needed N consecutive clean baseline runs (e.g. the #234/#252 sub-µs hardening validation).

### Fix
```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```
- **pull_request**: still cancels superseded runs when a newer commit is pushed to the same PR (preserves CI savings; the PR group is keyed by PR number).
- **push / workflow_dispatch on main**: no longer cancels — consecutive runs on the shared main group **queue**, so every main commit's regression check completes.

Job-level `gh-pages-deploy` concurrency (`cancel-in-progress: false`) is unrelated and left unchanged.

### Validation
- YAML parses cleanly (`yaml.safe_load`).
- One-line behavioral change to workflow-level concurrency only; no job logic touched.

Closes #263
