### PR TITLE
deps(nuget): roll up compatible bumps + pin Extensions to 8.0.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,11 @@ updates:
     labels:
       - "dependencies"
       - "nuget"
+    # Framework-aligned with the net8.0 target: decline major bumps for the Microsoft.Extensions.*
+    # stack (those ship .NET 10-era libraries). 8.0.x servicing patches/minors are still allowed.
+    ignore:
+      - dependency-name: "Microsoft.Extensions.*"
+        update-types: ["version-update:semver-major"]
 
   # GitHub Actions dependencies  
   - package-ecosystem: "github-actions"

--- a/CosmosToSqlAssessment.csproj
+++ b/CosmosToSqlAssessment.csproj
@@ -27,14 +27,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.15.0" />
+    <PackageReference Include="Azure.Identity" Version="1.19.0" />
     <PackageReference Include="Azure.Monitor.Query" Version="1.7.1" />
     <PackageReference Include="Azure.ResourceManager" Version="1.13.2" />
     <PackageReference Include="Azure.ResourceManager.Monitor" Version="1.3.1" />
     <PackageReference Include="Azure.ResourceManager.ResourceGraph" Version="1.1.0" />
     <PackageReference Include="ClosedXML" Version="0.105.0" />
-    <PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.53.0" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.5.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />

--- a/tests/CosmosToSqlAssessment.Tests/CosmosToSqlAssessment.Tests.csproj
+++ b/tests/CosmosToSqlAssessment.Tests/CosmosToSqlAssessment.Tests.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.collector" Version="8.0.1" />
     <PackageReference Include="FluentAssertions" Version="8.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />


### PR DESCRIPTION
## Summary
Rolls up the Dependabot **nuget** bumps that are verified compatible with current `main`, and adds a Dependabot **ignore rule** to keep the `Microsoft.Extensions.*` major jump (8.0.x → 10.0.5) declined — staying framework-aligned with the project's `net8.0` target.

### Bumps
| Package | From | To | Supersedes |
|---------|------|----|-----------|
| Azure.Identity | 1.15.0 | 1.19.0 | #113 |
| DocumentFormat.OpenXml | 3.3.0 | 3.5.1 | #122 |
| Microsoft.Azure.Cosmos | 3.53.0 | 3.58.0 | #123 |
| Microsoft.NET.Test.Sdk | 17.12.0 | 18.3.0 | #112 |
| coverlet.collector | 6.0.2 | 8.0.1 | #121 |

### Dependabot policy
`.github/dependabot.yml` now ignores `Microsoft.Extensions.*` `version-update:semver-major`. `main` is already on the latest 8.0.x patch for all 7 of those packages, so PRs #115/#116/#117/#119/#120 are being **closed as declined** (the 10.0.5 set ships .NET 10-era libraries). 8.0.x servicing patches/minors are still allowed.

### Validation
- Release build: **0 errors**.
- Full suite: **1038 / 1038 tests pass** (verified locally on these exact versions, off `665abeb`).
- `Benchmark regression` is intentionally **not** admin-bypassed here (Cosmos & OpenXml are benchmarked paths) — letting it run on its merits.

Closes #112
Closes #113
Closes #121
Closes #122
Closes #123
