### PR TITLE
ci(deps): upload-artifact v7 repo-wide + action-gh-release v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       run: dotnet build CosmosToSqlAssessment.sln --configuration Release --no-restore
       
     - name: Publish build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: build-artifacts
         path: |
@@ -115,7 +115,7 @@ jobs:
         EOF
 
     - name: Publish test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: always()
       with:
         name: test-results

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Upload vulnerability report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nuget-vulnerability-report
           path: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,7 +55,7 @@ jobs:
         run: dotnet docfx docfx/docfx.json --warningsAsErrors
 
       - name: Upload generated site
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: api-docs-site
           path: docfx/_site

--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Upload refreshed baseline (manual dispatch only)
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.update_baseline == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: refreshed-baseline
           path: ${{ env.BENCHMARK_DIR }}/baselines/baseline.json
@@ -138,7 +138,7 @@ jobs:
 
       - name: Upload BenchmarkDotNet artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-artifacts
           path: ${{ env.BENCHMARK_DIR }}/BenchmarkDotNet.Artifacts/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,7 +159,7 @@ jobs:
         echo "EOF" >> $GITHUB_OUTPUT
         
     - name: Create GitHub Release with Assets
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         name: Cosmos DB to SQL Assessment Tool v${{ steps.get_version.outputs.VERSION }}
         body: ${{ steps.release_notes.outputs.RELEASE_NOTES }}


### PR DESCRIPTION
## Summary
Completes the GitHub Actions dependency bumps that Dependabot left partial/stale.

### upload-artifact v4 → v7 (repo-wide — supersedes #109)
Dependabot PR #109 only bumped `build.yml`'s 2 refs (it predates the other workflow files added during the issue burn-down). This bumps **all 6** `upload-artifact@v4` refs:
- `build.yml` (×2), `dependency-review.yml`, `docs.yml`, `performance-regression.yml` (×2)

`download-artifact@v4` (2 refs in docs.yml / performance-regression.yml) is intentionally **left as-is** — v7's default still zips, and zipped artifacts remain v4-downloadable. The non-zipped (`archive: false`) feature that would require `download-artifact@v8` is not used here.

Runner note: upload-artifact v6+ defaults to Node 24 / runner ≥2.327.1, satisfied by GitHub-hosted runners.

### action-gh-release v2 → v3 (supersedes #124)
`release.yml` only. The single breaking change is Node 20 → 24 runtime; `release.yml` runs on `ubuntu-latest` (Node 24 available). No input/output API changes. Exercised at the next release tag.

### Validation
All 5 edited workflows parse as valid YAML; diff is limited to the `@v4→@v7` / `@v2→@v3` `uses:` lines.

Closes #109
Closes #124
