### PR TITLE
feat: expose agentic-mode, alert-template, metric-publish, and outcome-capture via CLI (#248, #256, #257, #259)

### DIFF
--- a/Cli/CliArgumentParser.cs
+++ b/Cli/CliArgumentParser.cs
@@ -1,5 +1,7 @@
 namespace CosmosToSqlAssessment.Cli;
 
+using CosmosToSqlAssessment.Agents;
+
 /// <summary>
 /// Parses raw <c>string[]</c> command-line arguments into a <see cref="CliOptions"/>
 /// instance and emits help / validation messages.
@@ -38,18 +40,68 @@ internal static class CliArgumentParser
                     DisplayHelp(output);
                     return null;
                 case "migration":
-                    // `migration status` subcommand for live progress reporting (#225).
-                    // Additive: leaves all existing flags/commands intact.
-                    if (i + 1 < args.Length && string.Equals(args[i + 1], "status", StringComparison.OrdinalIgnoreCase))
+                    // `migration` subcommands for live monitoring / alerting operations. Additive:
+                    // leaves all existing flags/commands intact. Supported: status (#225),
+                    // generate-alerts (#256), publish-metrics (#257).
                     {
-                        options.MigrationStatus = true;
-                        i++; // consume the "status" sub-token
+                        var sub = i + 1 < args.Length ? args[i + 1] : null;
+                        if (string.Equals(sub, "status", StringComparison.OrdinalIgnoreCase))
+                        {
+                            options.MigrationStatus = true;
+                            i++; // consume the sub-token
+                        }
+                        else if (string.Equals(sub, "generate-alerts", StringComparison.OrdinalIgnoreCase))
+                        {
+                            options.GenerateAlerts = true;
+                            i++;
+                        }
+                        else if (string.Equals(sub, "publish-metrics", StringComparison.OrdinalIgnoreCase))
+                        {
+                            options.PublishMetrics = true;
+                            i++;
+                        }
+                        else
+                        {
+                            output.WriteLine("Unknown command: 'migration'. Did you mean 'migration status', 'migration generate-alerts', or 'migration publish-metrics'?");
+                            DisplayHelp(output);
+                            return null;
+                        }
+                    }
+                    break;
+                case "feedback":
+                    // `feedback record` subcommand to import an anonymized migration outcome (#259).
+                    if (i + 1 < args.Length && string.Equals(args[i + 1], "record", StringComparison.OrdinalIgnoreCase))
+                    {
+                        options.FeedbackRecord = true;
+                        i++; // consume the "record" sub-token
                     }
                     else
                     {
-                        output.WriteLine("Unknown command: 'migration'. Did you mean 'migration status'?");
+                        output.WriteLine("Unknown command: 'feedback'. Did you mean 'feedback record'?");
                         DisplayHelp(output);
                         return null;
+                    }
+                    break;
+                case "--agentic-mode":
+                    // Scheduling mode for the agentic orchestration layer (#248). Restricted to the closed
+                    // set of AgentExecutionMode names; numeric/garbage values are rejected explicitly.
+                    if (i + 1 < args.Length &&
+                        Enum.GetNames<AgentExecutionMode>().Any(n => string.Equals(n, args[i + 1], StringComparison.OrdinalIgnoreCase)))
+                    {
+                        options.AgenticMode = Enum.Parse<AgentExecutionMode>(args[++i], ignoreCase: true);
+                        options.AgenticModeSpecified = true;
+                    }
+                    else
+                    {
+                        output.WriteLine("Invalid value for --agentic-mode: expected one of sequential, parallel, conditional.");
+                        DisplayHelp(output);
+                        return null;
+                    }
+                    break;
+                case "--import-outcome":
+                    if (i + 1 < args.Length)
+                    {
+                        options.ImportOutcomeFile = args[++i];
                     }
                     break;
                 case "--watch":
@@ -183,6 +235,58 @@ internal static class CliArgumentParser
             return false;
         }
 
+        // At most one operational subcommand may be requested per invocation. The parser sets these
+        // independently, so guard against combinations like `migration status migration generate-alerts`
+        // or pairing a subcommand with --test-connection (which would otherwise be silently ignored).
+        var operationalCommands = new (bool Set, string Name)[]
+        {
+            (options.MigrationStatus, "migration status"),
+            (options.GenerateAlerts, "migration generate-alerts"),
+            (options.PublishMetrics, "migration publish-metrics"),
+            (options.FeedbackRecord, "feedback record"),
+            (options.TestConnection, "--test-connection"),
+        };
+        var requested = operationalCommands.Where(c => c.Set).Select(c => c.Name).ToList();
+        if (requested.Count > 1)
+        {
+            output.WriteLine($"❌ Error: Cannot combine the commands: {string.Join(", ", requested)}.");
+            output.WriteLine("   Run one operation at a time.");
+            return false;
+        }
+
+        // --agentic-mode only has an effect on the agentic path; specifying it without --agentic is
+        // almost certainly a mistake (the chosen mode would be silently ignored).
+        if (options.AgenticModeSpecified && !options.Agentic)
+        {
+            output.WriteLine("❌ Error: --agentic-mode requires --agentic.");
+            output.WriteLine("   Add --agentic to run through the multi-agent orchestration layer, or omit --agentic-mode.");
+            return false;
+        }
+
+        // `migration generate-alerts` writes its templates to an explicit output directory.
+        if (options.GenerateAlerts && string.IsNullOrWhiteSpace(options.OutputDirectory))
+        {
+            output.WriteLine("❌ Error: 'migration generate-alerts' requires --output <dir>.");
+            output.WriteLine("   Specify the directory the alert-rule ARM templates should be written to.");
+            return false;
+        }
+
+        // `feedback record` imports a serialized outcome file; the file argument is mandatory and only
+        // meaningful together with the subcommand.
+        if (options.FeedbackRecord && string.IsNullOrWhiteSpace(options.ImportOutcomeFile))
+        {
+            output.WriteLine("❌ Error: 'feedback record' requires --import-outcome <file.json>.");
+            output.WriteLine("   Provide a JSON file holding the anonymized migration outcome to record.");
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.ImportOutcomeFile) && !options.FeedbackRecord)
+        {
+            output.WriteLine("❌ Error: --import-outcome is only valid with the 'feedback record' command.");
+            output.WriteLine("   Use: feedback record --import-outcome <file.json>.");
+            return false;
+        }
+
         return true;
     }
 
@@ -213,6 +317,7 @@ internal static class CliArgumentParser
         output.WriteLine("  --test-connection         Test connectivity to Cosmos DB and Azure Monitor");
         output.WriteLine("  -i, --interactive         Launch interactive wizard mode for guided configuration");
         output.WriteLine("  --agentic                 Run the assessment via the multi-agent orchestration layer (equivalent output)");
+        output.WriteLine("  --agentic-mode <mode>     Agentic scheduling mode: sequential (default), parallel, or conditional (requires --agentic)");
         output.WriteLine("  --enable-feedback         Opt in to anonymized continuous-learning feedback (default: off)");
         output.WriteLine("  --disable-feedback        Explicitly opt out of feedback collection (overrides config)");
         output.WriteLine("  -c, --config <path>       Load configuration from a saved JSON file");
@@ -223,6 +328,13 @@ internal static class CliArgumentParser
         output.WriteLine("  migration status          Report live migration progress (rows migrated, RU consumption, error rate)");
         output.WriteLine("    --watch                 Continuously poll and re-render progress until cancelled");
         output.WriteLine("    --poll-interval <sec>   Polling interval in seconds for --watch (default 10)");
+        output.WriteLine("  migration generate-alerts Generate Azure Monitor alert-rule ARM templates");
+        output.WriteLine("    --output <dir>          Directory the alert-rule templates are written to (required)");
+        output.WriteLine("  migration publish-metrics Stream ADF activity progress as live Azure Monitor custom metrics");
+        output.WriteLine("    --watch                 Continuously poll and publish until cancelled");
+        output.WriteLine("    --poll-interval <sec>   Polling interval in seconds for --watch (default 10)");
+        output.WriteLine("  feedback record           Import an anonymized migration outcome into the local feedback store (opt-in)");
+        output.WriteLine("    --import-outcome <file> JSON file holding the anonymized migration outcome (required)");
         output.WriteLine();
         output.WriteLine("Examples:");
         output.WriteLine("  CosmosToSqlAssessment --all-databases");
@@ -236,6 +348,10 @@ internal static class CliArgumentParser
         output.WriteLine("  CosmosToSqlAssessment --test-connection");
         output.WriteLine("  CosmosToSqlAssessment migration status");
         output.WriteLine("  CosmosToSqlAssessment migration status --watch --poll-interval 5");
+        output.WriteLine("  CosmosToSqlAssessment migration generate-alerts --output C:\\Reports");
+        output.WriteLine("  CosmosToSqlAssessment migration publish-metrics --watch");
+        output.WriteLine("  CosmosToSqlAssessment feedback record --import-outcome outcome.json --enable-feedback");
+        output.WriteLine("  CosmosToSqlAssessment --agentic --agentic-mode parallel --database MyDatabase");
         output.WriteLine();
     }
 }

--- a/Cli/CliOptions.cs
+++ b/Cli/CliOptions.cs
@@ -1,3 +1,5 @@
+using CosmosToSqlAssessment.Agents;
+
 namespace CosmosToSqlAssessment.Cli;
 
 /// <summary>
@@ -18,6 +20,20 @@ internal sealed class CliOptions
     public bool TestConnection { get; set; }
     public bool Interactive { get; set; }
     public bool Agentic { get; set; }
+
+    /// <summary>
+    /// Scheduling mode for the multi-agent orchestration layer (#248), honoured only when
+    /// <see cref="Agentic"/> is set. Defaults to <see cref="AgentExecutionMode.Sequential"/> so the
+    /// single-pass-equivalence guarantee holds out of the box. Set by <c>--agentic-mode</c>.
+    /// </summary>
+    public AgentExecutionMode AgenticMode { get; set; } = AgentExecutionMode.Sequential;
+
+    /// <summary>
+    /// <c>true</c> when <c>--agentic-mode</c> was explicitly supplied. Used to reject specifying a
+    /// mode without also enabling <c>--agentic</c> (which would silently have no effect).
+    /// </summary>
+    public bool AgenticModeSpecified { get; set; }
+
     public bool EnableFeedback { get; set; }
     public bool DisableFeedback { get; set; }
     public string? ConfigFile { get; set; }
@@ -42,4 +58,31 @@ internal sealed class CliOptions
     /// Defaults to 10.
     /// </summary>
     public int PollIntervalSeconds { get; set; } = 10;
+
+    /// <summary>
+    /// When <c>true</c>, the tool runs the additive <c>migration generate-alerts</c> subcommand (#256):
+    /// it writes the Azure Monitor alert-rule ARM templates to <see cref="OutputDirectory"/> instead of
+    /// running an assessment.
+    /// </summary>
+    public bool GenerateAlerts { get; set; }
+
+    /// <summary>
+    /// When <c>true</c>, the tool runs the additive <c>migration publish-metrics</c> subcommand (#257):
+    /// it streams ADF activity progress through the live custom-metric publisher instead of running an
+    /// assessment. Honours <see cref="Watch"/> / <see cref="PollIntervalSeconds"/>.
+    /// </summary>
+    public bool PublishMetrics { get; set; }
+
+    /// <summary>
+    /// When <c>true</c>, the tool runs the additive <c>feedback record</c> subcommand (#259): it imports a
+    /// serialized <see cref="Models.MigrationOutcome"/> from <see cref="ImportOutcomeFile"/> into the local
+    /// feedback store, gated by the existing opt-in consent.
+    /// </summary>
+    public bool FeedbackRecord { get; set; }
+
+    /// <summary>
+    /// Path to a JSON file holding a serialized anonymized <see cref="Models.MigrationOutcome"/> to import
+    /// via <c>feedback record --import-outcome</c> (#259).
+    /// </summary>
+    public string? ImportOutcomeFile { get; set; }
 }

--- a/Models/UserInputs.cs
+++ b/Models/UserInputs.cs
@@ -1,5 +1,7 @@
 namespace CosmosToSqlAssessment.Models;
 
+using CosmosToSqlAssessment.Agents;
+
 /// <summary>
 /// User inputs derived from a combination of command-line arguments and
 /// configuration, materialized by <see cref="Orchestration.AssessmentOrchestrator"/>
@@ -40,6 +42,14 @@ public class UserInputs
     /// assessment is equivalent; only the execution path differs.
     /// </summary>
     public bool UseAgentic { get; set; }
+
+    /// <summary>
+    /// Scheduling mode for the multi-agent orchestration layer (#248), honoured only when
+    /// <see cref="UseAgentic"/> is <see langword="true"/>. Defaults to
+    /// <see cref="AgentExecutionMode.Sequential"/> so agentic output stays equivalent to single-pass
+    /// out of the box.
+    /// </summary>
+    public AgentExecutionMode AgenticMode { get; set; } = AgentExecutionMode.Sequential;
 }
 
 /// <summary>

--- a/Orchestration/AssessmentOrchestrator.cs
+++ b/Orchestration/AssessmentOrchestrator.cs
@@ -85,6 +85,12 @@ internal sealed class AssessmentOrchestrator
             return await RunGenerateAlertsAsync(options, cancellationToken);
         }
 
+        if (options.PublishMetrics)
+        {
+            _logger.LogInformation("Publishing live migration progress metrics");
+            return await RunPublishMetricsAsync(options, cancellationToken);
+        }
+
         if (options.TestConnection)
         {
             _logger.LogInformation("Running connection test");
@@ -1226,6 +1232,91 @@ internal sealed class AssessmentOrchestrator
         {
             Console.WriteLine($"❌ Alert-rule template generation failed: {ex.Message}");
             _logger.LogError(ex, "Alert-rule template generation failed for output directory {OutputDirectory}", outputDirectory);
+            return 1;
+        }
+    }
+
+    /// <summary>
+    /// Additive <c>migration publish-metrics</c> subcommand (#257): reads ADF activity progress through
+    /// <see cref="IMigrationStatusSource"/> and streams it through <see cref="MigrationMonitoringService"/>
+    /// so the configured <see cref="IMigrationMetricPublisher"/> emits the live custom metrics
+    /// (rows migrated, RU consumed, error count/rate). Honours <c>options.Watch</c> /
+    /// <c>options.PollIntervalSeconds</c> and short-circuits the full assessment.
+    /// </summary>
+    /// <remarks>
+    /// No-op safe: metric publishing is off by default (<c>AzureMonitor:Metrics:Enabled = false</c>). When
+    /// disabled or misconfigured (missing <c>Region</c>/<c>ResourceId</c>) the command prints a clear
+    /// message and returns 0 without streaming. When enabled but no telemetry source is configured
+    /// (e.g. <c>AzureMonitor:WorkspaceId</c> unset) the source yields nothing and the command reports that
+    /// no samples were observed. All no-op paths return 0.
+    /// </remarks>
+    /// <param name="options">Parsed CLI options; <c>Watch</c>/<c>PollIntervalSeconds</c> drive the read.</param>
+    /// <param name="cancellationToken">Token that stops the read/publish loop.</param>
+    /// <returns>0 on success or any no-op path; 1 only on an unexpected streaming failure.</returns>
+    private async Task<int> RunPublishMetricsAsync(CliOptions options, CancellationToken cancellationToken)
+    {
+        var metricOptions = _services.GetRequiredService<AzureMonitorMetricOptions>();
+
+        Console.WriteLine();
+        Console.WriteLine("📡 Publishing live migration progress metrics...");
+
+        if (!metricOptions.Enabled)
+        {
+            Console.WriteLine("ℹ️  Metric publishing is disabled (AzureMonitor:Metrics:Enabled = false). Nothing to publish.");
+            Console.WriteLine("   Set AzureMonitor:Metrics:Enabled, Region, and ResourceId to publish custom metrics.");
+            _logger.LogInformation("publish-metrics requested but AzureMonitor:Metrics:Enabled is false; no-op");
+            return 0;
+        }
+
+        if (string.IsNullOrWhiteSpace(metricOptions.Region) || string.IsNullOrWhiteSpace(metricOptions.ResourceId))
+        {
+            Console.WriteLine("⚠️  Metric publishing is enabled but misconfigured: AzureMonitor:Metrics:Region and ResourceId are both required.");
+            _logger.LogWarning("publish-metrics enabled but Region/ResourceId missing; no-op");
+            return 0;
+        }
+
+        var source = _services.GetRequiredService<IMigrationStatusSource>();
+        var monitor = _services.GetRequiredService<MigrationMonitoringService>();
+        var reportOptions = new MigrationStatusReportOptions
+        {
+            Watch = options.Watch,
+            PollIntervalSeconds = options.PollIntervalSeconds,
+        };
+
+        try
+        {
+            var publishedSamples = 0;
+            var samples = source.ReadSamplesAsync(reportOptions, cancellationToken);
+            await foreach (var snapshot in monitor.MonitorAsync(samples, cancellationToken).WithCancellation(cancellationToken))
+            {
+                publishedSamples++;
+                Console.WriteLine(
+                    $"   • {snapshot.Sample.PipelineName}/{snapshot.Sample.ActivityName} " +
+                    $"rows={snapshot.CumulativeRowsMigrated} RU={snapshot.CumulativeRequestUnits:F0} " +
+                    $"errors={snapshot.CumulativeErrorCount} errorRate={snapshot.ErrorRate:P1}");
+            }
+
+            if (publishedSamples == 0)
+            {
+                Console.WriteLine("ℹ️  No migration progress samples were observed (no telemetry source configured, e.g. AzureMonitor:WorkspaceId is unset).");
+                _logger.LogInformation("publish-metrics enabled but no samples observed; nothing published");
+            }
+            else
+            {
+                Console.WriteLine($"✅ Published metrics for {publishedSamples} progress sample(s).");
+                _logger.LogInformation("publish-metrics streamed {SampleCount} sample(s)", publishedSamples);
+            }
+
+            return 0;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"❌ Publishing migration metrics failed: {ex.Message}");
+            _logger.LogError(ex, "publish-metrics streaming failed");
             return 1;
         }
     }

--- a/Orchestration/AssessmentOrchestrator.cs
+++ b/Orchestration/AssessmentOrchestrator.cs
@@ -79,6 +79,12 @@ internal sealed class AssessmentOrchestrator
             return await RunMigrationStatusAsync(options, cancellationToken);
         }
 
+        if (options.GenerateAlerts)
+        {
+            _logger.LogInformation("Generating Azure Monitor alert-rule templates");
+            return await RunGenerateAlertsAsync(options, cancellationToken);
+        }
+
         if (options.TestConnection)
         {
             _logger.LogInformation("Running connection test");
@@ -1168,6 +1174,60 @@ internal sealed class AssessmentOrchestrator
         };
 
         return await statusService.RunAsync(reportOptions, Console.Out, cancellationToken);
+    }
+
+    /// <summary>
+    /// Additive <c>migration generate-alerts</c> subcommand (#256): writes the Azure Monitor alert-rule
+    /// ARM templates (and their README) to <c>options.OutputDirectory</c> via
+    /// <see cref="AlertRuleTemplateGenerationService"/>, then prints the generated file paths and any
+    /// non-fatal warnings. This is pure local file I/O — it performs no Azure calls — and short-circuits
+    /// the full assessment.
+    /// </summary>
+    /// <param name="options">Parsed CLI options; <c>OutputDirectory</c> is the (validated) target root.</param>
+    /// <param name="cancellationToken">Token to cancel the file writes.</param>
+    /// <returns>0 on success; 1 if generation failed.</returns>
+    private async Task<int> RunGenerateAlertsAsync(CliOptions options, CancellationToken cancellationToken)
+    {
+        var outputDirectory = options.OutputDirectory!;
+        var generator = _services.GetRequiredService<AlertRuleTemplateGenerationService>();
+
+        Console.WriteLine();
+        Console.WriteLine("🔔 Generating Azure Monitor alert-rule ARM templates...");
+
+        try
+        {
+            var result = await generator.GenerateAsync(outputDirectory, cancellationToken);
+
+            Console.WriteLine("✅ Alert-rule templates generated:");
+            Console.WriteLine($"   • {result.MetricAlertsTemplatePath}");
+            Console.WriteLine($"   • {result.StalledPipelineTemplatePath}");
+            Console.WriteLine($"   • {result.ReadmePath}");
+
+            if (result.Warnings.Count > 0)
+            {
+                Console.WriteLine();
+                Console.WriteLine("⚠️ Warnings:");
+                foreach (var warning in result.Warnings)
+                {
+                    Console.WriteLine($"   • {warning}");
+                }
+            }
+
+            _logger.LogInformation(
+                "Alert-rule templates generated under {OutputDirectory} ({WarningCount} warning(s))",
+                outputDirectory, result.Warnings.Count);
+            return 0;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"❌ Alert-rule template generation failed: {ex.Message}");
+            _logger.LogError(ex, "Alert-rule template generation failed for output directory {OutputDirectory}", outputDirectory);
+            return 1;
+        }
     }
 
     /// <summary>

--- a/Orchestration/AssessmentOrchestrator.cs
+++ b/Orchestration/AssessmentOrchestrator.cs
@@ -2,6 +2,7 @@ using Azure;
 using Azure.Identity;
 using Azure.Monitor.Query;
 using Azure.Monitor.Query.Models;
+using System.Text.Json;
 using CosmosToSqlAssessment.Agents;
 using CosmosToSqlAssessment.Cli;
 using CosmosToSqlAssessment.DependencyInjection;
@@ -89,6 +90,12 @@ internal sealed class AssessmentOrchestrator
         {
             _logger.LogInformation("Publishing live migration progress metrics");
             return await RunPublishMetricsAsync(options, cancellationToken);
+        }
+
+        if (options.FeedbackRecord)
+        {
+            _logger.LogInformation("Recording a migration outcome into the local feedback store");
+            return await RunFeedbackRecordAsync(options, cancellationToken);
         }
 
         if (options.TestConnection)
@@ -1319,6 +1326,73 @@ internal sealed class AssessmentOrchestrator
             _logger.LogError(ex, "publish-metrics streaming failed");
             return 1;
         }
+    }
+
+    /// <summary>
+    /// Additive <c>feedback record</c> subcommand (#259): imports an anonymized, aggregate
+    /// <see cref="MigrationOutcome"/> from <c>options.ImportOutcomeFile</c> (JSON) and records it into the
+    /// local feedback store via <see cref="FeedbackCollectionService.RecordOutcomeAsync"/>. Recording is
+    /// gated by the <b>existing opt-in consent</b> (default OFF) and reuses the same consent precedence as
+    /// the assessment flow — no new data categories and no PII. Short-circuits the full assessment.
+    /// </summary>
+    /// <remarks>
+    /// When consent is denied the call is a legitimate no-op: nothing is persisted and the command returns
+    /// 0 after surfacing the consent status. A missing/unreadable/malformed file (or a JSON document that
+    /// deserializes to <see langword="null"/>) is a user error and returns 1.
+    /// </remarks>
+    /// <param name="options">Parsed CLI options; <c>ImportOutcomeFile</c> is the (validated) JSON path.</param>
+    /// <param name="cancellationToken">Token to observe for cancellation.</param>
+    /// <returns>0 when the outcome was recorded or consent was (legitimately) denied; 1 on a file/parse error.</returns>
+    private async Task<int> RunFeedbackRecordAsync(CliOptions options, CancellationToken cancellationToken)
+    {
+        var path = options.ImportOutcomeFile!;
+
+        Console.WriteLine();
+        Console.WriteLine($"📝 Recording migration outcome from {path}...");
+
+        MigrationOutcome? outcome;
+        try
+        {
+            var json = await File.ReadAllTextAsync(path, cancellationToken);
+            outcome = JsonSerializer.Deserialize<MigrationOutcome>(
+                json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException or ArgumentException)
+        {
+            Console.WriteLine($"❌ Could not read the outcome file: {ex.Message}");
+            _logger.LogError(ex, "Failed to read or parse outcome file {Path}", path);
+            return 1;
+        }
+
+        if (outcome is null)
+        {
+            Console.WriteLine("❌ The outcome file did not contain a valid migration outcome (parsed to null).");
+            _logger.LogError("Outcome file {Path} deserialized to null", path);
+            return 1;
+        }
+
+        var feedback = _services.GetRequiredService<FeedbackCollectionService>();
+        bool? cliOverride = options.EnableFeedback ? true : options.DisableFeedback ? false : (bool?)null;
+
+        var recorded = await feedback.RecordOutcomeAsync(outcome, cliOverride, cancellationToken);
+        if (recorded)
+        {
+            Console.WriteLine($"✅ Recorded the migration outcome to {feedback.StoreLocation}.");
+            _logger.LogInformation("Recorded an imported migration outcome to {Location}", feedback.StoreLocation);
+            return 0;
+        }
+
+        // Consent denied — a legitimate no-op, not an error. Surface why so the user can opt in.
+        var consent = feedback.ResolveConsent(cliOverride);
+        feedback.WriteConsentNotice(Console.Out, consent);
+        Console.WriteLine("ℹ️  Outcome not recorded: continuous-learning feedback is opt-in and currently disabled.");
+        Console.WriteLine("   Re-run with --enable-feedback (or set FeedbackLoop:Enabled=true) to record it.");
+        _logger.LogInformation("feedback record skipped: consent denied (source {Source})", consent.Source);
+        return 0;
     }
 
     /// <summary>

--- a/Orchestration/AssessmentOrchestrator.cs
+++ b/Orchestration/AssessmentOrchestrator.cs
@@ -346,7 +346,7 @@ internal sealed class AssessmentOrchestrator
         if (userInputs.UseAgentic)
         {
             return await RunDatabaseAssessmentAgenticAsync(
-                activeServiceProvider, assessmentResult, databaseName, cancellationToken);
+                activeServiceProvider, assessmentResult, databaseName, userInputs.AgenticMode, cancellationToken);
         }
 
         // Step 1: Cosmos DB Analysis
@@ -469,9 +469,10 @@ internal sealed class AssessmentOrchestrator
         IServiceProvider activeServiceProvider,
         AssessmentResult assessmentResult,
         string databaseName,
+        AgentExecutionMode mode,
         CancellationToken cancellationToken)
     {
-        Console.WriteLine("🤖 Agentic mode: coordinating specialist agents (Cosmos → SQL → data quality → Data Factory → validation)...");
+        Console.WriteLine($"🤖 Agentic mode ({mode.ToString().ToLowerInvariant()}): coordinating specialist agents (Cosmos → SQL → data quality → Data Factory → validation)...");
 
         using var scope = activeServiceProvider.CreateScope();
         var orchestrator = scope.ServiceProvider.GetRequiredService<AgentOrchestrator>();
@@ -479,7 +480,7 @@ internal sealed class AssessmentOrchestrator
         var run = await orchestrator.RunAsync(
             databaseName,
             assessmentResult.CosmosAccountName,
-            new AgentOrchestrationOptions { Mode = AgentExecutionMode.Sequential },
+            new AgentOrchestrationOptions { Mode = mode },
             cancellationToken);
 
         var projected = run.AssessmentResult;
@@ -809,6 +810,7 @@ internal sealed class AssessmentOrchestrator
         try
         {
             inputs.UseAgentic = options.Agentic;
+            inputs.AgenticMode = options.AgenticMode;
 
             inputs.AccountEndpoint = !string.IsNullOrEmpty(options.AccountEndpoint)
                 ? options.AccountEndpoint

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -465,7 +465,7 @@ Producers are scheduled by mode; the validator always runs **last** (see invaria
 role is *completed* once its agent records any terminal result, and a producer becomes *ready* when every
 role in its `Dependencies` is completed.
 
-#### Sequential (default, and what `--agentic` uses)
+#### Sequential (default, and what `--agentic` uses by default)
 
 Runs the highest-priority **ready** producer one at a time, reproducing the exact single-pass order.
 
@@ -574,8 +574,9 @@ incidental log order. (The orchestrator snapshots the result and message lists s
 Agentic mode is held to **output equivalence** with single-pass mode by regression tests
 (`tests/CosmosToSqlAssessment.Tests/EndToEnd/AgentEquivalenceTests.cs`): driving the real services (against
 the mock Azure SDKs) through the `AgentOrchestrator` produces an `AssessmentResult` that is field-for-field
-equivalent to the legacy `E2EFixture.RunAssessmentAsync` baseline — in **both Sequential and Parallel**
-modes — excluding only non-deterministic members (generated IDs and timestamps). Additional fake-agent
+equivalent to the legacy `E2EFixture.RunAssessmentAsync` baseline — in **Sequential, Parallel, and
+Conditional** modes (the latter for a fully-successful run, where no agent is skipped) — excluding only
+non-deterministic members (generated IDs and timestamps). Additional fake-agent
 scheduling tests (`Agents/AgentOrchestratorTests.cs`) cover ordering, parallel waves, failure isolation,
 conditional skip, timeout, and graph validation.
 
@@ -585,13 +586,20 @@ conditional skip, timeout, and graph validation.
 # Run the assessment through the multi-agent orchestration layer (equivalent output)
 CosmosToSqlAssessment --agentic --database MyDatabase
 
+# Choose the scheduling mode explicitly (default is sequential)
+CosmosToSqlAssessment --agentic --agentic-mode parallel --database MyDatabase
+CosmosToSqlAssessment --agentic --agentic-mode conditional --database MyDatabase
+
 # Works with the usual flags
 CosmosToSqlAssessment --agentic --all-databases --output C:\Reports
 ```
 
 When `--agentic` is set, `AssessmentOrchestrator` computes each database's assessment through the
-`AgentOrchestrator` (a **child DI scope per database**, explicit **Sequential** mode) and then feeds the same
-unchanged report / SQL-project generation. **Fatal semantics match single-pass** and are expressed as an
+`AgentOrchestrator` (a **child DI scope per database**) using the scheduling mode selected by
+`--agentic-mode` — `sequential` (default), `parallel`, or `conditional` — and then feeds the same
+unchanged report / SQL-project generation. `--agentic-mode` only takes effect together with `--agentic`
+(specifying it alone is rejected), and the default remains **Sequential** so agentic output stays
+equivalent to single-pass out of the box. **Fatal semantics match single-pass** and are expressed as an
 invariant: the run fails only when it is **incomplete** (`ValidationReport.IsComplete == false`), i.e. a
 *required* output is missing. A consistency-only finding (e.g. an unmapped container) and an absent/failed
 optional data-quality analysis are **non-fatal**, exactly as in single-pass.

--- a/docs/feedback-loop.md
+++ b/docs/feedback-loop.md
@@ -134,6 +134,28 @@ Pick whichever fits your workflow:
   export COSMOS2SQL_FEEDBACK_OPTIN=1
   ```
 
+## Recording a migration outcome (`feedback record`)
+
+Opting in only *permits* collection — to actually populate the local store with how a migration
+turned out, import an anonymized outcome with the additive subcommand:
+
+```bash
+CosmosToSqlAssessment feedback record --import-outcome outcome.json --enable-feedback
+```
+
+- `--import-outcome <file.json>` points at a JSON document that deserializes to a
+  `MigrationOutcome` (the same anonymized, aggregate schema described above — no names, endpoints,
+  credentials, or PII). Property names are matched case-insensitively.
+- The command **reuses the existing opt-in consent** (it does not introduce a new data category).
+  With consent granted (via `--enable-feedback`, `FeedbackLoop:Enabled=true`, or the opt-in env
+  var) the outcome is appended to the store at the location shown below, and — if a telemetry
+  endpoint is configured — a coarsened summary is sent too.
+- With consent **denied** (the default), the command is a **no-op**: it prints the consent status,
+  records nothing, and exits successfully (`0`). A missing or malformed file exits `1`.
+
+Recorded outcomes are read back automatically the next time an assessment runs, so the
+recommendation refinement (see below) can attribute results to *N prior similar migrations*.
+
 ## How to opt **out**
 
 Opt‑out always wins. Any of these disables collection:
@@ -216,6 +238,7 @@ how many prior migrations informed it and how confident the tool is.
 | --- | --- | --- | --- |
 | `--enable-feedback` | CLI flag | — | Opt in for this run |
 | `--disable-feedback` | CLI flag | — | Opt out for this run |
+| `feedback record --import-outcome <file>` | CLI subcommand | — | Import an anonymized outcome into the store (consent‑gated; no‑op when denied) |
 | `FeedbackLoop:Enabled` | config (bool?) | unset → off | Persistent opt in/out |
 | `FeedbackLoop:StorePath` | config (string) | per‑user path | Override local store location |
 | `FeedbackLoop:TelemetryEndpoint` | config (string) | unset | If set, also POST a coarsened summary |

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -146,10 +146,20 @@ runs never call Azure. To turn it on, set `Enabled`, `Region`, and `ResourceId`.
 misconfigured or disabled publisher degrades to a no-op rather than failing the run; a
 publish failure is logged and swallowed so it never aborts the migration stream.
 
-## Alert rule ARM templates (#224)
+## Alert rule ARM templates (#224, #256)
 
 `AlertRuleTemplateGenerationService.GenerateAsync(outputDirectory)` writes deployable ARM
-templates (and a README) under `<outputDirectory>/Monitoring/AlertRules/`:
+templates (and a README) under `<outputDirectory>/Monitoring/AlertRules/`. Run it from the CLI
+with the additive subcommand:
+
+```bash
+CosmosToSqlAssessment migration generate-alerts --output C:\Reports
+```
+
+The command short-circuits the full assessment (no Cosmos endpoint required), writes the files
+below, and prints each generated path plus any non-fatal warnings (e.g. a Request-Units alert
+enabled with a non-positive threshold). It performs **no Azure calls** — generation is pure
+local file I/O:
 
 | File | Resource | Purpose |
 | --- | --- | --- |

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -146,6 +146,31 @@ runs never call Azure. To turn it on, set `Enabled`, `Region`, and `ResourceId`.
 misconfigured or disabled publisher degrades to a no-op rather than failing the run; a
 publish failure is logged and swallowed so it never aborts the migration stream.
 
+### Driving a live publish loop: `migration publish-metrics` (#257)
+
+Stream ADF activity progress through the publisher from the CLI with the additive subcommand:
+
+```bash
+# One-shot publish of the currently-known progress samples
+CosmosToSqlAssessment migration publish-metrics
+
+# Keep polling and publishing until cancelled (Ctrl+C)
+CosmosToSqlAssessment migration publish-metrics --watch --poll-interval 15
+```
+
+The command reuses the same `IMigrationStatusSource` (ADF `ADFActivityRun` telemetry) as
+`migration status`, but pipes the samples through `MigrationMonitoringService` so the configured
+`IMigrationMetricPublisher` emits `MigrationRowsMigrated` / `MigrationRequestUnitsConsumed` /
+`MigrationErrorCount` / `MigrationErrorRate`. It short-circuits the full assessment and is
+**no-op safe**:
+
+- **Disabled** (`AzureMonitor:Metrics:Enabled = false`, the default): prints a message and
+  exits 0 without streaming.
+- **Enabled but misconfigured** (missing `Region`/`ResourceId`): prints the misconfiguration
+  and exits 0.
+- **Enabled but no telemetry source** (e.g. `AzureMonitor:WorkspaceId` unset): the source
+  yields nothing, so it reports that no samples were observed and exits 0.
+
 ## Alert rule ARM templates (#224, #256)
 
 `AlertRuleTemplateGenerationService.GenerateAsync(outputDirectory)` writes deployable ARM

--- a/tests/CosmosToSqlAssessment.Tests/Cli/CliArgumentParserCapabilityTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Cli/CliArgumentParserCapabilityTests.cs
@@ -1,0 +1,247 @@
+using CosmosToSqlAssessment.Agents;
+using CosmosToSqlAssessment.Cli;
+
+namespace CosmosToSqlAssessment.Tests.Cli;
+
+/// <summary>
+/// Parser/validation tests for the additive CLI capabilities wired in by #248 (--agentic-mode),
+/// #256 (migration generate-alerts), #257 (migration publish-metrics) and #259 (feedback record).
+/// These complement the existing <see cref="CliArgumentParserMigrationStatusTests"/> coverage and assert
+/// the new flags/subcommands are parsed and validated without disturbing the pre-existing surface.
+/// </summary>
+public class CliArgumentParserCapabilityTests
+{
+    // ---- #248 --agentic-mode --------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("sequential", AgentExecutionMode.Sequential)]
+    [InlineData("parallel", AgentExecutionMode.Parallel)]
+    [InlineData("conditional", AgentExecutionMode.Conditional)]
+    [InlineData("CONDITIONAL", AgentExecutionMode.Conditional)]
+    public void Parse_AgenticMode_SetsModeAndSpecifiedFlag(string value, AgentExecutionMode expected)
+    {
+        var output = new StringWriter();
+
+        var options = CliArgumentParser.Parse(new[] { "--agentic", "--agentic-mode", value }, output);
+
+        options.Should().NotBeNull();
+        options!.Agentic.Should().BeTrue();
+        options.AgenticMode.Should().Be(expected);
+        options.AgenticModeSpecified.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Parse_AgenticMode_DefaultsToSequentialWhenUnset()
+    {
+        var output = new StringWriter();
+
+        var options = CliArgumentParser.Parse(new[] { "--agentic" }, output);
+
+        options.Should().NotBeNull();
+        options!.AgenticMode.Should().Be(AgentExecutionMode.Sequential);
+        options.AgenticModeSpecified.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parse_AgenticMode_RejectsNumericValue()
+    {
+        var output = new StringWriter();
+
+        var options = CliArgumentParser.Parse(new[] { "--agentic", "--agentic-mode", "2" }, output);
+
+        options.Should().BeNull();
+        output.ToString().Should().Contain("Invalid value for --agentic-mode");
+    }
+
+    [Fact]
+    public void Parse_AgenticMode_RejectsUnknownValue()
+    {
+        var output = new StringWriter();
+
+        var options = CliArgumentParser.Parse(new[] { "--agentic", "--agentic-mode", "turbo" }, output);
+
+        options.Should().BeNull();
+        output.ToString().Should().Contain("Invalid value for --agentic-mode");
+    }
+
+    [Fact]
+    public void Validate_AgenticModeWithoutAgentic_Fails()
+    {
+        var output = new StringWriter();
+        var options = CliArgumentParser.Parse(new[] { "--agentic-mode", "parallel" }, new StringWriter());
+        options.Should().NotBeNull();
+
+        var ok = CliArgumentParser.Validate(options!, output);
+
+        ok.Should().BeFalse();
+        output.ToString().Should().Contain("--agentic-mode requires --agentic");
+    }
+
+    [Fact]
+    public void Validate_AgenticModeWithAgentic_Succeeds()
+    {
+        var output = new StringWriter();
+        var options = CliArgumentParser.Parse(new[] { "--agentic", "--agentic-mode", "conditional" }, new StringWriter());
+        options.Should().NotBeNull();
+
+        var ok = CliArgumentParser.Validate(options!, output);
+
+        ok.Should().BeTrue();
+    }
+
+    // ---- #256 migration generate-alerts ---------------------------------------------------------
+
+    [Fact]
+    public void Parse_GenerateAlerts_SetsFlag()
+    {
+        var output = new StringWriter();
+
+        var options = CliArgumentParser.Parse(
+            new[] { "migration", "generate-alerts", "--output", "C:\\Reports" }, output);
+
+        options.Should().NotBeNull();
+        options!.GenerateAlerts.Should().BeTrue();
+        options.OutputDirectory.Should().Be("C:\\Reports");
+        output.ToString().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_GenerateAlertsWithoutOutput_Fails()
+    {
+        var output = new StringWriter();
+        var options = CliArgumentParser.Parse(new[] { "migration", "generate-alerts" }, new StringWriter());
+        options.Should().NotBeNull();
+
+        var ok = CliArgumentParser.Validate(options!, output);
+
+        ok.Should().BeFalse();
+        output.ToString().Should().Contain("'migration generate-alerts' requires --output");
+    }
+
+    // ---- #257 migration publish-metrics ---------------------------------------------------------
+
+    [Fact]
+    public void Parse_PublishMetrics_SetsFlag()
+    {
+        var output = new StringWriter();
+
+        var options = CliArgumentParser.Parse(new[] { "migration", "publish-metrics" }, output);
+
+        options.Should().NotBeNull();
+        options!.PublishMetrics.Should().BeTrue();
+        output.ToString().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_PublishMetricsWithWatchAndPollInterval_SetsBoth()
+    {
+        var output = new StringWriter();
+
+        var options = CliArgumentParser.Parse(
+            new[] { "migration", "publish-metrics", "--watch", "--poll-interval", "7" }, output);
+
+        options.Should().NotBeNull();
+        options!.PublishMetrics.Should().BeTrue();
+        options.Watch.Should().BeTrue();
+        options.PollIntervalSeconds.Should().Be(7);
+    }
+
+    // ---- #259 feedback record -------------------------------------------------------------------
+
+    [Fact]
+    public void Parse_FeedbackRecord_SetsFlagAndFile()
+    {
+        var output = new StringWriter();
+
+        var options = CliArgumentParser.Parse(
+            new[] { "feedback", "record", "--import-outcome", "outcome.json" }, output);
+
+        options.Should().NotBeNull();
+        options!.FeedbackRecord.Should().BeTrue();
+        options.ImportOutcomeFile.Should().Be("outcome.json");
+        output.ToString().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_FeedbackWithoutRecord_ReturnsNullAndWritesHelp()
+    {
+        var output = new StringWriter();
+
+        var options = CliArgumentParser.Parse(new[] { "feedback" }, output);
+
+        options.Should().BeNull();
+        output.ToString().Should().Contain("Did you mean 'feedback record'");
+    }
+
+    [Fact]
+    public void Validate_FeedbackRecordWithoutFile_Fails()
+    {
+        var output = new StringWriter();
+        var options = CliArgumentParser.Parse(new[] { "feedback", "record" }, new StringWriter());
+        options.Should().NotBeNull();
+
+        var ok = CliArgumentParser.Validate(options!, output);
+
+        ok.Should().BeFalse();
+        output.ToString().Should().Contain("'feedback record' requires --import-outcome");
+    }
+
+    [Fact]
+    public void Validate_ImportOutcomeWithoutFeedbackRecord_Fails()
+    {
+        var output = new StringWriter();
+        var options = CliArgumentParser.Parse(new[] { "--import-outcome", "outcome.json" }, new StringWriter());
+        options.Should().NotBeNull();
+
+        var ok = CliArgumentParser.Validate(options!, output);
+
+        ok.Should().BeFalse();
+        output.ToString().Should().Contain("--import-outcome is only valid with the 'feedback record' command");
+    }
+
+    [Fact]
+    public void Validate_FeedbackRecordWithFile_Succeeds()
+    {
+        var output = new StringWriter();
+        var options = CliArgumentParser.Parse(
+            new[] { "feedback", "record", "--import-outcome", "outcome.json" }, new StringWriter());
+        options.Should().NotBeNull();
+
+        var ok = CliArgumentParser.Validate(options!, output);
+
+        ok.Should().BeTrue();
+    }
+
+    // ---- subcommand exclusivity -----------------------------------------------------------------
+
+    [Fact]
+    public void Validate_CombiningTwoSubcommands_Fails()
+    {
+        var output = new StringWriter();
+        var options = CliArgumentParser.Parse(
+            new[] { "migration", "status", "--test-connection" }, new StringWriter());
+        options.Should().NotBeNull();
+
+        var ok = CliArgumentParser.Validate(options!, output);
+
+        ok.Should().BeFalse();
+        output.ToString().Should().Contain("Cannot combine the commands");
+    }
+
+    // ---- help text ------------------------------------------------------------------------------
+
+    [Fact]
+    public void DisplayHelp_IncludesNewCommandsAndFlags()
+    {
+        var output = new StringWriter();
+
+        CliArgumentParser.DisplayHelp(output);
+
+        var text = output.ToString();
+        text.Should().Contain("--agentic-mode");
+        text.Should().Contain("migration generate-alerts");
+        text.Should().Contain("migration publish-metrics");
+        text.Should().Contain("feedback record");
+        text.Should().Contain("--import-outcome");
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/EndToEnd/AgentEquivalenceTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/EndToEnd/AgentEquivalenceTests.cs
@@ -81,6 +81,29 @@ public class AgentEquivalenceTests
     }
 
     [Fact]
+    public async Task Agentic_conditional_mode_is_equivalent_to_single_pass_for_a_fully_successful_run()
+    {
+        // #248: Conditional mode only diverges from Sequential/Parallel when a dependency FAILS (it then
+        // skips the dependents). For a fully-successful run every dependency succeeds, so no agent is
+        // skipped and the produced assessment must be identical to the single-pass baseline.
+        using var baselineFixture = BuildFixture();
+        using var agenticFixture = BuildFixture();
+
+        var baseline = await baselineFixture.RunAssessmentAsync("AppDb");
+
+        var run = await OrchestratorFor(agenticFixture).RunAsync(
+            "AppDb", "test-account",
+            new AgentOrchestrationOptions { Mode = AgentExecutionMode.Conditional });
+
+        run.AgentResults.Should().OnlyContain(r => r.Status == AgentRunStatus.Succeeded);
+        run.AssessmentResult.Should().BeEquivalentTo(baseline, opts => opts.Excluding(m =>
+            m.Name == "AssessmentId" ||
+            m.Name == "AssessmentDate" ||
+            m.Name == "AnalysisDate" ||
+            m.Name == "IssueId"));
+    }
+
+    [Fact]
     public async Task Complete_run_is_acceptable_and_maps_every_container()
     {
         using var fixture = BuildFixture();

--- a/tests/CosmosToSqlAssessment.Tests/Orchestration/AgenticModeWiringTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Orchestration/AgenticModeWiringTests.cs
@@ -1,0 +1,122 @@
+using CosmosToSqlAssessment.Agents;
+using CosmosToSqlAssessment.Orchestration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CosmosToSqlAssessment.Tests.Orchestration;
+
+/// <summary>
+/// Seam test for #248 proving that <see cref="UserInputs.AgenticMode"/> is actually threaded through
+/// <see cref="AssessmentOrchestrator"/> into the <see cref="AgentOrchestrator"/>'s
+/// <see cref="AgentOrchestrationOptions.Mode"/> — something the parser tests and the end-to-end
+/// equivalence tests (which call <see cref="AgentOrchestrator.RunAsync"/> directly) cannot demonstrate.
+///
+/// <para>
+/// The seam is observed via a behavioural difference: the Cosmos producer fails, so in
+/// <see cref="AgentExecutionMode.Conditional"/> the downstream SQL producer is skipped (never invoked),
+/// whereas in <see cref="AgentExecutionMode.Sequential"/> it is invoked regardless. Both runs end up
+/// incomplete (the failed Cosmos analysis means a required output is missing), so the agentic path throws
+/// <see cref="InvalidOperationException"/> in both cases — we catch that and assert on the recorded
+/// invocation flag.
+/// </para>
+/// </summary>
+public class AgenticModeWiringTests
+{
+    private sealed class RecordingAgent : AssessmentAgentBase
+    {
+        private readonly Action? _body;
+
+        public RecordingAgent(
+            string name,
+            AgentRole role,
+            IReadOnlyCollection<AgentRole> dependencies,
+            Action? body = null)
+        {
+            Name = name;
+            Role = role;
+            Dependencies = dependencies;
+            _body = body;
+        }
+
+        public override string Name { get; }
+        public override AgentRole Role { get; }
+        public override IReadOnlyCollection<AgentRole> Dependencies { get; }
+
+        public bool WasInvoked { get; private set; }
+
+        protected override Task ExecuteAsync(ISharedAssessmentContext context, CancellationToken cancellationToken)
+        {
+            WasInvoked = true;
+            _body?.Invoke();
+            return Task.CompletedTask;
+        }
+    }
+
+    private static (AssessmentOrchestrator Orchestrator, IServiceProvider Provider, RecordingAgent Sql) BuildHarness()
+    {
+        var sql = new RecordingAgent("Sql", AgentRole.SqlPlanning, new[] { AgentRole.CosmosAnalysis });
+        var agents = new List<IAssessmentAgent>
+        {
+            // Cosmos fails: its downstream dependents become skip candidates in Conditional mode.
+            new RecordingAgent("Cosmos", AgentRole.CosmosAnalysis, Array.Empty<AgentRole>(),
+                () => throw new InvalidOperationException("cosmos boom")),
+            sql,
+            new RecordingAgent("DataFactory", AgentRole.DataFactoryEstimation,
+                new[] { AgentRole.CosmosAnalysis, AgentRole.SqlPlanning }),
+            new RecordingAgent("Validator", AgentRole.Validation,
+                new[] { AgentRole.CosmosAnalysis, AgentRole.SqlPlanning })
+        };
+
+        var agentOrchestrator = new AgentOrchestrator(agents, NullLogger<AgentOrchestrator>.Instance);
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+
+        var provider = new ServiceCollection()
+            .AddSingleton(agentOrchestrator)
+            .BuildServiceProvider();
+
+        var orchestrator = new AssessmentOrchestrator(
+            provider, configuration, NullLogger<AssessmentOrchestrator>.Instance);
+
+        return (orchestrator, provider, sql);
+    }
+
+    [Fact]
+    public async Task Conditional_mode_skips_the_sql_agent_when_cosmos_fails()
+    {
+        var (orchestrator, provider, sql) = BuildHarness();
+        var userInputs = new UserInputs
+        {
+            AccountEndpoint = "https://fake.documents.azure.com:443/",
+            UseAgentic = true,
+            AgenticMode = AgentExecutionMode.Conditional
+        };
+
+        Func<Task> act = () => orchestrator.RunDatabaseAssessmentAsync(
+            provider, userInputs, "db", CancellationToken.None);
+
+        // Incomplete run (Cosmos failed) -> agentic path throws; the mode still reached the engine.
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        sql.WasInvoked.Should().BeFalse("Conditional mode must skip a dependent whose dependency failed");
+    }
+
+    [Fact]
+    public async Task Sequential_mode_still_invokes_the_sql_agent_when_cosmos_fails()
+    {
+        var (orchestrator, provider, sql) = BuildHarness();
+        var userInputs = new UserInputs
+        {
+            AccountEndpoint = "https://fake.documents.azure.com:443/",
+            UseAgentic = true,
+            AgenticMode = AgentExecutionMode.Sequential
+        };
+
+        Func<Task> act = () => orchestrator.RunDatabaseAssessmentAsync(
+            provider, userInputs, "db", CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        sql.WasInvoked.Should().BeTrue("Sequential mode runs every agent regardless of upstream failure");
+    }
+}

--- a/tests/CosmosToSqlAssessment.Tests/Orchestration/AssessmentOrchestratorTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Orchestration/AssessmentOrchestratorTests.cs
@@ -75,6 +75,39 @@ public class AssessmentOrchestratorTests
     }
 
     [Fact]
+    public async Task RunAsync_GenerateAlerts_ShortCircuitsAndWritesTemplatesWithoutEndpoint()
+    {
+        // #256: `migration generate-alerts` must short-circuit before GetUserInputsAsync, so it works with
+        // no Cosmos endpoint configured anywhere. It writes the ARM templates + README and returns 0.
+        var configuration = EmptyConfiguration();
+        var services = new ServiceCollection().AddCosmosAssessment(configuration);
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var orchestrator = scope.ServiceProvider.GetRequiredService<AssessmentOrchestrator>();
+
+        var tempDir = Path.Combine(Path.GetTempPath(), "alerts-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var exitCode = await orchestrator.RunAsync(
+                new CliOptions { GenerateAlerts = true, OutputDirectory = tempDir },
+                CancellationToken.None);
+
+            exitCode.Should().Be(0);
+            var alertsDir = Path.Combine(tempDir, "Monitoring", "AlertRules");
+            File.Exists(Path.Combine(alertsDir, "metric-alerts.template.json")).Should().BeTrue();
+            File.Exists(Path.Combine(alertsDir, "stalled-pipeline-log-alert.template.json")).Should().BeTrue();
+            File.Exists(Path.Combine(alertsDir, "README.md")).Should().BeTrue();
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public async Task RunDatabaseAssessmentAsync_WhenCancelledMidPhase_PropagatesOperationCanceledException()
     {
         // Regression test for #237: the per-phase broad catch blocks must not swallow

--- a/tests/CosmosToSqlAssessment.Tests/Orchestration/AssessmentOrchestratorTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Orchestration/AssessmentOrchestratorTests.cs
@@ -108,6 +108,45 @@ public class AssessmentOrchestratorTests
     }
 
     [Fact]
+    public async Task RunAsync_PublishMetrics_WhenDisabled_ShortCircuitsToNoOpWithoutEndpoint()
+    {
+        // #257: publishing is off by default (AzureMonitor:Metrics:Enabled = false). The command must
+        // short-circuit before GetUserInputsAsync, print a clear message, and return 0 without streaming.
+        var configuration = EmptyConfiguration();
+        var services = new ServiceCollection().AddCosmosAssessment(configuration);
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var orchestrator = scope.ServiceProvider.GetRequiredService<AssessmentOrchestrator>();
+
+        var exitCode = await orchestrator.RunAsync(
+            new CliOptions { PublishMetrics = true }, CancellationToken.None);
+
+        exitCode.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RunAsync_PublishMetrics_WhenEnabledButMisconfigured_ReturnsZeroNoOp()
+    {
+        // #257: enabled but missing Region/ResourceId is a misconfiguration; degrade to a no-op (return 0)
+        // rather than failing or attempting a live call.
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AzureMonitor:Metrics:Enabled"] = "true",
+            })
+            .Build();
+        var services = new ServiceCollection().AddCosmosAssessment(configuration);
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var orchestrator = scope.ServiceProvider.GetRequiredService<AssessmentOrchestrator>();
+
+        var exitCode = await orchestrator.RunAsync(
+            new CliOptions { PublishMetrics = true }, CancellationToken.None);
+
+        exitCode.Should().Be(0);
+    }
+
+    [Fact]
     public async Task RunDatabaseAssessmentAsync_WhenCancelledMidPhase_PropagatesOperationCanceledException()
     {
         // Regression test for #237: the per-phase broad catch blocks must not swallow

--- a/tests/CosmosToSqlAssessment.Tests/Orchestration/FeedbackRecordCommandTests.cs
+++ b/tests/CosmosToSqlAssessment.Tests/Orchestration/FeedbackRecordCommandTests.cs
@@ -1,0 +1,182 @@
+using System.Text.Json;
+using CosmosToSqlAssessment.Cli;
+using CosmosToSqlAssessment.DependencyInjection;
+using CosmosToSqlAssessment.Orchestration;
+using CosmosToSqlAssessment.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CosmosToSqlAssessment.Tests.Orchestration;
+
+/// <summary>
+/// Tests for the additive <c>feedback record --import-outcome</c> CLI path (#259): it imports an
+/// anonymized <see cref="MigrationOutcome"/> into the local store, gated by the existing opt-in consent
+/// (default OFF), and a recorded outcome is then picked up by <see cref="RecommendationRefinementService"/>.
+/// </summary>
+public class FeedbackRecordCommandTests
+{
+    private static MigrationOutcome ComparableSuccessfulOutcome() => new()
+    {
+        Profile = new WorkloadProfile
+        {
+            ComplexityRating = MigrationComplexityRating.High,
+            SizeBucket = WorkloadSizeBucket.Large,
+            ContainerCount = 10,
+            MaxProvisionedRUs = 1000,
+            RecommendedPlatform = "Azure SQL Database",
+            RecommendedTier = "General Purpose",
+        },
+        Status = MigrationOutcomeStatus.Succeeded,
+        DeployedPlatform = "Azure SQL Database",
+        DeployedTier = "General Purpose",
+        PerformanceSatisfactory = true,
+        EstimatedMonthlyCostUsd = 100m,
+        ActualMonthlyCostUsd = 100m,
+    };
+
+    // Builds an assessment whose derived WorkloadProfile matches ComparableSuccessfulOutcome().
+    private static AssessmentResult ComparableAssessment()
+    {
+        const double sizeGb = 200; // Large band (10 GB ≤ Large < 1024 GB)
+        long totalBytes = (long)(sizeGb * 1024 * 1024 * 1024);
+
+        var containers = new List<ContainerAnalysis>();
+        for (int i = 0; i < 10; i++)
+        {
+            containers.Add(new ContainerAnalysis
+            {
+                DocumentCount = 1000,
+                SizeBytes = i == 0 ? totalBytes : 0,
+                ProvisionedRUs = i == 0 ? 1000 : 0,
+            });
+        }
+
+        return new AssessmentResult
+        {
+            CosmosAnalysis = new CosmosDbAnalysis { Containers = containers },
+            SqlAssessment = new SqlMigrationAssessment
+            {
+                RecommendedPlatform = "Azure SQL Database",
+                RecommendedTier = "General Purpose",
+                Complexity = new MigrationComplexity { OverallComplexity = "High" },
+            },
+        };
+    }
+
+    private static string WriteOutcomeFile(string dir, MigrationOutcome outcome)
+    {
+        var path = Path.Combine(dir, $"outcome-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, JsonSerializer.Serialize(outcome));
+        return path;
+    }
+
+    [Fact]
+    public async Task FeedbackRecord_WhenConsentDenied_IsNoOpAndWritesNothing()
+    {
+        var workDir = Path.Combine(Path.GetTempPath(), "feedback-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+        var storePath = Path.Combine(workDir, "outcomes.jsonl");
+        try
+        {
+            // No FeedbackLoop:Enabled => consent denied by default.
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["FeedbackLoop:StorePath"] = storePath,
+                })
+                .Build();
+            var services = new ServiceCollection().AddCosmosAssessment(configuration);
+            using var provider = services.BuildServiceProvider();
+            using var scope = provider.CreateScope();
+            var orchestrator = scope.ServiceProvider.GetRequiredService<AssessmentOrchestrator>();
+
+            var importPath = WriteOutcomeFile(workDir, ComparableSuccessfulOutcome());
+
+            var exitCode = await orchestrator.RunAsync(
+                new CliOptions { FeedbackRecord = true, ImportOutcomeFile = importPath },
+                CancellationToken.None);
+
+            // Consent-denied is a legitimate no-op: exit 0, but nothing persisted.
+            exitCode.Should().Be(0);
+            File.Exists(storePath).Should().BeFalse("a denied consent must persist nothing");
+        }
+        finally
+        {
+            if (Directory.Exists(workDir))
+            {
+                Directory.Delete(workDir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task FeedbackRecord_WithMissingFile_ReturnsOne()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+        var services = new ServiceCollection().AddCosmosAssessment(configuration);
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var orchestrator = scope.ServiceProvider.GetRequiredService<AssessmentOrchestrator>();
+
+        var missing = Path.Combine(Path.GetTempPath(), "does-not-exist-" + Guid.NewGuid().ToString("N") + ".json");
+
+        var exitCode = await orchestrator.RunAsync(
+            new CliOptions { FeedbackRecord = true, ImportOutcomeFile = missing },
+            CancellationToken.None);
+
+        exitCode.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task FeedbackRecord_WhenConsentGranted_RoundTripsAndRefinementPicksItUp()
+    {
+        var workDir = Path.Combine(Path.GetTempPath(), "feedback-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+        var storePath = Path.Combine(workDir, "outcomes.jsonl");
+        try
+        {
+            // FeedbackLoop:Enabled=true => consent granted via configuration precedence.
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["FeedbackLoop:Enabled"] = "true",
+                    ["FeedbackLoop:StorePath"] = storePath,
+                })
+                .Build();
+            var services = new ServiceCollection().AddCosmosAssessment(configuration);
+            using var provider = services.BuildServiceProvider();
+            using var scope = provider.CreateScope();
+            var orchestrator = scope.ServiceProvider.GetRequiredService<AssessmentOrchestrator>();
+
+            // Record the minimum number of comparable successful outcomes via the CLI path so the
+            // refinement engine clears its similar/candidate sample floors. Each import file holds a
+            // distinct OutcomeId so the store accumulates separate records.
+            for (int i = 0; i < RecommendationRefinementService.MinimumSimilarSamples; i++)
+            {
+                var importPath = WriteOutcomeFile(workDir, ComparableSuccessfulOutcome());
+                var exit = await orchestrator.RunAsync(
+                    new CliOptions { FeedbackRecord = true, ImportOutcomeFile = importPath },
+                    CancellationToken.None);
+                exit.Should().Be(0);
+            }
+
+            File.Exists(storePath).Should().BeTrue("granted consent must persist the imported outcomes");
+
+            // The recorded outcomes must now be visible to the refinement service that reads the store.
+            var refiner = scope.ServiceProvider.GetRequiredService<RecommendationRefinementService>();
+            var refinement = await refiner.RefineAsync(ComparableAssessment(), CancellationToken.None);
+
+            refinement.HasRefinement.Should().BeTrue("the recorded comparable outcomes should drive a refinement");
+            refinement.PriorSimilarMigrationCount.Should()
+                .BeGreaterThanOrEqualTo(RecommendationRefinementService.MinimumSimilarSamples);
+        }
+        finally
+        {
+            if (Directory.Exists(workDir))
+            {
+                Directory.Delete(workDir, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Wires four already-implemented backend capabilities into the CLI. Additive — preserves every existing flag/subcommand.

- **#248** — Expose `AgentOrchestrator` Parallel/Conditional modes via `--agentic-mode <sequential|parallel|conditional>` (default sequential).
- **#256** — Expose alert-rule ARM template generation via `migration generate-alerts --output <dir>`.
- **#257** — Wire live custom-metric publishing via `migration publish-metrics [--watch] [--poll-interval <sec>]`.
- **#259** — Wire post-migration outcome capture via `feedback record` / `--import-outcome <file.json>`, gated by existing opt-in consent.

Closes #248
Closes #256
Closes #257
Closes #259